### PR TITLE
test: verify refresh endpoint returns access token

### DIFF
--- a/backend/tests/test_auth_and_sandbox.py
+++ b/backend/tests/test_auth_and_sandbox.py
@@ -51,6 +51,39 @@ def test_signup_and_login_flow():
     assert login_response.status_code == 200
     assert "access" in login_response.data
 
+@pytest.mark.django_db
+def test_refresh_token_returns_valid_access_token():
+    client = APIClient()
+
+    User.objects.create_user(
+        username="refresh_user",
+        email="refresh@example.com",
+        password="StrongPass123!",
+    )
+
+    login_response = client.post(
+        "/api/auth/login/",
+        {
+            "username": "refresh_user",
+            "password": "StrongPass123!",
+        },
+        format="json",
+    )
+
+    assert login_response.status_code == 200
+    assert "refresh" in login_response.data
+
+    refresh_response = client.post(
+        "/api/auth/refresh/",
+        {"refresh": login_response.data["refresh"]},
+        format="json",
+    )
+
+    assert refresh_response.status_code == 200
+    assert "access" in refresh_response.data
+    assert isinstance(refresh_response.data["access"], str)
+    assert len(refresh_response.data["access"]) > 0
+    assert refresh_response.data["access"].strip() != ""
 
 @pytest.mark.django_db
 def test_signup_saves_email_as_lowercase():


### PR DESCRIPTION
## Summary

Adds a test to verify that the refresh token endpoint returns a valid access token.

## Related Issue

Closes #116

## Changes Made

* Added a test for `/api/auth/refresh/`
* Creates a user and performs a login
* Uses the returned refresh token to request a new access token
* Verifies the endpoint returns a successful response with a non-empty access token

## Testing

* [x] Tested manually
* [ ] Add new unit/integration test
* [ ] verified existing test still pass

### Notes

The repository currently contains conflicting Django migration branches which prevent the test database from being created during pytest execution. The added test itself follows the existing authentication flow and targets the refresh endpoint behavior specified in the issue.

## Screenshots

N/A (backend test change)

## Checklist

* [x] Tests added or updated
* [ ] Documentation updated if needed
* [x] No secrets committed
