### PR TITLE
chore: add .gitattributes for consistent cross-platform line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,43 @@
+# Normalize text files and enforce LF line endings
+* text=auto eol=lf
+
+# Source code
+*.py text eol=lf
+*.js text eol=lf
+*.jsx text eol=lf
+*.ts text eol=lf
+*.tsx text eol=lf
+*.mjs text eol=lf
+*.cjs text eol=lf
+
+# Config files
+*.json text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.toml text eol=lf
+*.ini text eol=lf
+
+# Documentation
+*.md text eol=lf
+*.txt text eol=lf
+
+# Web assets
+*.html text eol=lf
+*.css text eol=lf
+*.scss text eol=lf
+*.svg text
+*.xml text eol=lf
+
+# Scripts
+*.sh text eol=lf
+
+# Binary files
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.webp binary
+*.ico binary
+*.pdf binary
+*.zip binary
+*.webm binary


### PR DESCRIPTION
## Summary

Added a `.gitattributes` file to standardize line endings across different operating systems by enforcing LF for text files and explicitly marking binary files to prevent unintended line-ending conversions.

## Related Issue

Closes #430

## Changes Made

* Added a root-level `.gitattributes` file.
* Configured common source, configuration, documentation, web asset, and script file types to use LF line endings.
* Marked binary assets (images, PDFs, archives, and videos) as binary to prevent Git from performing text normalization.

## Testing

* [x] Tested manually
* [ ] Add new unit/integration test
* [ ] verified existing test still pass

**Manual verification performed:**

* Verified text files are recognized with `eol=lf` using `git check-attr`.
* Verified binary files are recognized as `binary` and are not treated as text.
* Confirmed no unintended file modifications after adding the `.gitattributes` file.

## Screenshots

N/A (configuration-only change)

## Checklist

* [ ] Tests added or updated
* [ ] Documentation updated if needed
* [x] No secrets committed
