### PR TITLE
feat: add scroll to top button on dashboard

### DIFF
--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -95,7 +95,25 @@ export function DashboardPage() {
   const { isLessonCompleted, totalXP } = useUserProgress();
   const CONTRIBUTORS_CACHE_KEY = "github_contributors_cache";
   const CACHE_EXPIRY = 24 * 60 * 60 * 1000; // 24 hours
+  const [showScrollTop, setShowScrollTop] = useState(false);
+  const scrollToTop = () => {
+  window.scrollTo({
+    top: 0,
+    behavior: "smooth",
+  });
+};
 
+useEffect(() => {
+  const handleScroll = () => {
+    setShowScrollTop(window.scrollY > 300);
+  };
+
+  window.addEventListener("scroll", handleScroll);
+
+  return () => {
+    window.removeEventListener("scroll", handleScroll);
+  };
+}, []);
   // 1. Fetch static modules catalog
   const [curriculumData, setCurriculumData] = useState<any[]>([]);
   useEffect(() => {
@@ -910,6 +928,15 @@ export function DashboardPage() {
             </div>
           </div>
         </div>
+      )}
+            {showScrollTop && (
+        <button
+          onClick={scrollToTop}
+          aria-label="Scroll to top"
+          className="fixed bottom-6 right-6 z-50 rounded-xl bg-primary text-white border-4 border-black px-4 py-3 font-black shadow-card-sm hover:-translate-y-0.5 active:translate-y-0.5 active:shadow-card-sm cursor-pointer"
+        >
+          ↑ Top
+        </button>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

Adds a floating "Scroll to Top" button to the Dashboard page.

The button appears when the user scrolls more than 300px down the page and smoothly scrolls the user back to the top when clicked. The styling follows the existing neobrutalist design patterns used throughout the dashboard.

## Related Issue

Closes #81

## Changes Made

* Added scroll position tracking using a window scroll listener
* Added state to control the visibility of the scroll-to-top button
* Displayed the button only after scrolling beyond 300px
* Implemented smooth scrolling back to the top of the page
* Styled the button to match existing dashboard UI patterns

## Testing

* [ ] Tested manually
* [ ] Add new unit/integration test
* [ ] verified existing test still pass

### Notes

Manual testing could not be performed locally because the dashboard could not be accessed due to authentication/backend setup issues. The implementation was completed based on the issue requirements and existing dashboard code structure.

## Screenshots

N/A (unable to access dashboard locally for screenshots)

## Checklist

* [ ] Tests added or updated
* [ ] Documentation updated if needed
* [x] No secrets committed

