### PR TITLE
fix: make Recharts gauges responsive on mobile

### DIFF
--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -426,8 +426,8 @@ export function DashboardPage() {
                         data={issueStatusData}
                         cx="50%"
                         cy="50%"
-                        innerRadius={50}
-                        outerRadius={75}
+                        innerRadius="45%"
+                        outerRadius="70%"
                         paddingAngle={5}
                         dataKey="value"
                       >
@@ -652,8 +652,8 @@ export function DashboardPage() {
                     ]}
                     cx="50%"
                     cy="50%"
-                    innerRadius={55}
-                    outerRadius={75}
+                    innerRadius="50%"
+                    outerRadius="72%"
                     paddingAngle={3}
                     dataKey="value"
                   >


### PR DESCRIPTION
## Summary

Makes the dashboard Recharts gauge components responsive on mobile devices by replacing fixed pixel-based radii with percentage-based radii.

This allows the SVG gauges to scale automatically with their container size across different screen widths.

## Related Issue

Closes #185

## Changes Made

* Updated Task Distribution PieChart radii from fixed pixel values to percentage values
* Updated Completion Progress PieChart radii from fixed pixel values to percentage values
* Improved responsiveness of SVG gauges on smaller viewports
* Allowed charts to scale relative to their container dimensions

## Testing

* [ ] Tested manually
* [ ] Add new unit/integration test
* [ ] verified existing test still pass

### Notes

The change uses percentage-based `innerRadius` and `outerRadius` values, allowing Recharts to automatically resize the gauges based on available container space and viewport dimensions.

## Screenshots

N/A

## Checklist

* [ ] Tests added or updated
* [ ] Documentation updated if needed
* [x] No secrets committed


