### PR TITLE
Display Active GitHub Organizations grid on Login Page

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@react-oauth/google": "^0.13.4",
         "@tanstack/react-query": "^5.66.0",
         "clsx": "^2.1.1",
+        "framer-motion": "^12.40.0",
         "jwt-decode": "^4.0.0",
         "lucide-react": "^0.474.0",
         "react": "^19.0.0",
@@ -3343,6 +3344,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.40.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.40.0.tgz",
+      "integrity": "sha512-uaBd3qC1v3KQqBEjwTUd183K6PbS+j0yR9w9VmEOLWA/tnUcSn8Xa3uck7t4dgpDoUss8xQTcj8W2L07lrnLFg==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.40.0",
+        "motion-utils": "^12.39.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3864,6 +3892,21 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.40.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.40.0.tgz",
+      "integrity": "sha512-HxU3ZaBwNPVQUBQf1xxgq+7JrPNZvjLVxgbpEZL7RrWJnsxOf0/OM+yrHG9ogLQ31Do/r57Oz2gQWPK+6q62mg==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.39.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.39.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.39.0.tgz",
+      "integrity": "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -5026,6 +5069,12 @@
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "@react-oauth/google": "^0.13.4",
     "@tanstack/react-query": "^5.66.0",
     "clsx": "^2.1.1",
+    "framer-motion": "^12.40.0",
     "jwt-decode": "^4.0.0",
     "lucide-react": "^0.474.0",
     "react": "^19.0.0",

--- a/frontend/src/components/OrganizationsGrid.tsx
+++ b/frontend/src/components/OrganizationsGrid.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { ORGS } from '../lib/organizations';
+
+const OrganizationsGrid: React.FC = () => {
+  return (
+    <section aria-labelledby="orgs-heading" className="mt-8">
+      <h3 id="orgs-heading" className="text-lg font-semibold mb-4">Open-source organizations</h3>
+      <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+        {ORGS.map((slug) => (
+          <a
+            key={slug}
+            href={`https://github.com/${slug}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="border rounded-lg p-3 flex items-start gap-3 hover:shadow transition-shadow bg-white dark:bg-gray-800"
+          >
+            <img
+              src={`https://github.com/${slug}.png?size=120`}
+              alt={`${slug} avatar`}
+              className="w-12 h-12 rounded-md object-cover"
+            />
+            <div>
+              <div className="font-medium">{slug}</div>
+              <div className="text-sm text-muted mt-1">Visit on GitHub</div>
+            </div>
+          </a>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default OrganizationsGrid;

--- a/frontend/src/lib/organizations.ts
+++ b/frontend/src/lib/organizations.ts
@@ -1,0 +1,8 @@
+export const ORGS = [
+  'apache',
+  'cncf',
+  'linuxfoundation',
+  'nodejs',
+  'mozilla',
+  'github'
+];

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -3,6 +3,7 @@ import { useGoogleLogin } from "@react-oauth/google";
 import { Github } from "lucide-react";
 import { fetchApi } from "../lib/api";
 import { useAuth } from "../features/auth/AuthContext";
+import OrganizationsGrid from '../components/OrganizationsGrid';
 
 const githubAuthUrl =
   import.meta.env.VITE_GITHUB_OAUTH_URL ||
@@ -97,7 +98,7 @@ export function LandingPage() {
           </h2>
           
           {error && <div className="text-black font-bold text-sm bg-primary p-3 rounded-xl border-4 border-black shadow-card-sm mb-4">{error}</div>}
-
+          <OrganizationsGrid />
           <form onSubmit={handleStandardLogin} className="space-y-4">
             <button 
               type="button" 


### PR DESCRIPTION
Summary Adds a simple, client-side Organizations grid to the landing/login page. The grid displays a curated set of open-source organizations using their public GitHub avatar images and provides clickable cards that open each organization’s GitHub page. The implementation is static and does not require backend changes or secrets.

Related Issues Closes #187