### PR TITLE
feat: add character limit ticker for mentor support textarea

### DIFF
--- a/frontend/src/pages/LessonPage.tsx
+++ b/frontend/src/pages/LessonPage.tsx
@@ -48,6 +48,7 @@ export function LessonPage() {
   const [isHelpPanelOpen, setIsHelpPanelOpen] = useState(false);
   const [helpMessage, setHelpMessage] = useState("");
   const [helpSuccessMessage, setHelpSuccessMessage] = useState("");
+  const MAX_HELP_CHARS = 500;
 
   // Reading progress scroll ref
   const mainContentRef = useRef<HTMLDivElement>(null);
@@ -714,7 +715,11 @@ export function LessonPage() {
                 value={helpMessage}
                 onChange={(e) => setHelpMessage(e.target.value)}
                 disabled={helpRequestMutation.isPending}
+                maxLength={MAX_HELP_CHARS}
               />
+              <p className={`text-xs font-black text-right ${helpMessage.length > MAX_HELP_CHARS ? "text-red-600" : "text-muted dark:text-[#c4bbae]"}`}>
+                {helpMessage.length} / {MAX_HELP_CHARS} characters
+              </p>
 
               {helpRequestMutation.isError && (
                 <div className="text-red-700 text-xs font-black bg-red-50 p-2 rounded-lg border-2 border-red-700">
@@ -731,7 +736,7 @@ export function LessonPage() {
               <button
                 type="submit"
                 className="w-full px-4 py-2 bg-primary text-white font-bold rounded-xl border-4 border-black shadow-gel hover:bg-[#E62814] disabled:opacity-60"
-                disabled={!helpMessage.trim() || helpRequestMutation.isPending}
+                disabled={!helpMessage.trim() || helpMessage.length > MAX_HELP_CHARS || helpRequestMutation.isPending}
               >
                 {helpRequestMutation.isPending ? "Connecting..." : "Submit to cohort queue"}
               </button>


### PR DESCRIPTION
## Summary
Adds a character limit indicator and validation for the Mentor Support textarea in LessonPage.tsx.

## Related Issue
 Implement Character Limit Ticker on Support Textarea
Closes #151 

## Changes Made
Added a 500 character limit constant for the support message
Displayed a live character counter below the textarea (X / 500 characters)
Added validation to prevent form submission when character count exceeds 500
Updated submit button disabled state to include character limit check

## Testing
<!--Provide instructions on how it has been tested so reviewers can verify you change-->
- [x] Tested manually 
- [ ] Add new unit/integration test
- [x] verified existing test still pass

## Screenshots
<!-- Add Screenshots of visual changes-->
## Checklist

- [ ] Tests added or updated
- [ ] Documentation updated if needed
- [x] No secrets committed

