### PR TITLE
feat: highlight active module directory item in sidebar outline

### DIFF
--- a/frontend/src/pages/LessonPage.tsx
+++ b/frontend/src/pages/LessonPage.tsx
@@ -237,6 +237,9 @@ export function LessonPage() {
 
   const hasQuiz = lesson.quizzes && lesson.quizzes.length > 0;
   const isCompleted = isLessonCompleted(lesson.slug);
+  const activeModuleId = modules.find((mod) =>
+  mod.lessons.some((les) => les.slug === lesson.slug)
+)?.id;
 
   return (
     <div className="min-h-screen pt-20 flex flex-col lg:flex-row relative">
@@ -288,8 +291,14 @@ export function LessonPage() {
         <div className="space-y-6">
           {modules.map((mod, modIdx) => (
             <div key={mod.id} className="space-y-2">
-              <h3 className="font-mono text-[10px] uppercase tracking-wider text-muted dark:text-[#c4bbae] font-bold">
-                Module {modIdx + 1}: {mod.title}
+            
+              <h3
+                    className={`font-mono text-[10px] uppercase tracking-wider font-bold px-2 py-1.5 rounded-lg border-2 transition-all
+                         ${mod.id === activeModuleId
+                      ? "bg-yellow-300 text-black border-black shadow-[2px_2px_0px_#000]"
+                          : "text-muted dark:text-[#c4bbae] border-transparent"
+                        }`}>
+                     Module {modIdx + 1}: {mod.title}
               </h3>
               <div className="space-y-1">
                 {mod.lessons.map((les: { slug: string; title: string; difficulty?: string }) => {


### PR DESCRIPTION
## Summary

Implemented active module highlighting in the lesson sidebar curriculum outline to improve navigation and help users easily identify which module the current lesson belongs to.

## Related Issue

Closes #83

## Changes Made

* Added logic to determine the active module based on the currently opened lesson.
* Applied distinct styling to highlight the active module in the curriculum sidebar.
* Improved lesson navigation clarity and user experience.

## Testing

* [x] Tested manually
* [ ] Add new unit/integration test
* [x] Verified existing functionality still works

### Manual Testing

* Opened lesson pages locally.
* Verified Module 1 remains highlighted when navigating between lessons within Module 1.
* Confirmed the active module is visually distinguishable from other modules.
* Ensured no unrelated files were modified.

## Screenshots
<img width="1600" height="785" alt="Screenshot (104)" src="https://github.com/user-attachments/assets/ab142aae-4e71-4e9d-a180-d63f770310e6" />


## Checklist



* [ ] Tests added or updated
* [ ] Documentation updated if needed
* [x] No secrets committed
