### PR TITLE
feat: replace loading spinners with skeleton loaders

### DIFF
--- a/frontend/src/components/OrganizationsGrid.tsx
+++ b/frontend/src/components/OrganizationsGrid.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import SkeletonCard from './ui/skeletons/SkeletonCard';
 
 const OrganizationsGrid: React.FC = () => {
   const [organizations, setOrganizations] = useState<any[]>([]);
@@ -15,7 +16,24 @@ const OrganizationsGrid: React.FC = () => {
       .catch((err) => console.error("Error fetching organizations:", err));
   }, []);
 
-  if (loading) return <div className="text-center">Loading Organizations...</div>;
+  if (loading) {
+    return (
+      <section aria-labelledby="orgs-heading" className="mb-6">
+        <h3
+          id="orgs-heading"
+          className="text-xs font-black uppercase tracking-wider text-muted mb-3 text-center"
+        >
+          Supported Orgs
+        </h3>
+
+        <div className="grid gap-3 grid-cols-2 sm:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, index) => (
+            <SkeletonCard key={index} />
+          ))}
+        </div>
+      </section>
+    );
+  }
 
   return (
     <section aria-labelledby="orgs-heading" className="mb-6">

--- a/frontend/src/pages/VerifyCertificatePage.tsx
+++ b/frontend/src/pages/VerifyCertificatePage.tsx
@@ -83,11 +83,20 @@ export function VerifyCertificatePage() {
   // 1. Loading State
   if (loading) {
     return (
-      <div className="min-h-screen bg-bg flex flex-col items-center justify-center p-6">
-        <div className="animate-pulse flex flex-col items-center gap-4">
-          <div className="h-16 w-16 bg-muted rounded-full animate-spin"></div>
-          <div className="h-6 w-48 bg-muted rounded-xl"></div>
-          <p className="text-black font-bold">Verifying Certificate...</p>
+      <div className="min-h-screen bg-bg py-12 px-6 sm:px-12 animate-pulse">
+        <div className="w-full max-w-3xl mx-auto">
+          <div className="h-10 w-48 bg-muted rounded mb-8"></div>
+
+          <div className="bg-white border-4 border-black rounded-3xl p-8 space-y-6">
+            <div className="h-8 w-64 bg-muted rounded"></div>
+
+            <div className="h-24 w-full bg-muted rounded-2xl"></div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+              <div className="h-32 bg-muted rounded-2xl"></div>
+              <div className="h-32 bg-muted rounded-2xl"></div>
+            </div>
+          </div>
         </div>
       </div>
     );


### PR DESCRIPTION
## Summary

Replaced basic loading indicators with skeleton loading UI components to provide a more consistent and visually appealing loading experience across data-fetching components.

## Related Issue

Closes #422

## Changes Made

* Added `SkeletonCard` loading placeholders to `OrganizationsGrid`.
* Replaced the text-based "Loading Organizations..." state with a responsive skeleton grid.
* Replaced the spinner-based loading UI in `VerifyCertificatePage`.
* Added a skeleton layout that mirrors the final certificate verification page structure.
* Reused existing skeleton components and Tailwind pulse animations to maintain UI consistency.

## Testing

* [x] Tested manually
* [ ] Add new unit/integration test
* [ ] verified existing test still pass

### Manual Testing Performed

* Verified skeleton cards render while organizations are loading.
* Verified organization cards render correctly after data is fetched.
* Verified certificate verification page displays skeleton placeholders during loading.
* Verified certificate details render correctly once loading completes.

## Screenshots

<!-- Add screenshots/gifs of the skeleton loading states here -->

## Checklist

* [ ] Tests added or updated
* [ ] Documentation updated if needed
* [x] No secrets committed
