### PR TITLE
fix: add aria-live support for quiz feedback

### DIFF
--- a/frontend/src/pages/LessonPage.tsx
+++ b/frontend/src/pages/LessonPage.tsx
@@ -437,13 +437,21 @@ export function LessonPage() {
                   </div>
 
                   {quizFeedback === "correct" && (
-                    <div className="mt-4 p-4 bg-green-50 text-green-800 border-4 border-green-600 rounded-xl font-bold text-sm">
+                    <div
+                      role="alert"
+                      aria-live="assertive"
+                      className="mt-4 p-4 bg-green-50 text-green-800 border-4 border-green-600 rounded-xl font-bold text-sm"
+                    >
                       🎉 Correct! {lesson.quizzes![currentQuizIndex].explanation}
                     </div>
                   )}
 
                   {quizFeedback === "incorrect" && (
-                    <div className="mt-4 p-4 bg-red-50 text-red-800 border-4 border-red-600 rounded-xl font-bold text-sm">
+                    <div
+                      role="alert"
+                      aria-live="assertive"
+                      className="mt-4 p-4 bg-red-50 text-red-800 border-4 border-red-600 rounded-xl font-bold text-sm"
+                    >
                       ❌ Not quite. Try reviewing the lesson text or options again.
                     </div>
                   )}


### PR DESCRIPTION
## Summary

This PR improves accessibility for quiz feedback messages in `LessonPage.tsx`.

## Related Issue

Closes #113

## Changes Made

* Added `aria-live="assertive"` to quiz feedback messages.
* Added `role="alert"` to both correct and incorrect feedback containers.
* Ensures screen readers immediately announce quiz feedback when users submit an answer.

## Testing

* Verified that the accessibility attributes were added to both correct and incorrect quiz feedback messages.
* Confirmed there are no syntax issues in the modified component.
* Attempted to run the application locally using `npm run dev`.

### Note

The application could not be fully tested locally due to existing build issues unrelated to this change:

* No matching export in `src/app/App.tsx` for import `queryClient`
* No matching export in `src/app/App.tsx` for import `App`

## Screenshots

N/A (accessibility-only change)

## Checklist

* [ ] Tests added or updated
* [ ] Documentation updated if needed
* [x] No secrets committed


