### PR TITLE
fix: add fallback for missing VITE_API_BASE_URL

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,7 +1,8 @@
 import { queueProgressSync } from "./offlineQueue";
 
 const API_BASE =
-  import.meta.env.VITE_API_BASE_URL || "http://localhost:8000/api";
+  import.meta.env.VITE_API_BASE_URL?.trim() ||
+  `${window.location.origin}/api`;
 
 type RequestOptions = RequestInit & {
   requireAuth?: boolean;


### PR DESCRIPTION
## Summary

Adds a fallback for `VITE_API_BASE_URL` in `frontend/src/lib/api.ts` when the environment variable is missing or empty.

Instead of defaulting to a localhost URL, the application now derives the API base URL from the browser origin, helping deployments work correctly without requiring explicit environment configuration.

## Related Issue

Closes #121

## Changes Made

* Updated API base URL initialization in `frontend/src/lib/api.ts`
* Added support for empty environment variable values using `trim()`
* Added fallback to `window.location.origin` when `VITE_API_BASE_URL` is not configured

## Testing

* [x] Tested manually
* [ ] Add new unit/integration test
* [ ] verified existing test still pass

### Manual Testing

1. Started the frontend locally using `npm run dev`
2. Verified the application builds successfully
3. Confirmed the fallback logic compiles correctly when no `.env` file is present
4. Verified the change is limited to `frontend/src/lib/api.ts`

## Screenshots

N/A (no visual/UI changes)

## Checklist

* [ ] Tests added or updated
* [ ] Documentation updated if needed
* [x] No secrets committed
