### PR TITLE
feat: enforce lowercase emails on signup

### DIFF
--- a/backend/apps/accounts/serializers.py
+++ b/backend/apps/accounts/serializers.py
@@ -10,9 +10,11 @@ class SignupSerializer(serializers.ModelSerializer):
         model = User
         fields = ("id", "username", "email", "password")
 
+    def validate_email(self, value):
+        return value.strip().lower()
+
     def create(self, validated_data):
         return User.objects.create_user(**validated_data)
-
 
 class UserListSerializer(serializers.ModelSerializer):
     class Meta:

--- a/backend/tests/test_auth_and_sandbox.py
+++ b/backend/tests/test_auth_and_sandbox.py
@@ -24,6 +24,25 @@ def test_signup_and_login_flow():
 
 
 @pytest.mark.django_db
+def test_signup_saves_email_as_lowercase():
+    client = APIClient()
+
+    response = client.post(
+        "/api/auth/signup/",
+        {
+            "username": "mentor_lowercase",
+            "email": "MENTOR@EXAMPLE.COM",
+            "password": "strongpass123",
+        },
+        format="json",
+    )
+
+    assert response.status_code == 201
+
+    user = User.objects.get(username="mentor_lowercase")
+    assert user.email == "mentor@example.com"
+
+@pytest.mark.django_db
 def test_login_with_email_identifier():
     client = APIClient()
     User.objects.create_user(


### PR DESCRIPTION
## Changes
- Normalize email values to lowercase in SignupSerializer.
- Added a test to verify uppercase emails are stored as lowercase.

Fixes #152