### PR TITLE
feat: add hover transitions to navigation sidebar items

### DIFF
--- a/frontend/src/components/layout/Navigation.tsx
+++ b/frontend/src/components/layout/Navigation.tsx
@@ -81,7 +81,7 @@ export function Navigation() {
                   to={item.to}
                   className={({ isActive }) =>
                     [
-                      "flex items-center gap-3 rounded-xl px-4 py-3 text-sm font-medium transition",
+                      "flex items-center gap-3 rounded-xl px-4 py-3 text-sm font-medium transition-all duration-200 ease-in-out hover:scale-102 hover:shadow-card",
                       isActive
                         ? "bg-[linear-gradient(135deg,rgba(79,70,229,0.28),rgba(195,192,255,0.16))] text-text shadow-card dark:text-[#f0ebe2]"
                         : "text-muted hover:bg-surface-low hover:text-text dark:text-[#c4bbae] dark:hover:bg-[#151411] dark:hover:text-[#f0ebe2]",

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -31,6 +31,9 @@ export default {
         "card-sm": "2px 2px 0px 0px rgba(0, 0, 0, 1)",
         "gel": "0px 8px 0px 0px rgba(230, 40, 20, 1), 0px -4px 0px 0px rgba(255,100,80,1) inset",
       },
+      scale: {
+        "102": "1.02",
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary

Closes #90

Added subtle hover animations to sidebar navigation items to improve interactivity and align with the neobrutalist design language.

## Changes Made

- Added `hover:scale-102` to navigation links
- Added `hover:shadow-card` hover state
- Added smooth transitions using `transition-all duration-200 ease-in-out`
- Added custom `scale-102` utility in Tailwind configuration

## Testing

- Verified hover scale effect on all sidebar navigation items
- Verified shadow transition appears smoothly
- Confirmed transition timing matches acceptance criteria

<img width="354" height="330" alt="sidebar-animations" src="https://github.com/user-attachments/assets/7d1a5d51-089a-49dd-9a38-98b7cf3ec6d8" />
