### PR TITLE
Add localized timezone display to Mentor Response SLA metric

### DIFF
--- a/frontend/src/pages/CommunityPage.tsx
+++ b/frontend/src/pages/CommunityPage.tsx
@@ -9,6 +9,15 @@ import { useAuth } from "../features/auth/AuthContext";
 export function CommunityPage() {
   const { user } = useAuth();
 
+  const timezoneAbbreviation =
+    new Intl.DateTimeFormat("en-US", {
+      timeZoneName: "short",
+  })
+      .formatToParts(new Date())
+      .find((part) => part.type === "timeZoneName")
+      ?.value || "UTC";
+      console.log("Timezone:", timezoneAbbreviation);
+
   // 1. Fetch backend community stats
   const { data: stats, isLoading } = useQuery({
     queryKey: ["communityStats"],
@@ -55,7 +64,10 @@ export function CommunityPage() {
   const displayStats = [
     { label: "Weekly active contributors", value: stats?.active_contributors || "128" },
     { label: "Merged learning PRs", value: stats?.merged_prs || "342" },
-    { label: "Mentor response SLA", value: stats?.response_sla || "3.2h" },
+    {
+      label: "Mentor response SLA",
+      value: `${stats?.response_sla || "3.2h"} ${timezoneAbbreviation}`,
+    },
     { label: "Open help requests", value: stats?.open_requests || "0" },
   ];
 


### PR DESCRIPTION
## Description

This PR adds localized timezone information to the Mentor Response SLA metric on the Community page.

### Changes Made

* Detected the user's local timezone abbreviation using the `Intl.DateTimeFormat` API.
* Appended the timezone abbreviation (e.g., IST, EST, GMT) to the Mentor Response SLA value.
* Added a fallback to `UTC` if the timezone abbreviation cannot be determined.

### Example

Before:

* 3.2h

After:

* 3.2h IST
* 3.2h EST
* 3.2h GMT

(depending on the user's local timezone)

### Files Modified

* `frontend/src/pages/CommunityPage.tsx`

### Verification

* Confirmed that the timezone is detected within `CommunityPage.tsx`.
* Verified that the SLA metric displays the timezone abbreviation alongside the response time.
* Successfully ran a production build using:

```bash
npm run build
```

Build completed successfully without introducing any new errors.

### Issue Addressed

* Displays localized timezone information next to SLA metrics as requested.

Closes #98

