### PR TITLE
fix: add print styles to hide navigation when printing certificates

### DIFF
--- a/frontend/src/pages/VerifyCertificatePage.tsx
+++ b/frontend/src/pages/VerifyCertificatePage.tsx
@@ -80,7 +80,7 @@ export function VerifyCertificatePage() {
   if (!hash) {
     return (
       <div className="min-h-screen bg-bg py-12 px-6 sm:px-12 flex flex-col items-center">
-        <div className="w-full max-w-3xl mb-8 flex items-center justify-between">
+        <div className="w-full max-w-3xl mb-8 flex items-center justify-between no-print">
           <Link
             to="/"
             className="group flex items-center gap-2 font-bold text-black border-4 border-black bg-white px-4 py-2 rounded-xl shadow-card-sm transition-all hover:-translate-y-1 hover:shadow-card active:translate-y-0 active:shadow-none"
@@ -155,7 +155,7 @@ export function VerifyCertificatePage() {
         </div>
       </div>
 
-      <div className="w-full max-w-3xl bg-white border-4 border-black rounded-3xl p-8 sm:p-12 shadow-card">
+      <div className="w-full max-w-3xl bg-white border-4 border-black rounded-3xl p-8 sm:p-12 shadow-card certificate-printable">
         {error && !data ? (
           /* Case 3a: Non-existent hash (404 Error) */
           <div className="flex flex-col items-center text-center space-y-6">

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -58,3 +58,27 @@ input {
     box-shadow 0.15s ease-out,
     color 200ms cubic-bezier(0.4, 0, 0.2, 1);
 }
+
+@media print {
+  body * {
+    visibility: hidden;
+  }
+
+  .certificate-printable,
+  .certificate-printable * {
+    visibility: visible;
+  }
+
+  .certificate-printable {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    box-shadow: none !important;
+    border: none !important;
+  }
+
+  .no-print {
+    display: none !important;
+  }
+}


### PR DESCRIPTION
## Summary

Adds print-specific styles so that certificate pages print cleanly without navigation elements or extra UI components.

## Related Issue

Closes #84

## Changes Made

* Added print media query in `styles.css`
* Added print-specific class for the certificate container
* Added `no-print` class for navigation/header elements
* Ensured only the certificate content is visible in print preview

## Testing

* [x] Tested manually
* [ ] Added new unit/integration tests
* [x] Verified functionality using browser print preview (Ctrl + P)

## Screenshots

Print preview now displays only the certificate content without navigation or extra page elements.

<img width="1920" height="1080" alt="Screenshot (118)" src="https://github.com/user-attachments/assets/d57e37f4-b005-4785-819c-c57b0d78123a" />


## Checklist

* [x] No secrets committed
* [x] Changes tested locally
* [x] Issue requirements addressed
