### PR TITLE
feat: add lock icon for locked achievements

### DIFF
--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -23,7 +23,8 @@ import {
   ChevronRight,
   HelpCircle,
   Code,
-  X
+  X,
+  Lock
 } from "lucide-react";
 import {
   BarChart,
@@ -658,7 +659,8 @@ export function DashboardPage() {
                     UNLOCKED
                   </span>
                 ) : (
-                  <span className="absolute top-2 right-2 bg-gray-100 text-gray-400 border-2 border-gray-400 text-[8px] font-black px-1.5 py-0.5 rounded-full dark:border-none">
+                  <span className="absolute top-2 right-2 bg-gray-100 text-gray-400 border-2 border-gray-400 text-[8px] font-black px-1.5 py-0.5 rounded-full dark:border-none flex items-center gap-1">
+                    <Lock size={10} />
                     LOCKED
                   </span>
                 )}


### PR DESCRIPTION
## Summary

Adds a visual lock icon to unearned achievement badges in the Dashboard.

## Related Issue

Closes #89

## Changes Made

* Added `Lock` icon from `lucide-react`.
* Displayed the lock icon alongside the `LOCKED` badge label for unearned achievements.
* Improves visual clarity and user feedback for locked badges.

## Testing

* Verified that the lock icon is displayed for badges where `isEarned` is false.
* Confirmed that earned badges remain unchanged.

## Checklist

* [ ] Tests added or updated
* [ ] Documentation updated if needed
* [x] No secrets committed
