### PR TITLE
feat(auth): implement identity-based rate limiting for auth endpoints

### DIFF
--- a/backend/apps/accounts/throttles.py
+++ b/backend/apps/accounts/throttles.py
@@ -56,6 +56,15 @@ class _ProxyAwareThrottle(AnonRateThrottle):
         return _get_real_ip(request)
 
 
+class StrictIdentityLoginThrottle(AnonRateThrottle):
+    scope = "auth_login"
+
+    def get_ident(self, request):
+        identity = request.data.get("email") or request.data.get("username")
+        if identity:
+            return str(identity).strip().lower()
+        return _get_real_ip(request)
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Login – strict IP-based limit to block brute-force credential attacks
 # ─────────────────────────────────────────────────────────────────────────────
@@ -90,6 +99,24 @@ class OtpGenerateThrottle(_ProxyAwareThrottle):
 class OtpVerifyThrottle(_ProxyAwareThrottle):
     scope = "auth_otp_verify"
 
+
+class StrictIdentityPasswordResetThrottle(AnonRateThrottle):
+    scope = "auth_password_reset"
+
+    def get_ident(self, request):
+        email = request.data.get("email")
+        if email:
+            return str(email).strip().lower()
+        return _get_real_ip(request)
+
+class StrictIdentityPasswordResetThrottle(AnonRateThrottle):
+    scope = "auth_password_reset"
+
+    def get_ident(self, request):
+        email = request.data.get("email")
+        if email:
+            return str(email).strip().lower()
+        return _get_real_ip(request)
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Password reset – prevent email bombing / enumeration attacks

--- a/backend/apps/accounts/views.py
+++ b/backend/apps/accounts/views.py
@@ -32,8 +32,8 @@ from .serializers import (EmailOrUsernameTokenObtainPairSerializer,
                           PasswordResetRequestSerializer, SignupSerializer,
                           UserListSerializer, UserUpdateSerializer)
 from .tasks import send_otp_email_task, send_password_reset_email_task
-from .throttles import (LoginThrottle, OAuthThrottle, OtpGenerateThrottle,
-                        OtpVerifyThrottle, PasswordResetThrottle,
+from .throttles import (LoginThrottle, StrictIdentityLoginThrottle, OAuthThrottle, OtpGenerateThrottle,
+                        OtpVerifyThrottle, PasswordResetThrottle, StrictIdentityPasswordResetThrottle,
                         SignupThrottle, TokenRefreshThrottle)
 
 
@@ -153,7 +153,7 @@ class UserStatisticsView(APIView):
 class LoginView(TokenObtainPairView):
     permission_classes = [permissions.AllowAny]
     serializer_class = EmailOrUsernameTokenObtainPairSerializer
-    throttle_classes = [LoginThrottle]
+    throttle_classes = [LoginThrottle, StrictIdentityLoginThrottle]
 
 
 class RefreshView(TokenRefreshView):
@@ -390,7 +390,7 @@ class PasswordResetRequestView(APIView):
     """
 
     permission_classes = [permissions.AllowAny]
-    throttle_classes = [PasswordResetThrottle]
+    throttle_classes = [PasswordResetThrottle, StrictIdentityPasswordResetThrottle]
 
     def post(self, request):
         serializer = PasswordResetRequestSerializer(data=request.data)


### PR DESCRIPTION
## Summary
This PR implements strict, identity-aware rate limiting for authentication and password-reset endpoints. Standard DRF IP-based throttling is insufficient against distributed attacks (like proxy-hopping). This update introduces custom throttle classes that rate-limit based on the target identity (email/username) regardless of the incoming IP address, effectively neutralizing credential stuffing and targeted email-bombing attacks.

## Related Issue
Closes #456

## Changes Made
* **`backend/apps/accounts/throttles.py`**: Added `StrictIdentityLoginThrottle` and `StrictIdentityPasswordResetThrottle` which extract the `email` or `username` from the request payload to use as the cache key.
* **`backend/apps/accounts/views.py`**: Injected the new strict throttles into `LoginView` and `PasswordResetRequestView`, creating a dual-layer defense (IP-based + Identity-based).

## Testing
1. Run the local backend development server.
2. Open a terminal and run a bash loop to simulate a brute-force attack against a single email:
    ````bash
    for i in {1..7}; do curl -s -X POST [http://127.0.0.1:8000/api/auth/login/](http://127.0.0.1:8000/api/auth/login/) -H "Content-Type: application/json" -d '{"email":"lakshaytest@gmail.com","password":"wrong"}'; done
    ````
3. Verify that the first 5 attempts return a `401 Unauthorized` and subsequent attempts immediately return a `429 Too Many Requests` (Expected available in X seconds).

- [x] Tested manually 
- [ ] Add new unit/integration test
- [x] verified existing test still pass

## Screenshots
*Backend security update only. No visual UI changes.*
<img width="831" height="105" alt="Screenshot 2026-06-22 at 6 41 12 PM" src="https://github.com/user-attachments/assets/22d84441-4a93-40d1-9964-98c59acdcea1" />


## Checklist

- [ ] Tests added or updated
- [ ] Documentation updated if needed
- [x] No secrets committed