### PR TITLE
fix: add dynamic aria-label to theme togglebutton

### DIFF
--- a/frontend/src/components/layout/Navigation.tsx
+++ b/frontend/src/components/layout/Navigation.tsx
@@ -194,6 +194,7 @@ export function Navigation() {
             <button 
               className="rounded-xl bg-surface-low p-2 text-muted hover:text-text dark:bg-[#151411] dark:text-[#c4bbae] dark:hover:text-[#f0ebe2]"
               onClick={toggleTheme}
+              aria-label={theme === "light" ? "Switch to dark mode" : "Switch to light mode"}
             >
               {theme === "light" ? <Moon size={16} /> : <Sun size={16} />}
             </button>


### PR DESCRIPTION
## Summary
Added a dynamic `aria-label` to the theme toggle button in `Navigation.tsx`

## Related Issue
<!--What are the issues it solves  -->
Closes #92 

## Changes Made
Added `aria-label={theme === "light" ? "Switch to dark mode" : "Switch to light mode"}` to the theme toggle `<button>` inside `frontend/src/components/layout/Navigation.tsx`.

## Testing
<!--Provide instructions on how it has been tested so reviewers can verify you change-->
- [x] Tested manually 
- [ ] Add new unit/integration test
- [ ] verified existing test still pass

## Screenshots
<!-- Add Screenshots of visual changes-->
N/A
## Checklist

- [ ] Tests added or updated
- [ ] Documentation updated if needed
- [x] No secrets committed

