### PR TITLE
feat(user): implement GDPR data export pipeline

### DIFF
--- a/backend/apps/accounts/urls.py
+++ b/backend/apps/accounts/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from .views import (GitHubOAuthCallbackView, GitHubOAuthStartView,
+from .views import (ExportDataView, GitHubOAuthCallbackView, GitHubOAuthStartView,
                     GoogleLoginView, LoginView, MeView, OtpRequestView,
                     OtpVerifyView, PasswordResetConfirmView,
                     PasswordResetRequestView, RefreshView, SignupView,
@@ -12,6 +12,7 @@ urlpatterns = [
     path("login/", LoginView.as_view(), name="login"),
     path("refresh/", RefreshView.as_view(), name="refresh"),
     path("me/", MeView.as_view(), name="me"),
+    path("me/export/", ExportDataView.as_view(), name="me-export"),
     path("stats/", UserStatisticsView.as_view(), name="user-stats"),
     path("users/", UserListView.as_view(), name="user-list"),
     # ── OAuth ──────────────────────────────────────────────────────────────────

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -103,7 +103,7 @@ export function AppRouter() {
             </ProtectedRoute>
           }
         />
-        <Routex
+        <Route
           path="/community"
           element={
             <ProtectedRoute>

--- a/frontend/src/features/auth/ProfileSettingsForm.tsx
+++ b/frontend/src/features/auth/ProfileSettingsForm.tsx
@@ -24,6 +24,7 @@ export function ProfileSettingsForm() {
   const { user, checkUser } = useAuth();
   const { addToast } = useToast();
   const [loading, setLoading] = useState(false);
+  const [downloading, setDownloading] = useState(false);
   const [selectedAvatar, setSelectedAvatar] = useState<File | null>(null);
 
   const {
@@ -88,6 +89,30 @@ export function ProfileSettingsForm() {
     }
   };
 
+  const handleDownloadData = async () => {
+    setDownloading(true);
+    try {
+      const blob = await fetchApi("/auth/me/export/?export_format=csv", {
+        requireAuth: true,
+        responseType: "blob",
+      });
+      const url = window.URL.createObjectURL(blob as Blob);
+      const a = document.createElement("a");
+      a.style.display = "none";
+      a.href = url;
+      a.download = `data_export_${user?.username || "data"}.zip`;
+      document.body.appendChild(a);
+      a.click();
+      window.URL.revokeObjectURL(url);
+      document.body.removeChild(a);
+      addToast("Data archive downloaded successfully!", "success");
+    } catch (err: unknown) {
+      addToast("Failed to download data archive.", "error");
+    } finally {
+      setDownloading(false);
+    }
+  };
+
   return (
     <form className="space-y-6 pt-2" onSubmit={handleSubmit(onSubmit)}>
       <AvatarUploadDropzone
@@ -135,12 +160,30 @@ export function ProfileSettingsForm() {
         )}
       </div>
 
-      <button
-        className="w-full rounded-2xl border-4 border-black bg-accent px-5 py-5 font-black text-black text-xl shadow-card hover:bg-tertiary transition-colors cursor-pointer mt-4 uppercase disabled:opacity-50"
-        disabled={loading}
-      >
-        {loading ? "Updating..." : "Save Settings"}
-      </button>
+    <div className="space-y-4 mt-8">
+        <button
+          className="w-full rounded-2xl border-4 border-black bg-accent px-5 py-5 font-black text-black text-xl shadow-card hover:bg-tertiary transition-colors cursor-pointer uppercase disabled:opacity-50"
+          disabled={loading}
+        >
+          {loading ? "Updating..." : "Save Settings"}
+        </button>
+
+        <hr className="border-2 border-black/10 my-8" />
+
+        <div className="space-y-2">
+          <label className="font-bold text-black ml-2 uppercase tracking-wide text-sm">
+            Data Privacy (GDPR)
+          </label>
+          <button
+            type="button"
+            onClick={handleDownloadData}
+            disabled={downloading}
+            className="w-full rounded-2xl border-4 border-black bg-white px-5 py-4 font-black text-black text-lg shadow-card-sm hover:-translate-y-1 hover:shadow-card transition-all cursor-pointer uppercase disabled:opacity-50 flex items-center justify-center gap-2"
+          >
+            {downloading ? "Compiling Archive..." : "Download All My Data"}
+          </button>
+        </div>
+      </div>
     </form>
   );
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -5,6 +5,7 @@ const API_BASE =
 
 type RequestOptions = RequestInit & {
   requireAuth?: boolean;
+  responseType?: "json" | "blob";
 };
 
 export async function fetchApi(endpoint: string, options: RequestOptions = {}) {
@@ -38,6 +39,10 @@ export async function fetchApi(endpoint: string, options: RequestOptions = {}) {
       throw new Error(
         errorBody.detail || errorBody.error || "An error occurred",
       );
+    }
+
+    if (options.responseType === "blob") {
+      return response.blob();
     }
 
     return response.json().catch(() => ({}));


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this Pull-request does -->
This PR implements a full-stack, self-serve "Download all my data" feature to comply with GDPR Right to Access. It connects the existing backend `DataExportService` to the frontend `ProfileSettingsForm`, allowing authenticated users to request and download a `.zip` archive containing their personal data in `.csv` format.

## Related Issue
<!--What are the issues it solves  -->
Closes #462

## Changes Made
<!--List the changes made -->
* **Backend:** Registered the isolated `ExportDataView` to the `/api/auth/me/export/` route in `apps/accounts/urls.py`.
* **Network Layer:** Updated the `fetchApi` wrapper in `frontend/src/lib/api.ts` to accept an optional `responseType: "blob"` parameter, allowing it to safely process `.zip` file downloads without crashing on the default `response.json()` parser.
* **Frontend UI:** Injected a "Data Privacy (GDPR)" section with a "Download All My Data" button into `ProfileSettingsForm.tsx`.
* **State Management:** Added loading states and integrated DOM manipulation to securely create an object URL, trigger the download, and revoke the URL to prevent memory leaks.

## Testing
<!--Provide instructions on how it has been tested so reviewers can verify you change-->
1. Log in to the frontend dashboard.
2. Navigate to `Profile Settings`.
3. Click the "Download All My Data" button.
4. Verify the button state changes to "Compiling Archive...".
5. Verify a file named `data_export_[username].zip` is successfully downloaded to the local machine.
6. Extract the `.zip` and confirm the presence of populated `.csv` files (e.g., `user_profile.csv`, `lesson_progress.csv`).

- [x] Tested manually 
- [ ] Add new unit/integration test
- [x] verified existing test still pass

## Screenshots
<!-- Add Screenshots of visual changes-->
*(Please drag and drop the screenshot of your new Profile Settings UI button here before submitting!)*

## Checklist

- [ ] Tests added or updated
- [ ] Documentation updated if needed
- [x] No secrets committed

<img width="1029" height="230" alt="Screenshot 2026-06-22 at 6 13 59 PM" src="https://github.com/user-attachments/assets/f551f19c-62d4-482d-b29f-4068ee956653" />
<img width="568" height="188" alt="Screenshot 2026-06-22 at 6 14 18 PM" src="https://github.com/user-attachments/assets/587115e9-407d-477b-a5c3-34eff608c527" />
<img width="753" height="207" alt="Screenshot 2026-06-22 at 6 14 50 PM" src="https://github.com/user-attachments/assets/45f407e9-e8be-4c95-88d6-a7890d53e4ee" />
