### PR TITLE
feat: Implement QuizAttempt serializer and tests

### DIFF
--- a/backend/apps/progress/serializers.py
+++ b/backend/apps/progress/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-from .models import Badge, HelpRequest, LessonProgress, UserBadge, Certificate
+from .models import Badge, HelpRequest, LessonProgress, UserBadge, Certificate, QuizAttempt
 
 
 class BadgeSerializer(serializers.ModelSerializer):
@@ -64,3 +64,20 @@ class CertificateVerificationSerializer(serializers.ModelSerializer):
 
     def get_learner_name(self, obj):
         return obj.user.get_full_name() or obj.user.username
+
+
+class QuizAttemptSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = QuizAttempt
+        fields = [
+            "id",
+            "user",
+            "question_id",
+            "question_text",
+            "selected_answer",
+            "correct_answer",
+            "is_correct",
+            "time_taken_seconds",
+            "created_at",
+        ]
+        read_only_fields = ["id", "user", "created_at"]

--- a/backend/apps/progress/tests.py
+++ b/backend/apps/progress/tests.py
@@ -7,7 +7,7 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 from django.contrib.auth.models import User
 
-from .models import Certificate, LessonProgress
+from .models import Certificate, LessonProgress, QuizAttempt
 from apps.content.models import Lesson
 
 # ---------------------------------------------------------------------------
@@ -441,3 +441,87 @@ class RecommendationsTests(APITestCase):
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 0)
+
+
+# ---------------------------------------------------------------------------
+# QuizAttemptView  (authenticated – POST/GET /api/progress/quiz-attempts/)
+# ---------------------------------------------------------------------------
+
+class QuizAttemptTests(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="learner", password="password123")
+        self.url = reverse("quiz-attempts")
+
+    def test_unauthenticated_returns_401(self):
+        response = self.client.post(self.url, {})
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_post_valid_data_creates_attempt(self):
+        self.client.force_authenticate(user=self.user)
+        data = {
+            "question_id": "q1",
+            "question_text": "What is 2+2?",
+            "selected_answer": "4",
+            "correct_answer": "4",
+            "is_correct": True,
+            "time_taken_seconds": 15
+        }
+        response = self.client.post(self.url, data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertIn("id", response.data)
+        self.assertEqual(response.data["question_id"], "q1")
+        self.assertTrue(response.data["is_correct"])
+
+        # Verify DB
+        self.assertEqual(QuizAttempt.objects.count(), 1)
+        attempt = QuizAttempt.objects.first()
+        self.assertEqual(attempt.user, self.user)
+        self.assertEqual(attempt.question_id, "q1")
+
+    def test_post_missing_required_fields_returns_400(self):
+        self.client.force_authenticate(user=self.user)
+        # Missing question_id, selected_answer, correct_answer
+        data = {"is_correct": True}
+        response = self.client.post(self.url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("question_id", response.data)
+        self.assertIn("selected_answer", response.data)
+        self.assertIn("correct_answer", response.data)
+        self.assertEqual(QuizAttempt.objects.count(), 0)
+
+    def test_get_quiz_attempts_list(self):
+        self.client.force_authenticate(user=self.user)
+        QuizAttempt.objects.create(
+            user=self.user, question_id="q1", question_text="q1",
+            selected_answer="a", correct_answer="a", is_correct=True
+        )
+        QuizAttempt.objects.create(
+            user=self.user, question_id="q2", question_text="q2",
+            selected_answer="b", correct_answer="c", is_correct=False
+        )
+
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["total_attempts"], 2)
+        self.assertEqual(response.data["correct"], 1)
+        self.assertEqual(response.data["incorrect"], 1)
+        self.assertEqual(response.data["accuracy_percent"], 50.0)
+        self.assertEqual(len(response.data["attempts"]), 2)
+
+    def test_get_quiz_attempts_filter_by_question_id(self):
+        self.client.force_authenticate(user=self.user)
+        QuizAttempt.objects.create(
+            user=self.user, question_id="q1", question_text="q1",
+            selected_answer="a", correct_answer="a", is_correct=True
+        )
+        QuizAttempt.objects.create(
+            user=self.user, question_id="q2", question_text="q2",
+            selected_answer="b", correct_answer="c", is_correct=False
+        )
+
+        response = self.client.get(f"{self.url}?question_id=q1")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["total_attempts"], 1)
+        self.assertEqual(len(response.data["attempts"]), 1)
+        self.assertEqual(response.data["attempts"][0]["question_id"], "q1")
+

--- a/backend/apps/progress/views.py
+++ b/backend/apps/progress/views.py
@@ -15,7 +15,7 @@ from .models import (
 )
 from apps.content.models import Lesson
 from apps.content.serializers import LessonSerializer
-from .serializers import BadgeSerializer, HelpRequestSerializer, LessonProgressSerializer, LessonProgressCreateSerializer, CertificateVerificationSerializer
+from .serializers import BadgeSerializer, HelpRequestSerializer, LessonProgressSerializer, LessonProgressCreateSerializer, CertificateVerificationSerializer, QuizAttemptSerializer
 from drf_spectacular.utils import extend_schema, extend_schema_view, OpenApiResponse
 from .throttles import HelpRequestRateThrottle
 from django.shortcuts import get_object_or_404
@@ -265,45 +265,19 @@ class QuizAttemptView(APIView):
     permission_classes = [permissions.IsAuthenticated]
 
     def post(self, request):
-        question_id = request.data.get("question_id")
-        question_text = request.data.get("question_text", "")
-        selected_answer = request.data.get("selected_answer")
-        correct_answer = request.data.get("correct_answer")
-        is_correct = request.data.get("is_correct", False)
-        time_taken_seconds = request.data.get("time_taken_seconds", 0)
-
-        if not question_id:
-            return Response(
-                {"error": "question_id is required"},
-                status=status.HTTP_400_BAD_REQUEST
-            )
-        if selected_answer is None:
-            return Response(
-                {"error": "selected_answer is required"},
-                status=status.HTTP_400_BAD_REQUEST
-            )
-        if correct_answer is None:
-            return Response(
-                {"error": "correct_answer is required"},
-                status=status.HTTP_400_BAD_REQUEST
-            )
-
-        attempt = QuizAttempt.objects.create(
-            user=request.user,
-            question_id=question_id,
-            question_text=question_text,
-            selected_answer=selected_answer,
-            correct_answer=correct_answer,
-            is_correct=is_correct,
-            time_taken_seconds=time_taken_seconds,
-        )
-
-        return Response({
-            "id": attempt.id,
-            "question_id": attempt.question_id,
-            "is_correct": attempt.is_correct,
-            "created_at": attempt.created_at,
-        }, status=status.HTTP_201_CREATED)
+        serializer = QuizAttemptSerializer(data=request.data)
+        if serializer.is_valid():
+            attempt = serializer.save(user=request.user)
+            return Response({
+                "id": attempt.id,
+                "question_id": attempt.question_id,
+                "is_correct": attempt.is_correct,
+                "created_at": attempt.created_at,
+            }, status=status.HTTP_201_CREATED)
+        
+        # If there are field errors, extract the first one generically to match typical client expectations
+        # Or return all errors. DRF will return a dict like {"selected_answer": ["This field is required."]}
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     def get(self, request):
         attempts = QuizAttempt.objects.filter(user=request.user)
@@ -321,11 +295,7 @@ class QuizAttemptView(APIView):
             "correct": correct,
             "incorrect": incorrect,
             "accuracy_percent": round((correct / total) * 100, 1) if total > 0 else 0,
-            "attempts": list(attempts.values(
-                "id", "question_id", "question_text",
-                "selected_answer", "correct_answer",
-                "is_correct", "time_taken_seconds", "created_at"
-            ))
+            "attempts": QuizAttemptSerializer(attempts, many=True).data
         })
 
 class CertificateVerificationThrottle(AnonRateThrottle):


### PR DESCRIPTION
## Summary
This PR completes the backend logging system for quiz attempts by standardizing data validation and response formatting with a DRF `QuizAttemptSerializer`, replacing the previous manual parameter parsing in `QuizAttemptView`. It also adds comprehensive unit test coverage for the endpoint.

## Related Issue
Closes #174

## Changes Made
- Added `QuizAttemptSerializer` to handle payload validation and serialization.
- Refactored `QuizAttemptView` (`post` and `get` methods) to utilize the new serializer.
- Added a full suite of `APITestCase` unit tests for `QuizAttemptView` covering missing fields, valid data processing, unauthenticated access, and query filtering.

## Testing
- [x] Tested manually 
- [x] Add new unit/integration test
- [x] verified existing test still pass

Run `python manage.py test apps.progress.tests.QuizAttemptTests` to verify the newly added suite.

## Screenshots
N/A (Backend changes only)

## Checklist
- [x] Tests added or updated
- [x] Documentation updated if needed
- [x] No secrets committed
