### PR TITLE
fix: add missing backend dependencies for fresh setup

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,3 +12,6 @@ channels==4.0.0
 channels-redis==4.1.0
 daphne==4.1.2
 redis==7.4.0
+django-filter>=25.1
+drf-spectacular>=0.28.0
+


### PR DESCRIPTION
## Description

Fixes backend setup issues caused by missing dependencies.

Added:
- django-filter
- drf-spectacular

These packages were required by the project but were not listed in backend/requirements.txt.

## Testing

- Installed dependencies on Python 3.14
- Ran backend setup
- Successfully executed:
  python manage.py migrate

The backend now starts without ModuleNotFoundError for these packages.