### PR TITLE
feat: add localStorage caching for GitHub contributors

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -107,7 +107,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -436,7 +435,6 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -459,7 +457,6 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1655,7 +1652,8 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1803,7 +1801,6 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -1856,7 +1853,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.0.tgz",
       "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.0",
         "@typescript-eslint/types": "8.58.0",
@@ -2227,7 +2223,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2274,6 +2269,7 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2449,7 +2445,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2901,7 +2896,8 @@
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.331",
@@ -3004,7 +3000,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3596,7 +3591,6 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -3624,7 +3618,6 @@
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -3798,6 +3791,7 @@
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -4099,7 +4093,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4266,6 +4259,7 @@
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -4280,6 +4274,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -4320,7 +4315,6 @@
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4329,7 +4323,6 @@
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4901,7 +4894,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5025,7 +5017,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5139,7 +5130,6 @@
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -5253,7 +5243,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -63,6 +63,8 @@ const BADGES = [
 export function DashboardPage() {
   const { user } = useAuth();
   const { isLessonCompleted } = useUserProgress();
+  const CONTRIBUTORS_CACHE_KEY = "github_contributors_cache";
+  const CACHE_EXPIRY = 24 * 60 * 60 * 1000; // 24 hours
 
   // 1. Fetch static modules catalog
   const [curriculumData, setCurriculumData] = useState<any[]>([]);
@@ -114,25 +116,68 @@ export function DashboardPage() {
   // GitHub Live Contributors list
   const [gitHubContributors, setGitHubContributors] = useState<any[]>([]);
   useEffect(() => {
-    fetch("https://api.github.com/repos/goyaljiiiiii/Open-Source-Contribution-Atelier/contributors")
-      .then(res => {
-        if (!res.ok) throw new Error("API Limit");
-        return res.json();
-      })
-      .then(data => {
-        if (Array.isArray(data)) {
-          setGitHubContributors(data.slice(0, 8));
+  const fallbackContributors = [
+    {
+      login: "goyaljiiiiii",
+      avatar_url: "https://github.com/goyaljiiiiii.png",
+      html_url: "https://github.com/goyaljiiiiii"
+    },
+    {
+      login: "nandini",
+      avatar_url: "https://github.com/github.png",
+      html_url: "https://github.com"
+    },
+    {
+      login: "antigravity",
+      avatar_url: "https://github.com/google.png",
+      html_url: "https://github.com"
+    }
+  ];
+
+  fetch("https://api.github.com/repos/goyaljiiiiii/Open-Source-Contribution-Atelier/contributors")
+    .then(res => {
+      if (!res.ok) throw new Error("API Limit");
+      return res.json();
+    })
+    .then(data => {
+      if (Array.isArray(data)) {
+        const contributors = data.slice(0, 8);
+
+        setGitHubContributors(contributors);
+
+        localStorage.setItem(
+          CONTRIBUTORS_CACHE_KEY,
+          JSON.stringify({
+            data: contributors,
+            timestamp: Date.now()
+          })
+        );
+      }
+    })
+    .catch(() => {
+      const cachedData = localStorage.getItem(CONTRIBUTORS_CACHE_KEY);
+
+      if (cachedData) {
+        try {
+          const parsedCache = JSON.parse(cachedData);
+
+          const isCacheValid =
+            Date.now() - parsedCache.timestamp < CACHE_EXPIRY;
+
+          if (isCacheValid) {
+            setGitHubContributors(parsedCache.data);
+            return;
+          }
+
+          localStorage.removeItem(CONTRIBUTORS_CACHE_KEY);
+        } catch {
+          localStorage.removeItem(CONTRIBUTORS_CACHE_KEY);
         }
-      })
-      .catch(() => {
-        // Fallback contributors list
-        setGitHubContributors([
-          { login: "goyaljiiiiii", avatar_url: "https://github.com/goyaljiiiiii.png", html_url: "https://github.com/goyaljiiiiii" },
-          { login: "nandini", avatar_url: "https://github.com/github.png", html_url: "https://github.com" },
-          { login: "antigravity", avatar_url: "https://github.com/google.png", html_url: "https://github.com" }
-        ]);
-      });
-  }, []);
+      }
+
+      setGitHubContributors(fallbackContributors);
+    });
+}, []);
 
   // Onboarding Tour state
   const [showOnboarding, setShowOnboarding] = useState(false);


### PR DESCRIPTION
## Summary

Implemented LocalStorage caching fallback for the GitHub Contributors API on the Dashboard page. Contributor data is now cached locally after a successful API response and reused when the GitHub API is unavailable or rate-limited.

## Related Issue

Closes #124

## Changes Made

* Added LocalStorage caching for GitHub contributors data.
* Added a 24-hour cache expiration mechanism using timestamps.
* Stored contributor data in LocalStorage after successful API responses.
* Added fallback logic to load cached contributor data when the GitHub API request fails.
* Automatically removes expired cache entries.
* Preserved the existing hardcoded fallback contributors list when no valid cache is available.

## Testing

* [x] Tested manually
* [ ] Add new unit/integration test
* [x] Verified existing build passes

### Manual Testing Performed

1. Built the frontend using `npm run build`.
2. Verified the project compiles successfully without TypeScript errors.
3. Confirmed contributor data is cached after a successful API response.
4. Verified cached data is used when the GitHub API request fails.
5. Confirmed expired cache entries are removed and fallback contributors are displayed when no valid cache exists.

## Screenshots

N/A (No UI changes were introduced)

## Checklist

* [ ] Tests added or updated
* [ ] Documentation updated if needed
* [x] No secrets committed

