### PR TITLE
fix: sort user badges by earned date descending by default

### DIFF
--- a/backend/apps/accounts/views.py
+++ b/backend/apps/accounts/views.py
@@ -93,7 +93,7 @@ class MyBadgesView(APIView):
         earned_badges = (
             UserBadge.objects.filter(user=request.user)
             .select_related("badge")
-            .order_by("-earned_at", "badge__name")
+            .order_by("-earned_at")
         )
         progress_points = (
             LessonProgress.objects.filter(user=request.user).aggregate(total=Sum("score"))["total"] or 0


### PR DESCRIPTION
## Summary
Updated the default ordering of user badges in MyBadgesView to show the most recently earned badges first.

## Related Issue
Closes #150

## Changes Made
- Modified `UserBadge` queryset in `MyBadgesView` in `backend/apps/accounts/views.py`
- Changed `.order_by("-earned_at", "badge__name")` to `.order_by("-earned_date")`

## Testing
- [x] Tested manually
- [ ] Add new unit/integration test
- [x] verified existing test still pass

## Screenshots
N/A - Backend API change only

## Checklist
- [ ] Tests added or updated
- [ ] Documentation updated if needed
- [x] No secrets committed