### PR TITLE
docs: add badges and architecture overview to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Open Source Contribution Atelier
 
+![Build](https://img.shields.io/badge/build-passing-brightgreen?style=for-the-badge) ![License](https://img.shields.io/github/license/goyaljiiiiii/Open-Source-Contribution-Atelier?style=for-the-badge) ![React](https://img.shields.io/badge/React-20232A?style=for-the-badge&logo=react&logoColor=61DAFB) ![Django](https://img.shields.io/badge/Django-092E20?style=for-the-badge&logo=django&logoColor=white) ![TypeScript](https://img.shields.io/badge/TypeScript-007ACC?style=for-the-badge&logo=typescript&logoColor=white) ![Docker](https://img.shields.io/badge/Docker-2CA5E0?style=for-the-badge&logo=docker&logoColor=white) [![Live Demo](https://img.shields.io/badge/Live%20Demo-Visit-blue?style=for-the-badge)](https://contribution-atelier-frontend.onrender.com/)
+
 A full-stack learning and operations platform for teaching open source contribution from beginner to advanced levels. The repository is structured for public collaboration and is designed for lesson delivery, challenge tracking, contributor progress, and safe Git practice.
 
 ## Stack
@@ -8,6 +10,19 @@ A full-stack learning and operations platform for teaching open source contribut
 - Frontend: React, TypeScript, Vite, Tailwind CSS, React Router
 - Infra: Docker, Docker Compose
 - Testing: Django test suite, Pytest, Vitest, React Testing Library
+
+## Architecture Overview
+
+```mermaid
+graph LR
+    User([🌐 User/Browser]) -->|HTTPS Requests| frontend
+    
+    subgraph Infrastructure ["Infrastructure (Docker)"]
+        frontend[💻 React Frontend] -->|API Requests| api
+        api[⚙️ Django REST API] -->|Database Queries| db[(🗄️ PostgreSQL)]
+        api -->|Executes Challenges| sandbox[🧪 Sandbox Verifier]
+    end
+```
 
 ## Monorepo Structure
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Open Source Contribution Atelier
 
-![Build](https://img.shields.io/badge/build-passing-brightgreen?style=for-the-badge) ![License](https://img.shields.io/github/license/goyaljiiiiii/Open-Source-Contribution-Atelier?style=for-the-badge) ![React](https://img.shields.io/badge/React-20232A?style=for-the-badge&logo=react&logoColor=61DAFB) ![Django](https://img.shields.io/badge/Django-092E20?style=for-the-badge&logo=django&logoColor=white) ![TypeScript](https://img.shields.io/badge/TypeScript-007ACC?style=for-the-badge&logo=typescript&logoColor=white) ![Docker](https://img.shields.io/badge/Docker-2CA5E0?style=for-the-badge&logo=docker&logoColor=white) [![Live Demo](https://img.shields.io/badge/Live%20Demo-Visit-blue?style=for-the-badge)](https://contribution-atelier-frontend.onrender.com/)
+![Status](https://img.shields.io/badge/status-active-brightgreen?style=for-the-badge) ![License](https://img.shields.io/github/license/goyaljiiiiii/Open-Source-Contribution-Atelier?style=for-the-badge) ![React](https://img.shields.io/badge/React-20232A?style=for-the-badge&logo=react&logoColor=61DAFB) ![Django](https://img.shields.io/badge/Django-092E20?style=for-the-badge&logo=django&logoColor=white) ![TypeScript](https://img.shields.io/badge/TypeScript-007ACC?style=for-the-badge&logo=typescript&logoColor=white) ![Docker](https://img.shields.io/badge/Docker-2CA5E0?style=for-the-badge&logo=docker&logoColor=white) [![Live Demo](https://img.shields.io/badge/Live%20Demo-Visit-blue?style=for-the-badge)](https://contribution-atelier-frontend.onrender.com/)
 
 A full-stack learning and operations platform for teaching open source contribution from beginner to advanced levels. The repository is structured for public collaboration and is designed for lesson delivery, challenge tracking, contributor progress, and safe Git practice.
 
@@ -19,8 +19,7 @@ graph LR
     
     subgraph Infrastructure ["Infrastructure (Docker)"]
         frontend[💻 React Frontend] -->|API Requests| api
-        api[⚙️ Django REST API] -->|Database Queries| db[(🗄️ PostgreSQL)]
-        api -->|Executes Challenges| sandbox[🧪 Sandbox Verifier]
+        api[⚙️ Django REST API<br/>incl. Sandbox Verification] -->|Database Queries| db[(🗄️ PostgreSQL)]
     end
 ```
 


### PR DESCRIPTION
hey @goyaljiiiiii 
thanks for the guidance , really appreciated :)

## Summary
Addresses #5 :  added badges and an architecture diagram to make the README more welcoming and visually informative for newcomers.

## Changes
- Added shields.io badges (Build, License, React, Django, TypeScript, Docker) at the top with consistent `for-the-badge` styling
- Added a Live Demo badge linking to the deployed frontend as it  felt like a natural addition since the URL was already in the repo description
- Added an Architecture Overview section with a Mermaid diagram showing the full request flow (User → React Frontend → Django REST API → PostgreSQL + Sandbox Verifier) within the Docker infrastructure. i chose Mermaid over a screenshot so it stays maintainable as the project evolves

## Testing
No functional changes ,  README only. Verified Mermaid diagram renders correctly on GitHub and all badges load properly.

## Screenshots
N/A - no UI changes

## Checklist
- [x] Tests added or updated :  N/A (documentation only)
- [x] Documentation updated if needed
- [x] No secrets committed

## Additional Note
Noticed the README link inside `CONTRIBUTING.md` is pointing to a local machine path.... i'm happy to raise a separate PR to fix that if it'd be helpful!

Closes #5