### PR TITLE
Leaderboard Pagination Implemented

### DIFF
--- a/backend/apps/dashboard/views.py
+++ b/backend/apps/dashboard/views.py
@@ -1,14 +1,69 @@
 from django.contrib.auth.models import User
 from django.core.cache import cache
-from django.db.models import Sum, Count
+from django.db.models import Count, F, IntegerField, OuterRef, Subquery, Sum, Value
+from django.db.models.functions import Coalesce
 from django.utils import timezone
-from rest_framework import permissions, status
+from rest_framework import permissions, serializers
+from rest_framework.generics import ListAPIView
+from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from apps.dashboard.models import Issue, PullRequest
 from apps.progress.models import LessonProgress, ExerciseAttempt
 from apps.content.models import Lesson
+
+
+class LeaderboardPagination(PageNumberPagination):
+    page_size = 20
+
+
+class LeaderboardSerializer(serializers.ModelSerializer):
+    prs_merged = serializers.IntegerField(read_only=True)
+    issues_solved = serializers.IntegerField(read_only=True)
+    xp = serializers.IntegerField(read_only=True)
+
+    class Meta:
+        model = User
+        fields = ("id", "username", "prs_merged", "issues_solved", "xp")
+
+
+class LeaderboardView(ListAPIView):
+    """
+    Paginated contributor leaderboard ordered by total XP.
+    """
+    serializer_class = LeaderboardSerializer
+    pagination_class = LeaderboardPagination
+
+    def get_queryset(self):
+        lesson_xp = LessonProgress.objects.filter(
+            user=OuterRef("pk"),
+            completed=True,
+        ).values("user").annotate(total=Sum("score")).values("total")
+
+        issues_xp = Issue.objects.filter(
+            assigned_to=OuterRef("pk"),
+            status=Issue.Status.SOLVED,
+        ).values("assigned_to").annotate(total=Sum("points")).values("total")
+
+        prs_merged = PullRequest.objects.filter(
+            user=OuterRef("pk"),
+            status=PullRequest.Status.MERGED,
+        ).values("user").annotate(total=Count("id")).values("total")
+
+        issues_solved = Issue.objects.filter(
+            assigned_to=OuterRef("pk"),
+            status=Issue.Status.SOLVED,
+        ).values("assigned_to").annotate(total=Count("id")).values("total")
+
+        return User.objects.filter(is_staff=False).annotate(
+            prs_merged=Coalesce(Subquery(prs_merged, output_field=IntegerField()), Value(0)),
+            issues_solved=Coalesce(Subquery(issues_solved, output_field=IntegerField()), Value(0)),
+            lesson_xp=Coalesce(Subquery(lesson_xp, output_field=IntegerField()), Value(0)),
+            issues_xp=Coalesce(Subquery(issues_xp, output_field=IntegerField()), Value(0)),
+        ).annotate(
+            xp=F("lesson_xp") + F("issues_xp"),
+        ).order_by("-xp", "username", "id")
 
 
 class AdminDashboardView(APIView):

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -1,9 +1,11 @@
 from django.contrib import admin
 from django.urls import include, path
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView # Add this line
+from apps.dashboard.views import LeaderboardView
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("api/leaderboard/", LeaderboardView.as_view(), name="leaderboard"),
     path("api/auth/", include("apps.accounts.urls")),
     path("api/users/", include("apps.accounts.user_urls")),
     path("api/content/", include("apps.content.urls")),

--- a/backend/tests/test_dashboard_analytics.py
+++ b/backend/tests/test_dashboard_analytics.py
@@ -122,6 +122,47 @@ def test_admin_dashboard_statistics():
 
 
 @pytest.mark.django_db
+def test_leaderboard_is_paginated_to_twenty_contributors_per_page():
+    lesson = Lesson.objects.create(
+        title="Git Basics",
+        slug="git-basics",
+        summary="basics",
+        content="content",
+        order=1,
+    )
+
+    for index in range(25):
+        contributor = User.objects.create_user(
+            username=f"contrib{index:02d}",
+            is_staff=False,
+        )
+        LessonProgress.objects.create(
+            user=contributor,
+            lesson=lesson,
+            completed=True,
+            score=index,
+        )
+
+    client = APIClient()
+
+    first_page = client.get("/api/leaderboard/")
+    assert first_page.status_code == 200
+    assert first_page.data["count"] == 25
+    assert len(first_page.data["results"]) == 20
+    assert first_page.data["next"] is not None
+    assert first_page.data["previous"] is None
+    assert first_page.data["results"][0]["username"] == "contrib24"
+    assert first_page.data["results"][0]["xp"] == 24
+
+    second_page = client.get("/api/leaderboard/?page=2")
+    assert second_page.status_code == 200
+    assert len(second_page.data["results"]) == 5
+    assert second_page.data["next"] is None
+    assert second_page.data["previous"] is not None
+    assert second_page.data["results"][0]["username"] == "contrib04"
+
+
+@pytest.mark.django_db
 def test_contributor_dashboard_statistics():
     contrib = User.objects.create_user(username="contrib", is_staff=False)
     


### PR DESCRIPTION
## Summary

Implemented DRF pagination for the `/api/leaderboard/` endpoint so the leaderboard no longer returns the entire contributor list at once. The endpoint now returns 20 contributors per page using `PageNumberPagination`.

Related issue: #11 

## Changes

Added a dedicated paginated leaderboard API view with a serializer for contributor ranking data, including username, merged PR count, solved issue count, and XP. Wired the new `/api/leaderboard/` route into the main URL config. Added a regression test to confirm the endpoint returns 20 contributors on the first page and the remaining contributors on the second page.

## Testing

Ran `python3 -m pytest backend/tests/test_dashboard_analytics.py`. All tests passed with `7 passed`.

## Screenshots

No frontend screenshots included because this change affects the backend API response only. The endpoint can be inspected through the DRF browsable API at `/api/leaderboard/`.

## Checklist

- [ ] Tests added or updated
- [ ] Documentation updated if needed
- [x] No secrets committed

