### PR TITLE
Feat/sandbox error shake

### DIFF
--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -426,8 +426,8 @@ export function DashboardPage() {
                         data={issueStatusData}
                         cx="50%"
                         cy="50%"
-                        innerRadius={50}
-                        outerRadius={75}
+                        innerRadius="45%"
+                        outerRadius="70%"
                         paddingAngle={5}
                         dataKey="value"
                       >
@@ -652,8 +652,8 @@ export function DashboardPage() {
                     ]}
                     cx="50%"
                     cy="50%"
-                    innerRadius={55}
-                    outerRadius={75}
+                    innerRadius="50%"
+                    outerRadius="72%"
                     paddingAngle={3}
                     dataKey="value"
                   >

--- a/frontend/src/pages/LessonPage.tsx
+++ b/frontend/src/pages/LessonPage.tsx
@@ -546,7 +546,14 @@ export function LessonPage() {
                 </div>
               ) : (
                 // TERMINAL INTERACTIVE COMMAND MODE
-                <div className="rounded-3xl border-4 border-black bg-surface-low p-6 shadow-card dark:bg-[#1f1c18] dark:border-[#2e2924]">
+                <div
+                  className={`rounded-3xl border-4 bg-surface-low p-6 shadow-card dark:bg-[#1f1c18] dark:border-[#2e2924]
+                    ${
+                      feedback === "error"
+                        ? "border-red-600 shake-error"
+                        : "border-black"
+                    }`}
+                >
                   <h3 className="text-xl font-black mb-4 flex items-center gap-2 text-text dark:text-[#f0ebe2]">
                     <span>💻</span> Sandbox terminal check
                   </h3>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -59,6 +59,18 @@ input {
     color 200ms cubic-bezier(0.4, 0, 0.2, 1);
 }
 
+@keyframes shake {
+  0% { transform: translateX(0); }
+  20% { transform: translateX(-6px); }
+  40% { transform: translateX(6px); }
+  60% { transform: translateX(-6px); }
+  80% { transform: translateX(6px); }
+  100% { transform: translateX(0); }
+}
+
+.shake-error {
+  animation: shake 0.4s ease-in-out;
+}
 @media print {
   body * {
     visibility: hidden;


### PR DESCRIPTION
## Summary

Adds visual feedback for invalid sandbox commands by introducing a shake animation and red border styling when terminal validation fails.

## Related Issue

Closes #114

## Changes Made

* Added custom `shake` keyframe animation in `styles.css`
* Added reusable `shake-error` CSS class
* Applied conditional red border styling to the sandbox terminal container
* Triggered shake animation whenever feedback state is `"error"`

## Testing

* [ ] Tested manually
* [ ] Add new unit/integration test
* [ ] verified existing test still pass

## Screenshots

N/A

## Checklist

* [x] Issue requirements implemented
* [x] No secrets committed
* [ ] Tests added or updated if required
* [ ] Documentation updated if needed