### PR TITLE
Add drf-spectacular schema annotations to accounts and progress views (issue #110)

### DIFF
--- a/backend/apps/accounts/views.py
+++ b/backend/apps/accounts/views.py
@@ -19,7 +19,7 @@ from django.db.models import Sum
 from apps.progress.models import LessonProgress, UserBadge
 from apps.progress.serializers import UserBadgeSerializer
 from .serializers import SignupSerializer, UserListSerializer, EmailOrUsernameTokenObtainPairSerializer
-
+from drf_spectacular.utils import extend_schema, extend_schema_view, OpenApiResponse
 
 def unique_username_from_value(value: str) -> str:
     base = slugify(value.split("@")[0]) or "user"
@@ -40,7 +40,7 @@ def frontend_url(path: str, query: Optional[dict[str, str]] = None) -> str:
         url = f"{url}?{urlencode(query)}"
     return url
 
-
+@extend_schema(request=SignupSerializer, responses=SignupSerializer)
 class SignupView(generics.CreateAPIView):
     queryset = User.objects.all()
     serializer_class = SignupSerializer
@@ -49,7 +49,8 @@ class SignupView(generics.CreateAPIView):
 
 class MeView(APIView):
     permission_classes = [IsAuthenticated] # check jwt authentication
-    
+
+    @extend_schema(responses=UserListSerializer)
     def get(self, request):
         return Response(
             {
@@ -64,6 +65,12 @@ class MeView(APIView):
 class MyBadgesView(APIView):
     permission_classes = [permissions.IsAuthenticated]
 
+    @extend_schema(
+        responses=OpenApiResponse(
+            response=UserBadgeSerializer(many=True),
+            description="Returns object {progress_points: number, badges: [UserBadgeSerializer]}",
+        )
+    )
     def get(self, request):
         earned_badges = (
             UserBadge.objects.filter(user=request.user)
@@ -82,7 +89,10 @@ class MyBadgesView(APIView):
             }
         )
 
-
+@extend_schema(
+    request=EmailOrUsernameTokenObtainPairSerializer,
+    responses=OpenApiResponse(description="Returns JWT refresh & access tokens and basic user info.")
+)
 class LoginView(TokenObtainPairView):
     permission_classes = [permissions.AllowAny]
     serializer_class = EmailOrUsernameTokenObtainPairSerializer
@@ -235,7 +245,7 @@ class GitHubOAuthCallbackView(APIView):
         except Exception:
             return redirect(frontend_url("/", {"auth_error": "GitHub authentication failed."}))
 
-
+@extend_schema(responses=UserListSerializer(many=True))
 class UserListView(generics.ListAPIView):
     queryset = User.objects.all().order_by("id")
     permission_classes = [permissions.IsAuthenticated]

--- a/backend/apps/progress/serializers.py
+++ b/backend/apps/progress/serializers.py
@@ -48,3 +48,8 @@ class HelpRequestSerializer(serializers.ModelSerializer):
             "updated_at",
         ]
         read_only_fields = ["user", "status", "created_at", "updated_at"]
+
+class LessonProgressCreateSerializer(serializers.Serializer):
+    lesson_slug = serializers.SlugField(help_text="Slug of the lesson")
+    score = serializers.IntegerField(default=100, help_text="Numeric score")
+    completed = serializers.BooleanField(default=True, help_text="Whether the lesson is completed")

--- a/backend/apps/progress/views.py
+++ b/backend/apps/progress/views.py
@@ -5,16 +5,19 @@ from rest_framework.views import APIView
 from .models import Badge, HelpRequest, LessonProgress, ExerciseAttempt, QuizAttempt
 
 from apps.content.models import Lesson
-from .models import Badge, HelpRequest, LessonProgress, ExerciseAttempt
-from .serializers import BadgeSerializer, HelpRequestSerializer, LessonProgressSerializer
+from .serializers import BadgeSerializer, HelpRequestSerializer, LessonProgressSerializer, LessonProgressCreateSerializer
+from drf_spectacular.utils import extend_schema, extend_schema_view, OpenApiResponse
 
-
+@extend_schema(responses=BadgeSerializer(many=True))
 class BadgeListView(ListAPIView):
     queryset = Badge.objects.all()
     serializer_class = BadgeSerializer
     permission_classes = [permissions.IsAuthenticatedOrReadOnly]
 
-
+@extend_schema_view(
+    get=extend_schema(responses=LessonProgressSerializer(many=True)),
+    post=extend_schema(request=LessonProgressCreateSerializer, responses=LessonProgressSerializer),
+)
 class MyProgressView(APIView):
     permission_classes = [permissions.IsAuthenticated]
 
@@ -52,6 +55,7 @@ class MyProgressView(APIView):
         )
 
 
+@extend_schema(responses=OpenApiResponse(description="Community stats summary JSON: active_contributors, merged_prs, response_sla, open_requests"))
 class CommunityStatsView(APIView):
     def get(self, request):
         from django.contrib.auth.models import User
@@ -70,6 +74,10 @@ class CommunityStatsView(APIView):
         })
 
 
+@extend_schema_view(
+    get=extend_schema(responses=HelpRequestSerializer(many=True)),
+    post=extend_schema(request=HelpRequestSerializer, responses=HelpRequestSerializer),
+)
 class HelpRequestListCreateView(APIView):
     permission_classes = [permissions.IsAuthenticated]
 
@@ -100,7 +108,8 @@ class HelpRequestListCreateView(APIView):
         )
         serializer = HelpRequestSerializer(help_request)
         return Response(serializer.data, status=status.HTTP_201_CREATED)
-    
+
+@extend_schema(responses=OpenApiResponse(description="Contributor timeline: first_contribution_date, completed_lessons, exercise_attempts, help_requests, contribution_streak"))   
 class ContributorTimelineView(APIView):
     permission_classes = [permissions.IsAuthenticated]
 
@@ -125,6 +134,17 @@ class ContributorTimelineView(APIView):
             "help_requests": help_requests,
             "contribution_streak": completed_lessons,
         })
+    
+@extend_schema_view(
+    post=extend_schema(
+        description="Create a quiz attempt. Expected JSON fields: question_id, question_text (optional), selected_answer, correct_answer, is_correct, time_taken_seconds.",
+        responses=OpenApiResponse(description="Created attempt summary: {id, question_id, is_correct, created_at}"),
+    ),
+    get=extend_schema(
+        description="List quiz attempts and stats. Optional query param: question_id. Returns total_attempts, correct, incorrect, accuracy_percent, attempts array.",
+        responses=OpenApiResponse(description="Quiz attempts summary and attempts array."),
+    ),
+)
 class QuizAttemptView(APIView):
     permission_classes = [permissions.IsAuthenticated]
 


### PR DESCRIPTION
**Summary**
Added drf-spectacular extend_schema annotations to accounts and progress views so Swagger shows correct request/response schemas. Added LessonProgressCreateSerializer to document POST /api/progress/me/ payload.

**Related Issues**
Closes #110

**Testing & Verification**
Installed drf-spectacular, ran:

```Code```

```bash 
python backend/manage.py migrate
python backend/manage.py runserver
```

Verified /api/schema/ and /api/docs/ — endpoints annotated and POST /api/progress/me/ shows lesson_slug, score, completed.
