### PR TITLE
Pagination endpoint being called now

### DIFF
--- a/backend/apps/dashboard/signals.py
+++ b/backend/apps/dashboard/signals.py
@@ -9,7 +9,7 @@ from apps.progress.models import LessonProgress
 
 def clear_dashboard_caches(user_id=None):
     # Always clear the global admin stats cache
-    cache.delete("dashboard_admin_stats")
+    cache.delete("dashboard_admin_stats_v2")
     
     # If a specific user is affected, clear their specific contributor stats cache
     if user_id:

--- a/backend/apps/dashboard/views.py
+++ b/backend/apps/dashboard/views.py
@@ -74,7 +74,7 @@ class AdminDashboardView(APIView):
     permission_classes = [permissions.IsAuthenticated, permissions.IsAdminUser]
 
     def get(self, request):
-        cache_key = "dashboard_admin_stats"
+        cache_key = "dashboard_admin_stats_v2"
         data = cache.get(cache_key)
         
         if data is None:
@@ -107,33 +107,7 @@ class AdminDashboardView(APIView):
                 "active_contributors": active_contributors,
             }
 
-            # 2. Contributor activity list
-            contributor_activity = []
-            contributors = User.objects.filter(is_staff=False).order_by("username")
-            for contributor in contributors:
-                prs_merged = PullRequest.objects.filter(user=contributor, status=PullRequest.Status.MERGED).count()
-                issues_solved = Issue.objects.filter(assigned_to=contributor, status=Issue.Status.SOLVED).count()
-                
-                # Calculate XP
-                lesson_xp = LessonProgress.objects.filter(user=contributor, completed=True).aggregate(
-                    total=Sum("score")
-                )["total"] or 0
-                issues_xp = Issue.objects.filter(assigned_to=contributor, status=Issue.Status.SOLVED).aggregate(
-                    total=Sum("points")
-                )["total"] or 0
-                
-                contributor_activity.append({
-                    "id": contributor.id,
-                    "username": contributor.username,
-                    "prs_merged": prs_merged,
-                    "issues_solved": issues_solved,
-                    "xp": lesson_xp + issues_xp,
-                })
-
-            # Sort contributors by XP descending
-            contributor_activity.sort(key=lambda x: x["xp"], reverse=True)
-
-            # 3. Pending PRs queue
+            # 2. Pending PRs queue
             pending_prs_qs = PullRequest.objects.filter(
                 status=PullRequest.Status.OPEN
             ).select_related("user", "issue").order_by("-created_at")
@@ -150,7 +124,6 @@ class AdminDashboardView(APIView):
 
             data = {
                 "system_stats": system_stats,
-                "contributor_activity": contributor_activity,
                 "pending_prs": pending_prs,
             }
             

--- a/backend/tests/test_dashboard_analytics.py
+++ b/backend/tests/test_dashboard_analytics.py
@@ -104,15 +104,6 @@ def test_admin_dashboard_statistics():
     assert stats["pending_prs"] == 1
     assert stats["active_contributors"] == 1
 
-    # Verify contributor activity
-    activity = response.data["contributor_activity"]
-    assert len(activity) == 1
-    assert activity[0]["username"] == "contrib"
-    assert activity[0]["prs_merged"] == 1
-    assert activity[0]["issues_solved"] == 1
-    # XP should be lesson_xp (200) + issues_xp (100) = 300
-    assert activity[0]["xp"] == 300
-
     # Verify pending PRs list
     pending = response.data["pending_prs"]
     assert len(pending) == 1

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -84,14 +84,21 @@ export function DashboardPage() {
     enabled: !!user?.is_staff,
   });
 
-  // 3. Fetch Contributor Dashboard stats (only queries if user is NOT staff)
+  // 3. Fetch paginated leaderboard for admin chart (only queries if user is staff)
+  const { data: leaderboardData, isLoading: isLeaderboardLoading } = useQuery({
+    queryKey: ["leaderboard", 1],
+    queryFn: () => fetchApi("/leaderboard/"),
+    enabled: !!user?.is_staff,
+  });
+
+  // 4. Fetch Contributor Dashboard stats (only queries if user is NOT staff)
   const { data: contributorData, isLoading: isContributorLoading, error: contributorError } = useQuery({
     queryKey: ["contributorDashboardStats"],
     queryFn: () => fetchApi("/dashboard/contributor/"),
     enabled: !!user && !user.is_staff,
   });
 
-  // 4. Fetch standard list of lessons via cache
+  // 5. Fetch standard list of lessons via cache
   const { data: lessons = [], isLoading: isLessonsLoading } = useQuery<Lesson[]>({
     queryKey: ["lessons"],
     queryFn: fetchLessonsApi,
@@ -209,7 +216,8 @@ export function DashboardPage() {
       );
     }
 
-    const { system_stats, contributor_activity, pending_prs } = adminData;
+    const { system_stats, pending_prs } = adminData;
+    const leaderboardResults = leaderboardData?.results || [];
     const issueStatusData = [
       { name: "Open", value: system_stats.open_issues },
       { name: "In Progress", value: system_stats.in_progress_issues },
@@ -288,9 +296,13 @@ export function DashboardPage() {
               <span>📊</span> Active Contributor Activity
             </h2>
             <div className="h-[300px] w-full">
-              {contributor_activity.length > 0 ? (
+              {isLeaderboardLoading ? (
+                <div className="h-full flex items-center justify-center border-4 border-dashed border-black rounded-2xl p-8 dark:border-[#2e2924]">
+                  <p className="font-bold text-muted dark:text-[#c4bbae]">Loading contributors...</p>
+                </div>
+              ) : leaderboardResults.length > 0 ? (
                 <ResponsiveContainer width="100%" height="100%">
-                  <BarChart data={contributor_activity}>
+                  <BarChart data={leaderboardResults}>
                     <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
                     <XAxis dataKey="username" tick={{ fontStyle: "bold", fill: "#6b5a49" }} />
                     <YAxis tick={{ fontStyle: "bold", fill: "#6b5a49" }} />

--- a/frontend/src/test/Dashboard.test.tsx
+++ b/frontend/src/test/Dashboard.test.tsx
@@ -95,7 +95,7 @@ describe("DashboardPage Dual-Role Views", () => {
       },
     });
 
-    // Mock API response for admin analytics
+    // Mock API response for admin analytics and leaderboard
     mockFetchApi.mockImplementation((endpoint: string) => {
       if (endpoint === "/dashboard/admin/") {
         return Promise.resolve({
@@ -110,12 +110,19 @@ describe("DashboardPage Dual-Role Views", () => {
             closed_prs: 1,
             active_contributors: 2,
           },
-          contributor_activity: [
-            { id: 2, username: "bob_coder", prs_merged: 2, issues_solved: 3, xp: 250 },
-            { id: 3, username: "alice_dev", prs_merged: 1, issues_solved: 1, xp: 100 },
-          ],
           pending_prs: [
             { id: 9, title: "Feature request review", contributor: "bob_coder", issue_title: "Add dark mode toggle", created_at: "2026-06-01T12:00:00Z" }
+          ],
+        });
+      }
+      if (endpoint === "/leaderboard/") {
+        return Promise.resolve({
+          count: 2,
+          next: null,
+          previous: null,
+          results: [
+            { id: 2, username: "bob_coder", prs_merged: 2, issues_solved: 3, xp: 250 },
+            { id: 3, username: "alice_dev", prs_merged: 1, issues_solved: 1, xp: 100 },
           ],
         });
       }


### PR DESCRIPTION
## Summary

Refactored the admin dashboard to use the paginated /api/leaderboard/ endpoint for the contributor activity chart instead of returning the full unbounded contributor_activity list from /api/dashboard/admin/. The backend AdminDashboardView no longer computes per-contributor stats (removing O(N) queries), and its response now only contains system_stats and pending_prs with a bumped cache key (dashboard_admin_stats_v2). The frontend adds a separate useQuery for /api/leaderboard/ when the user is staff, renders the chart from leaderboardData?.results, and shows a local loading state so stats and PR queue render immediately. All backend and frontend tests pass.

Related issue: #77 

## Testing

Backend: All 35 tests pass, including test admin dashboard statistics, test caching and signal invalidation, and test leaderboard is paginated to twenty contributors per page.

Frontend: All 7 tests pass, including both admin and contributor dashboard renders.

## Checklist

- [x] Tests added or updated
- [ ] Documentation updated if needed
- [x] No secrets committed

