### PR TITLE
feat: Add Copy-to-Clipboard Button for Quick Start Commands

### DIFF
--- a/frontend/src/components/ui/CopyButton.tsx
+++ b/frontend/src/components/ui/CopyButton.tsx
@@ -8,18 +8,24 @@ export default function CopyButton({ text }: CopyButtonProps) {
   const [copied, setCopied] = useState(false);
 
   const handleCopy = async () => {
-    await navigator.clipboard.writeText(text);
-    setCopied(true);
+    try {
+      await navigator.clipboard.writeText(text);
 
-    setTimeout(() => {
-      setCopied(false);
-    }, 2000);
+      setCopied(true);
+
+      setTimeout(() => {
+        setCopied(false);
+      }, 2000);
+    } catch (error) {
+      console.error("Copy failed:", error);
+    }
   };
 
   return (
     <button
+      type="button"
       onClick={handleCopy}
-      className="px-2 py-1 text-xs rounded border"
+      className="rounded-lg border border-outline bg-surface-low px-3 py-1 text-xs font-semibold text-text transition hover:bg-surface"
     >
       {copied ? "Copied!" : "Copy"}
     </button>

--- a/frontend/src/components/ui/CopyButton.tsx
+++ b/frontend/src/components/ui/CopyButton.tsx
@@ -1,0 +1,27 @@
+import { useState } from "react";
+
+type CopyButtonProps = {
+  text: string;
+};
+
+export default function CopyButton({ text }: CopyButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+
+    setTimeout(() => {
+      setCopied(false);
+    }, 2000);
+  };
+
+  return (
+    <button
+      onClick={handleCopy}
+      className="px-2 py-1 text-xs rounded border"
+    >
+      {copied ? "Copied!" : "Copy"}
+    </button>
+  );
+}

--- a/frontend/src/components/ui/TerminalPanel.tsx
+++ b/frontend/src/components/ui/TerminalPanel.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useState } from "react";
-
+import CopyButton from "./CopyButton";
 
 type TerminalPanelProps = {
   expectedCommand?: string;
@@ -32,10 +32,18 @@ export function TerminalPanel({ expectedCommand = "git status" }: TerminalPanelP
           <span className="h-2.5 w-2.5 rounded-full bg-primary/80" />
         </div>
       </div>
-      <div className="rounded-2xl border-t border-primary/30 bg-surface px-4 py-4 font-mono text-sm text-muted">
-        <p className="text-primary">atelier-admin:~$ initialize training shell</p>
-        <p className="mt-2">Sandbox ready. Type the expected Git command for this lesson.</p>
-      </div>
+     <div className="rounded-2xl border-t border-primary/30 bg-surface px-4 py-4 font-mono text-sm text-muted">
+       <div className="flex items-center justify-between">
+         <p className="text-primary">
+           atelier-admin:~$ {expectedCommand}
+         </p>
+         <CopyButton text={expectedCommand} />
+       </div>
+       
+       <p className="mt-2">
+         Sandbox ready. Type the expected Git command for this lesson.
+       </p>
+     </div>
       <form onSubmit={handleSubmit}>
         <label className="mt-4 flex items-center gap-3 rounded-2xl border border-primary/20 bg-surface px-4 py-3 shadow-inner">
           <span className="font-mono text-tertiary">$</span>


### PR DESCRIPTION
## Summary

Added a reusable CopyButton component to improve command usability in the frontend.

### Changes Made

* Created a reusable `CopyButton` component.
* Implemented clipboard copy functionality using `navigator.clipboard`.
* Added visual feedback (`Copied!`) after successful copy.
* Integrated the CopyButton into TerminalPanel command display.

### Benefits

* One-click command copying.
* Better onboarding experience.
* Improved usability for new contributors.
* Reusable solution for future command/code blocks.

Closes #133 

