### PR TITLE
feat: implement persistent dark mode toggle (#318)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,6 +3,15 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <script>
+      try {
+        if (localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+          document.documentElement.classList.add('dark');
+        } else {
+          document.documentElement.classList.remove('dark');
+        }
+      } catch (_) {}
+    </script>
     <title>Open Source Contribution Atelier</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/frontend/src/features/auth/AuthPageShell.tsx
+++ b/frontend/src/features/auth/AuthPageShell.tsx
@@ -1,4 +1,6 @@
 import React from "react";
+import { Sun, Moon } from "lucide-react";
+import { useTheme } from "../../hooks/useTheme";
 
 type AuthPageShellProps = {
   title: string;
@@ -13,6 +15,8 @@ export function AuthPageShell({
   mode,
   children,
 }: AuthPageShellProps) {
+  const { theme, toggleTheme } = useTheme();
+
   const highlightBox1 =
     mode === "login"
       ? {
@@ -52,7 +56,16 @@ export function AuthPageShell({
         };
 
   return (
-    <div className="min-h-screen flex items-center justify-center p-4 sm:p-8 font-display bg-surface text-text overflow-hidden">
+    <div className="min-h-screen flex items-center justify-center p-4 sm:p-8 font-display bg-surface text-text overflow-hidden dark:bg-[#0f0e0c] dark:text-[#f0ebe2]">
+      {/* Theme Toggle Button */}
+      <button
+        className="absolute top-4 right-4 sm:top-8 sm:right-8 rounded-xl bg-surface-low p-3 text-muted hover:text-text border-2 border-black dark:border-[#2e2924] shadow-card-sm hover:-translate-y-0.5 active:translate-y-0 transition-all z-50 dark:bg-[#151411] dark:text-[#c4bbae] dark:hover:text-[#f0ebe2]"
+        onClick={toggleTheme}
+        aria-label={theme === "light" ? "Switch to dark mode" : "Switch to light mode"}
+      >
+        {theme === "light" ? <Moon size={20} /> : <Sun size={20} />}
+      </button>
+
       <div className="mx-auto flex w-full max-w-6xl flex-col lg:flex-row gap-12 lg:gap-16 items-center relative z-10 py-12">
         {/* LEFT SIDE: Description */}
         <div className="flex-1 flex flex-col justify-center py-6 order-2 lg:order-1">
@@ -62,10 +75,10 @@ export function AuthPageShell({
             </span>
           </div>
 
-          <h1 className="text-5xl lg:text-[5.5rem] font-black tracking-tight text-black mb-8 leading-[1.05] drop-shadow-[5px_5px_0_rgba(0,0,0,1)]">
+          <h1 className="text-5xl lg:text-[5.5rem] font-black tracking-tight text-black mb-8 leading-[1.05] drop-shadow-[5px_5px_0_rgba(0,0,0,1)] dark:text-[#f0ebe2]">
             {title}
           </h1>
-          <p className="text-xl text-black font-semibold leading-relaxed mb-12 border-l-4 border-black pl-5 bg-white p-5 shadow-card rounded-r-xl max-w-lg">
+          <p className="text-xl text-black font-semibold leading-relaxed mb-12 border-l-4 border-black pl-5 bg-white p-5 shadow-card rounded-r-xl max-w-lg dark:text-[#c4bbae] dark:bg-[#151411] dark:border-[#2e2924]">
             {subtitle}
           </p>
 
@@ -95,9 +108,9 @@ export function AuthPageShell({
 
         {/* RIGHT SIDE: Form */}
         <div className="flex-1 w-full max-w-md order-1 lg:order-2 self-center">
-          <div className="w-full rounded-[2rem] border-4 border-black bg-white p-8 sm:p-10 shadow-card-lg relative rotate-[2deg] hover:rotate-0 transition-transform duration-300">
+          <div className="w-full rounded-[2rem] border-4 border-black bg-white p-8 sm:p-10 shadow-card-lg relative rotate-[2deg] hover:rotate-0 transition-transform duration-300 dark:bg-[#151411] dark:border-[#2e2924]">
             {/* Quirky tape or clip on top */}
-            <div className="absolute -top-5 left-1/2 -translate-x-1/2 w-32 h-10 bg-primary border-4 border-black rotate-[-4deg] shadow-card-sm z-20"></div>
+            <div className="absolute -top-5 left-1/2 -translate-x-1/2 w-32 h-10 bg-primary border-4 border-black rotate-[-4deg] shadow-card-sm z-20 dark:border-[#2e2924]"></div>
             {children}
           </div>
         </div>
@@ -105,3 +118,4 @@ export function AuthPageShell({
     </div>
   );
 }
+

--- a/frontend/src/hooks/useTheme.ts
+++ b/frontend/src/hooks/useTheme.ts
@@ -2,7 +2,10 @@ import { useState, useEffect } from "react";
 
 function getInitialTheme(): string {
   try {
-    return localStorage.getItem("theme") || "light";
+    if (localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+      return "dark";
+    }
+    return "light";
   } catch {
     return "light";
   }
@@ -27,6 +30,16 @@ export function useTheme() {
       document.documentElement.classList.remove("dark");
     }
   }, [theme]);
+
+  useEffect(() => {
+    const handleStorage = (e: StorageEvent) => {
+      if (e.key === "theme" && (e.newValue === "light" || e.newValue === "dark")) {
+        setTheme(e.newValue);
+      }
+    };
+    window.addEventListener("storage", handleStorage);
+    return () => window.removeEventListener("storage", handleStorage);
+  }, []);
 
   const toggleTheme = () => {
     setTheme((prevTheme) => (prevTheme === "light" ? "dark" : "light"));


### PR DESCRIPTION
## Summary
This Pull Request introduces a persistent dark mode toggle for the application, addressing both the lack of dark mode support on authentication pages and fixing the Flash of Unstyled Content (FOUC) issue on the initial page load.

## Related Issue
Closes #318

## Changes Made
- Added a synchronous inline script to `frontend/index.html` to prevent FOUC by applying the `dark` class before the React app boots.
- Enhanced the `useTheme` hook in `frontend/src/hooks/useTheme.ts` to respect the OS system preference (`prefers-color-scheme`) when `localStorage` is empty, and added cross-tab synchronization.
- Added a theme toggle button and supportive dark mode styling to `frontend/src/features/auth/AuthPageShell.tsx`, bringing the brutalist login/signup pages in line with the rest of the application's dark mode capabilities.

## Testing
- [x] Tested manually (Verified the toggle works seamlessly across the app and on auth pages, FOUC is gone, and cross-tab syncing works)
- [ ] Add new unit/integration test
- [x] verified existing test still pass (Ran `npm run lint` and `npm run test` to verify no new regressions were introduced)

## Screenshots
*(Consider taking a quick screenshot of the Signup page in Dark Mode and dropping it here before you hit submit!)*

## Checklist
- [ ] Tests added or updated
- [ ] Documentation updated if needed
- [x] No secrets committed
