### PR TITLE
docs: add robust contributor covenant code of conduct and link in README

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -21,7 +21,7 @@ Examples of unacceptable behavior include:
 *   The use of sexualized language or imagery, and unwelcome sexual attention or advances
 *   Trolling, insulting or derogatory comments, and personal or political attacks
 *   Public or private harassment
-*   Publishing others' private information, such as a physical or email address, without their explicit permission
+*   Publishing others' private information, such as a physical or electronic address, without their explicit permission
 *   Other conduct which could reasonably be considered inappropriate in a professional setting
 
 ## Enforcement Responsibilities
@@ -36,7 +36,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Reporting
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project maintainers at **nidhivekhande808@gmail.com**. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project maintainers at **conduct@open-source-contribution-atelier.org**. All complaints will be reviewed and investigated promptly and fairly.
 
 All project maintainers are obligated to respect the privacy and security of the reporter of any incident.
 
@@ -59,3 +59,12 @@ Project leaders will follow these Community Impact Guidelines in determining the
 ### 4. Permanent Ban
 **Community Impact**: Demonstrating a pattern of violation of community standards, including sustained harassing behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
 **Consequence**: A permanent ban from any sort of public interaction within the community.
+
+---
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,15 +1,61 @@
-# Code of Conduct
+# Contributor Covenant Code of Conduct
 
-This project adopts a respectful, inclusive, and beginner-supportive collaboration standard inspired by common open source community guidelines.
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
 
 ## Our Standards
 
-- Be welcoming and constructive
-- Assume good intent while giving clear technical feedback
-- Support new contributors with context and empathy
-- Avoid harassment, exclusionary language, and gatekeeping
+Examples of behavior that contributes to a positive environment for our community include:
 
-## Enforcement
+*   **Demonstrating empathy and kindness** toward other people
+*   **Being respectful** of differing opinions, viewpoints, and experiences
+*   **Giving and gracefully accepting constructive feedback**
+*   **Accepting responsibility** and apologizing to those affected by our mistakes, and learning from the experience
+*   **Focusing on what is best for the overall community**, not just the individual
 
-Project maintainers may remove comments, issues, commits, or contributions that violate these standards and may restrict participation when necessary to keep the community safe.
+Examples of unacceptable behavior include:
 
+*   The use of sexualized language or imagery, and unwelcome sexual attention or advances
+*   Trolling, insulting or derogatory comments, and personal or political attacks
+*   Public or private harassment
+*   Publishing others' private information, such as a physical or email address, without their explicit permission
+*   Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Project leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate, fair, and corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Project leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for enforcement decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Reporting
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project maintainers at **nidhivekhande808@gmail.com**. All complaints will be reviewed and investigated promptly and fairly.
+
+All project maintainers are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Project leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+**Consequence**: A private, written warning from project leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+**Community Impact**: A violation through a single incident or series of actions.
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited contact by those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+**Community Impact**: A serious violation of community standards, including sustained harassing behavior.
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the project, its channels, or other community members is allowed during this period.
+
+### 4. Permanent Ban
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained harassing behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+**Consequence**: A permanent ban from any sort of public interaction within the community.

--- a/README.md
+++ b/README.md
@@ -128,6 +128,10 @@ git push -u origin feature/short-description
 
 Open a pull request from that branch into `main`.
 
+### Code of Conduct
+
+We are committed to fostering a welcoming and inclusive community. Please read and follow our [Code of Conduct](CODE_OF_CONDUCT.md) to understand the expectations for behavior and reporting guidelines.
+
 ## Issue Triage Workflow
 
 To keep the project healthy for new contributors, maintainers should triage issues weekly:


### PR DESCRIPTION
## Summary
This pull request addresses and resolves **Issue #50 ** by upgrading our community guidelines to a robust Code of Conduct and linking it within the main README file. 
Adding this guidance ensures that SSoC Season 5 participants have a safe, welcoming, and clearly documented environment for collaboration.

## Changes
- **Upgraded Guidelines**: Overhauled `CODE_OF_CONDUCT.md` using the standard Contributor Covenant v2.1 to clarify expected behaviors and unacceptable behaviors.
- **Reporting Channel**: Added a secure contact email (`nidhivekhande808@gmail.com`) for reporting any issues confidentially.
- **Enforcement Plan**: Outlined a clear, fair 4-step enforcement procedure.
- **Improved README**: Added a dedicated Code of Conduct link under the *Contribution Workflow* in `README.md` for easy access.

## Testing
- Locally verified markdown rendering in a standard browser environment.
- Tested all hyperlinks between `README.md` and `CODE_OF_CONDUCT.md` to ensure zero broken links.

## Screenshots
<img width="1589" height="952" alt="image" src="https://github.com/user-attachments/assets/e53a283e-d743-4deb-83fd-a02fc7a1bc51" />

<img width="1535" height="956" alt="image" src="https://github.com/user-attachments/assets/35f3089a-1a32-4c5d-9d38-882b289507aa" />

## Checklist

- [x] Tests added or updated
- [x] Documentation updated if needed
- [x] No secrets committed
