### PR TITLE
feat: add API endpoint for fetching user statistics (#327)

### DIFF
--- a/backend/apps/accounts/urls.py
+++ b/backend/apps/accounts/urls.py
@@ -13,6 +13,7 @@ from .views import (
     PasswordResetConfirmView,
     OtpRequestView,
     OtpVerifyView,
+    UserStatisticsView,
 )
 
 
@@ -22,6 +23,8 @@ urlpatterns = [
     path("login/",            LoginView.as_view(),              name="login"),
     path("refresh/",          RefreshView.as_view(),            name="refresh"),
     path("me/",               MeView.as_view(),                 name="me"),
+
+    path("stats/",           UserStatisticsView.as_view(),    name="user-stats"),
     path("users/",            UserListView.as_view(),           name="user-list"),
 
     # ── OAuth ──────────────────────────────────────────────────────────────────

--- a/backend/apps/accounts/views.py
+++ b/backend/apps/accounts/views.py
@@ -130,6 +130,27 @@ class MyBadgesView(APIView):
     request=EmailOrUsernameTokenObtainPairSerializer,
     responses=OpenApiResponse(description="Returns JWT refresh & access tokens and basic user info.")
 )
+class UserStatisticsView(APIView):
+    permission_classes = [permissions.IsAuthenticated]
+
+    @extend_schema(
+        responses=OpenApiResponse(
+            description="Returns basic user stats: join date and total contributions (lessons completed)."
+        )
+    )
+    def get(self, request):
+        user = request.user
+        
+        # Count total LessonProgress entries as "contributions"
+        total_contributions = LessonProgress.objects.filter(user=user).count()
+
+        return Response(
+            {
+                "join_date": user.date_joined,
+                "total_contributions": total_contributions,
+            },
+            status=status.HTTP_200_OK
+        )
 class LoginView(TokenObtainPairView):
     permission_classes = [permissions.AllowAny]
     serializer_class = EmailOrUsernameTokenObtainPairSerializer


### PR DESCRIPTION
Summary
This Pull Request introduces a new authenticated API endpoint (GET /api/auth/stats/) that retrieves basic user statistics. Specifically, it fetches the user's join_date from the default Django User model and calculates their total_contributions by aggregating their completed lessons via the LessonProgress model.

Related Issue
Closes #327

Changes Made
Created UserStatisticsView inheriting from APIView in backend/apps/accounts/views.py.

Implemented dynamic calculation for total_contributions using LessonProgress.objects.filter(user=user).count().

Secured the endpoint with the [IsAuthenticated] permission class to ensure data privacy.

Registered the new route path("stats/", ...) in backend/apps/accounts/urls.py.

Added @extend_schema and OpenApiResponse decorators to ensure the endpoint is accurately documented in the Swagger/OpenAPI UI.

Testing
[x] Tested manually

[ ] Add new unit/integration test

[x] verified existing test still pass

Test Instructions:

Navigate to the backend directory, activate the virtual environment, and run python manage.py runserver.

Open the Swagger UI at http://127.0.0.1:8000/api/docs/.

Locate the GET /api/auth/stats/ endpoint.

Execute without credentials to verify it correctly blocks access (returns 401 Unauthorized).

Authorize with a valid JWT token and execute again to verify it returns a 200 OK response with the expected JSON structure (join_date and total_contributions).

Screenshots
Swagger UI / 401 Unauthorized screenshot here to show the endpoint is active and secured
<img width="1920" height="759" alt="image" src="https://github.com/user-attachments/assets/dc37a61e-9741-4317-9cd0-31f50b0d5605" />


Checklist
[ ] Tests added or updated

[x] Documentation updated if needed (Swagger Schema updated)

[x] No secrets committed