### PR TITLE
fix: footer link alignment on mobile

### DIFF
--- a/frontend/src/pages/LessonPage.tsx
+++ b/frontend/src/pages/LessonPage.tsx
@@ -634,7 +634,7 @@ export function LessonPage() {
                         $
                       </span>
                       <input
-                        className="flex-1 rounded-xl border-4 border-black bg-surface-lowest px-4 py-2.5 text-text font-bold outline-none placeholder:text-muted/40 dark:bg-[#151411] dark:border-[#2e2924]"
+                        className="flex-1 min-w-0 rounded-xl border-4 border-black bg-surface-lowest px-4 py-2.5 text-text font-bold outline-none placeholder:text-muted/40 dark:bg-[#151411] dark:border-[#2e2924]"
                         placeholder={lesson.hint || "Type your git command here"}
                         value={input}
                         onChange={(e) => setInput(e.target.value)}
@@ -709,7 +709,7 @@ export function LessonPage() {
             </div>
 
             {/* Course Navigation Footer */}
-            <div className="flex items-center justify-between pt-10 pb-12">
+            <div className="flex flex-col items-center gap-4 sm:flex-row sm:justify-between sm:gap-0 pt-10 pb-12">
               {previousLesson ? (
                 <Link
                   to={`/lessons/${previousLesson.slug}`}
@@ -719,7 +719,7 @@ export function LessonPage() {
                   Prev: {previousLesson.title}
                 </Link>
               ) : (
-                <div />
+                <div className="hidden sm:block" />
               )}
 
               {nextLesson ? (


### PR DESCRIPTION
## Summary
Fixes responsive layout alignment bugs on narrow mobile viewports by stacking navigation links vertically and enabling the sandbox CLI input to shrink dynamically.

## Related Issue
Closes #309

## Changes Made
- Updated the course navigation footer container class in `LessonPage.tsx` to use `flex flex-col items-center gap-4 sm:flex-row sm:justify-between sm:gap-0` to stack vertically on small screens.
- Added `min-w-0` to the CLI `<input>` class list to prevent horizontal container overflow on narrow viewports.

## Testing
- [x] Tested manually 
- [ ] Add new unit/integration test
- [x] verified existing test still pass

## Screenshots
<!-- Add Screenshots of visual changes-->
* **Before**: 
<img width="397" height="628" alt="Screenshot 2026-06-20 212831" src="https://github.com/user-attachments/assets/3d3f1560-1ad5-4487-886b-386649c6da24" />

* **After**:
<img width="411" height="667" alt="Screenshot 2026-06-20 213048" src="https://github.com/user-attachments/assets/b1ebdb35-53ed-4fe9-b15b-85c7828677b5" />


## Checklist

- [ ] Tests added or updated
- [ ] Documentation updated if needed
- [x] No secrets committed
