### PR TITLE
feat: enforce estimated minutes range on lessons

### DIFF
--- a/backend/apps/content/models.py
+++ b/backend/apps/content/models.py
@@ -1,3 +1,4 @@
+from django.core.validators import MinValueValidator, MaxValueValidator
 from django.db import models
 
 
@@ -9,7 +10,13 @@ class Lesson(models.Model):
     content = models.TextField()
     learning_objectives = models.JSONField(default=list, blank=True)
     tips = models.JSONField(default=list, blank=True)
-    estimated_minutes = models.PositiveIntegerField(default=15)
+    estimated_minutes = models.PositiveIntegerField(
+    default=15,
+    validators=[
+        MinValueValidator(1),
+        MaxValueValidator(120),
+    ],
+)
     order = models.PositiveIntegerField(default=0)
 
     class Meta:

--- a/backend/tests/test_content_roadmap.py
+++ b/backend/tests/test_content_roadmap.py
@@ -1,7 +1,7 @@
 import pytest
 from django.contrib.auth.models import User
 from rest_framework.test import APIClient
-
+from django.core.exceptions import ValidationError
 from apps.content.models import Lesson, Exercise
 from apps.progress.models import LessonProgress
 
@@ -63,3 +63,34 @@ def test_roadmap_endpoint_includes_user_progress():
     assert response.data["track"][0]["slug"] == "branching-roadmap"
     assert response.data["track"][0]["completed"] is True
     assert response.data["track"][0]["score"] == 95
+
+@pytest.mark.django_db
+def test_estimated_minutes_below_range_raises_validation_error():
+    lesson = Lesson(
+        difficulty="beginner",
+        title="Invalid Low",
+        slug="invalid-low",
+        summary="summary",
+        content="content",
+        estimated_minutes=0,
+        order=1,
+    )
+
+    with pytest.raises(ValidationError):
+        lesson.full_clean()
+
+
+@pytest.mark.django_db
+def test_estimated_minutes_above_range_raises_validation_error():
+    lesson = Lesson(
+        difficulty="beginner",
+        title="Invalid High",
+        slug="invalid-high",
+        summary="summary",
+        content="content",
+        estimated_minutes=121,
+        order=1,
+    )
+
+    with pytest.raises(ValidationError):
+        lesson.full_clean()


### PR DESCRIPTION
## Changes
- Added validators to restrict estimated minutes to 1–120.
- Added tests to ensure invalid values raise ValidationError.

Fixes #160