### PR TITLE
Build a Neobrutalist Modal Window for Logout Confirmation

### DIFF
--- a/frontend/src/components/layout/LogoutButtonWithConfirm.tsx
+++ b/frontend/src/components/layout/LogoutButtonWithConfirm.tsx
@@ -8,7 +8,7 @@ export default function LogoutButtonWithConfirm() {
 
   return (
     <>
-      <button
+      <button type="button"
         onClick={() => setOpen(true)}
         className="rounded-xl bg-[#ffb5e8] px-3 py-2 text-xs font-black text-black border-2 border-black shadow-card-sm hover:-translate-y-0.5 hover:shadow-card active:translate-y-0.5 active:shadow-card-sm transition-all cursor-pointer uppercase"
       >

--- a/frontend/src/components/layout/LogoutButtonWithConfirm.tsx
+++ b/frontend/src/components/layout/LogoutButtonWithConfirm.tsx
@@ -1,0 +1,28 @@
+import React, { useState } from "react";
+import { useAuth } from "../../features/auth/AuthContext";
+import LogoutConfirmModal from "../ui/LogoutConfirmModal";
+
+export default function LogoutButtonWithConfirm() {
+  const { logout } = useAuth();
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <button
+        onClick={() => setOpen(true)}
+        className="rounded-xl bg-[#ffb5e8] px-3 py-2 text-xs font-black text-black border-2 border-black shadow-card-sm hover:-translate-y-0.5 hover:shadow-card active:translate-y-0.5 active:shadow-card-sm transition-all cursor-pointer uppercase"
+      >
+        Logout
+      </button>
+
+      <LogoutConfirmModal
+        open={open}
+        onCancel={() => setOpen(false)}
+        onConfirm={() => {
+          setOpen(false);
+          logout();
+        }}
+      />
+    </>
+  );
+}

--- a/frontend/src/components/layout/Navigation.tsx
+++ b/frontend/src/components/layout/Navigation.tsx
@@ -5,6 +5,7 @@ import { fetchApi } from "../../lib/api";
 import { useTheme } from "../../hooks/useTheme";
 import { useAuth } from "../../features/auth/AuthContext";
 import { fetchLessonsApi } from "../../lib/lessons";
+import LogoutButtonWithConfirm from "./LogoutButtonWithConfirm";
 
 const navItems = [
   { to: "/dashboard", label: "Dashboard", icon: LayoutGrid },
@@ -209,12 +210,7 @@ export function Navigation() {
                     </span>
                   )}
                 </span>
-                <button
-                  onClick={logout}
-                  className="rounded-xl bg-[#ffb5e8] px-3 py-2 text-xs font-black text-black border-2 border-black shadow-card-sm hover:-translate-y-0.5 hover:shadow-card active:translate-y-0.5 active:shadow-card-sm transition-all cursor-pointer uppercase"
-                >
-                  Logout
-                </button>
+                <LogoutButtonWithConfirm />
               </div>
             ) : (
               <Link

--- a/frontend/src/components/ui/LogoutConfirmModal.test.tsx
+++ b/frontend/src/components/ui/LogoutConfirmModal.test.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import LogoutConfirmModal from "./LogoutConfirmModal";
+
+describe("LogoutConfirmModal", () => {
+  beforeEach(() => {
+    cleanup();
+    document.body.innerHTML = "";
+  });
+
+  it("does not render when open is false", () => {
+    render(<LogoutConfirmModal open={false} onConfirm={() => {}} onCancel={() => {}} />);
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("renders and calls handlers on click", async () => {
+    const user = userEvent.setup();
+    const onConfirm = vi.fn();
+    const onCancel = vi.fn();
+
+    render(<LogoutConfirmModal open={true} onConfirm={onConfirm} onCancel={onCancel} />);
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    await user.click(screen.getByTestId("cancel-button"));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByTestId("confirm-button"));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/ui/LogoutConfirmModal.tsx
+++ b/frontend/src/components/ui/LogoutConfirmModal.tsx
@@ -35,15 +35,15 @@ export default function LogoutConfirmModal({
         <p className="mb-4">{description}</p>
 
         <div className="flex gap-3 justify-end">
-          <button
+          <button type="button"
             className="px-3 py-1 border-2 border-black text-sm bg-white hover:bg-gray-100"
-            onClick={onCancel}
-            data-testid="cancel-button"
-          >
+            onClick={onCancel} 
+            data-testid="cancel-button">
+
             Cancel
           </button>
 
-          <button
+          <button type="button"
             className="px-3 py-1 border-2 border-black text-sm bg-black text-white font-bold"
             onClick={onConfirm}
             data-testid="confirm-button"

--- a/frontend/src/components/ui/LogoutConfirmModal.tsx
+++ b/frontend/src/components/ui/LogoutConfirmModal.tsx
@@ -1,0 +1,58 @@
+import React, { useEffect } from "react";
+import { createPortal } from "react-dom";
+
+type Props = {
+  open: boolean;
+  title?: string;
+  description?: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+};
+
+export default function LogoutConfirmModal({
+  open,
+  title = "Confirm Logout",
+  description = "Are you sure you want to logout?",
+  onConfirm,
+  onCancel,
+}: Props) {
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onCancel();
+      if (e.key === "Enter") onConfirm();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open, onCancel, onConfirm]);
+
+  if (!open) return null;
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4" aria-hidden={!open}>
+      <div role="dialog" aria-modal="true" aria-labelledby="logout-modal-title" className="bg-white p-6 border-4 border-black max-w-sm w-full shadow-lg">
+        <h2 id="logout-modal-title" className="font-bold text-lg mb-2">{title}</h2>
+        <p className="mb-4">{description}</p>
+
+        <div className="flex gap-3 justify-end">
+          <button
+            className="px-3 py-1 border-2 border-black text-sm bg-white hover:bg-gray-100"
+            onClick={onCancel}
+            data-testid="cancel-button"
+          >
+            Cancel
+          </button>
+
+          <button
+            className="px-3 py-1 border-2 border-black text-sm bg-black text-white font-bold"
+            onClick={onConfirm}
+            data-testid="confirm-button"
+          >
+            Confirm
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}


### PR DESCRIPTION
This adds a small confirmation modal so users don’t get logged out by accident. The modal follows the repo’s neobrutalist styling and only calls the existing logout() after the user confirms.

What changed

Added: frontend/src/components/ui/LogoutConfirmModal.tsx
Added: frontend/src/components/layout/LogoutButtonWithConfirm.tsx
Added: frontend/src/components/ui/LogoutConfirmModal.test.tsx
Modified: frontend/src/components/layout/Navigation.tsx — replaced the direct logout button with <LogoutButtonWithConfirm />
How to test

Run frontend tests: cd frontend && npm install && npm run test
Manual check:
Start the frontend (npm run dev) and open the app.
Click Logout → modal appears.
Click Cancel → stays signed in.
Click Confirm → logout happens.
Closes Closes #125