### PR TITLE
feat: add Cmd/Ctrl+Enter shortcut for terminal checks

### DIFF
--- a/frontend/src/pages/LessonPage.tsx
+++ b/frontend/src/pages/LessonPage.tsx
@@ -494,6 +494,12 @@ export function LessonPage() {
                         placeholder="Type your git command here"
                         value={input}
                         onChange={(e) => setInput(e.target.value)}
+                        onKeyDown={(e) => {
+                          if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+                            e.preventDefault();
+                            handleCommandSubmit(e as any);
+                          }
+                        }}
                         disabled={feedback === "correct"}
                         autoFocus
                       />


### PR DESCRIPTION
## Summary

Adds keyboard shortcuts for terminal command submission in `LessonPage.tsx`.

## Related Issue

Closes #85

## Changes Made

* Added support for `Cmd + Enter` on macOS.
* Added support for `Ctrl + Enter` on Windows/Linux.
* Triggers the same submission flow as the existing **Run** button.
* Prevents default keyboard behavior before submitting.

## Testing

* Verified that the keyboard shortcut handler was added to the terminal input field.
* Confirmed support for both `metaKey` (macOS) and `ctrlKey` (Windows/Linux).
* Attempted to run the application locally.

### Note

The current repository contains unrelated build issues preventing full local execution:

* Missing export `App` from `src/app/App.tsx`
* Missing export `queryClient` from `src/app/App.tsx`

These issues are unrelated to the changes in this PR.

## Checklist

* [ ] Tests added or updated
* [ ] Documentation updated if needed
* [x] No secrets committed
