### PR TITLE
feat: animate XP counter on dashboard

### DIFF
--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -137,8 +137,7 @@ export function DashboardPage() {
     enabled: !user?.is_staff,
   });
 
-  const targetXP = contributorData?.personal_stats?.total_xp || 0;
-  const animatedXP = useCountUp(targetXP);
+  const animatedXP = useCountUp(totalXP);
 
   // Random Fact of the Day
   const factOfDay = useMemo(() => {
@@ -527,7 +526,7 @@ export function DashboardPage() {
               Welcome to the Atelier, {user?.username}.
             </h1>
             <p className="text-lg font-bold text-black bg-white/95 p-4 rounded-xl border-4 border-black shadow-card-sm inline-block max-w-xl leading-relaxed dark:bg-[#151411] dark:border-[#2e2924] dark:text-[#f0ebe2]">
-               You have completed {completedLessonsCount} of {totalLessonsCount} course modules, earning <span className="text-primary font-black">{totalXP} XP</span>.
+               You have completed {completedLessonsCount} of {totalLessonsCount} course modules, earning <span className="text-primary font-black">{animatedXP} XP</span>.
 
             </p>
           </div>


### PR DESCRIPTION
## Summary

Adds a smooth count-up animation to the contributor XP display on the dashboard.

The dashboard now animates XP from 0 to the user's earned XP value on load using the existing `useCountUp` hook.

## Related Issue

Closes #120

## Changes Made

* Reused the existing `useCountUp` hook for XP animation
* Replaced the static XP display with the animated value
* Removed unused XP animation state that was already present in the codebase
* Preserved the existing XP calculation source (`totalXP`)

## Testing

* [x] Tested manually
* [ ] Add new unit/integration test
* [ ] verified existing test still pass

### Manual Testing

1. Opened the contributor dashboard
2. Verified XP count animates from 0 to the earned XP value
3. Confirmed the displayed XP total remains unchanged
4. Verified no additional UI regressions

## Screenshots

N/A (small UI behavior change)

## Checklist

* [ ] Tests added or updated
* [ ] Documentation updated if needed
* [x] No secrets committed
