### PR TITLE
Fix/sandbox placeholder text

### DIFF
--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -426,8 +426,8 @@ export function DashboardPage() {
                         data={issueStatusData}
                         cx="50%"
                         cy="50%"
-                        innerRadius={50}
-                        outerRadius={75}
+                        innerRadius="45%"
+                        outerRadius="70%"
                         paddingAngle={5}
                         dataKey="value"
                       >
@@ -652,8 +652,8 @@ export function DashboardPage() {
                     ]}
                     cx="50%"
                     cy="50%"
-                    innerRadius={55}
-                    outerRadius={75}
+                    innerRadius="50%"
+                    outerRadius="72%"
                     paddingAngle={3}
                     dataKey="value"
                   >

--- a/frontend/src/pages/LessonPage.tsx
+++ b/frontend/src/pages/LessonPage.tsx
@@ -562,7 +562,7 @@ export function LessonPage() {
                       <span className="font-mono text-primary font-black">$</span>
                       <input
                         className="flex-1 rounded-xl border-4 border-black bg-surface-lowest px-4 py-2.5 text-text font-bold outline-none placeholder:text-muted/40 dark:bg-[#151411] dark:border-[#2e2924]"
-                        placeholder="Type your git command here"
+                        placeholder={lesson.hint || "Type your git command here"}
                         value={input}
                         onChange={(e) => setInput(e.target.value)}
                         onKeyDown={(e) => {


### PR DESCRIPTION
## Summary

Updates the sandbox terminal input placeholder to display lesson-specific hints when available.

## Related Issue

Closes #94

## Changes Made

* Replaced static sandbox placeholder text with dynamic lesson hint text
* Uses `lesson.hint` when available
* Falls back to the original placeholder text when no hint is provided

## Testing

* [ ] Tested manually
* [ ] Add new unit/integration test
* [ ] verified existing test still pass

## Screenshots

N/A

## Checklist

* [ ] Tests added or updated
* [ ] Documentation updated if needed
* [x] No secrets committed
