### PR TITLE
Add custom 404 page not found page

### DIFF
--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -6,6 +6,7 @@ import { CommunityPage } from "../pages/CommunityPage";
 import { DashboardPage } from "../pages/DashboardPage";
 import { LandingPage } from "../pages/LandingPage";
 import { LessonPage } from "../pages/LessonPage";
+import { NotFoundPage } from "../pages/NotFoundPage";
 import { useAuth } from "../features/auth/AuthContext";
 
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
@@ -43,6 +44,8 @@ export function AppRouter() {
         <Route path="/challenges" element={<ProtectedRoute><ChallengePage /></ProtectedRoute>} />
         <Route path="/community" element={<ProtectedRoute><CommunityPage /></ProtectedRoute>} />
       </Route>
+
+      <Route path="*" element={<NotFoundPage />} />
     </Routes>
   );
 }

--- a/frontend/src/pages/NotFoundPage.tsx
+++ b/frontend/src/pages/NotFoundPage.tsx
@@ -1,0 +1,44 @@
+import { Link } from "react-router-dom";
+
+export function NotFoundPage() {
+  return (
+    <div className="min-h-[85vh] flex items-center justify-center p-4">
+      <div className="w-full max-w-2xl mx-auto">
+        <div className="text-center mb-6">
+          <span className="font-black text-xs bg-accent text-black px-4 py-2 rounded-full border-2 border-black rotate-[-2deg] inline-block shadow-sm">
+            ROUTE MISSING
+          </span>
+        </div>
+
+        <div className="bg-white rounded-[2rem] border-4 border-black shadow-card-lg p-8 sm:p-12 relative overflow-hidden">
+          <div className="absolute -top-10 -right-10 h-40 w-40 rounded-full bg-surface-high opacity-40 border-4 border-black"></div>
+          <div className="absolute -bottom-12 -left-12 h-44 w-44 rounded-full bg-primary-container opacity-60 border-4 border-black"></div>
+
+          <div className="relative">
+            <p className="font-mono text-[11px] uppercase tracking-[0.3em] text-muted">
+              Error 404
+            </p>
+            <h1 className="text-5xl sm:text-6xl font-black tracking-tight mt-3">
+              This corridor doesn&apos;t exist.
+            </h1>
+            <p className="mt-4 text-muted text-lg">
+              The page you requested isn&apos;t in the atelier. Let&apos;s get you back to the home base.
+            </p>
+
+            <div className="mt-8 flex flex-wrap items-center gap-4">
+              <Link
+                to="/"
+                className="inline-flex items-center justify-center rounded-2xl border-4 border-black bg-primary px-6 py-4 font-black text-white text-lg shadow-gel hover:bg-[#E62814] active:translate-y-2 transition-all uppercase tracking-wide"
+              >
+                Back to Home
+              </Link>
+              <div className="text-sm font-semibold text-muted">
+                Tip: check your URL spelling.
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
# Summary
Adds a custom 404 Not Found page styled to match the existing UI and routes all unknown paths to it.

# Changes

- Created a new NotFoundPage with Tailwind styling and a “Back to Home” CTA.
- Added a catch‑all * route in the router to render the 404 page for unknown URLs.

# Testing
- Tried visiting http://localhost:5173/abc

# preview
<img width="1917" height="945" alt="Screenshot (43)" src="https://github.com/user-attachments/assets/71fba9e0-b276-4609-8ef5-4cb9a044d1bc" />
