### PR TITLE
Chat feature implemented and user is typing interface

### DIFF
--- a/backend/apps/chat/apps.py
+++ b/backend/apps/chat/apps.py
@@ -1,0 +1,7 @@
+from django.apps import AppConfig
+
+
+class ChatConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "apps.chat"
+    label = "chat"

--- a/backend/apps/chat/consumers.py
+++ b/backend/apps/chat/consumers.py
@@ -1,0 +1,127 @@
+import json
+import logging
+
+from channels.generic.websocket import AsyncWebsocketConsumer
+
+logger = logging.getLogger(__name__)
+
+
+class ChatConsumer(AsyncWebsocketConsumer):
+    """
+    WebSocket consumer for real-time chat (including typing indicators).
+
+    URL pattern:  ws://host/ws/chat/<room_id>/ ?token=<JWT>
+    """
+
+    async def connect(self):
+        user = self.scope.get("user")
+
+        if not user or not user.is_authenticated:
+            logger.warning("WS Chat rejected: unauthenticated user")
+            await self.close(code=4001)
+            return
+
+        room_id = self.scope["url_route"]["kwargs"].get("room_id")
+        if not room_id:
+            logger.warning("WS Chat rejected: missing room_id")
+            await self.close(code=4002)
+            return
+
+        self.user = user
+        self.room_id = room_id
+        self.group_name = f"chat_{room_id}"
+
+        await self.channel_layer.group_add(self.group_name, self.channel_name)
+        await self.accept()
+
+        logger.info("WS Chat connected: user=%s room=%s", self.user.id, self.room_id)
+
+        await self.send(
+            text_data=json.dumps(
+                {
+                    "type": "connection_established",
+                    "room_id": self.room_id,
+                    "user_id": self.user.id,
+                }
+            )
+        )
+
+    async def disconnect(self, close_code):
+        if hasattr(self, "group_name"):
+            await self.channel_layer.group_discard(self.group_name, self.channel_name)
+            logger.info(
+                "WS Chat disconnected: group=%s code=%s",
+                self.group_name,
+                close_code,
+            )
+
+    async def receive(self, text_data=None, bytes_data=None):
+        try:
+            data = json.loads(text_data or "{}")
+        except json.JSONDecodeError:
+            logger.error("WS Chat receive: invalid JSON")
+            return
+
+        action = data.get("action")
+
+        if action == "typing_start":
+            await self.channel_layer.group_send(
+                self.group_name,
+                {
+                    "type": "user_typing",
+                    "action": "typing_start",
+                    "username": self.user.username,
+                    "user_id": self.user.id,
+                    "sender_channel": self.channel_name,
+                },
+            )
+
+        elif action == "typing_stop":
+            await self.channel_layer.group_send(
+                self.group_name,
+                {
+                    "type": "user_typing",
+                    "action": "typing_stop",
+                    "username": self.user.username,
+                    "user_id": self.user.id,
+                    "sender_channel": self.channel_name,
+                },
+            )
+
+        elif action == "send_message":
+            await self.channel_layer.group_send(
+                self.group_name,
+                {
+                    "type": "chat_message",
+                    "username": self.user.username,
+                    "user_id": self.user.id,
+                    "message": data.get("message", ""),
+                    "sender_channel": self.channel_name,
+                },
+            )
+
+    async def user_typing(self, event):
+        if event["sender_channel"] == self.channel_name:
+            return
+        await self.send(
+            text_data=json.dumps(
+                {
+                    "type": "typing",
+                    "action": event["action"],
+                    "username": event["username"],
+                    "user_id": event["user_id"],
+                }
+            )
+        )
+
+    async def chat_message(self, event):
+        await self.send(
+            text_data=json.dumps(
+                {
+                    "type": "new_message",
+                    "username": event["username"],
+                    "user_id": event["user_id"],
+                    "message": event["message"],
+                }
+            )
+        )

--- a/backend/apps/chat/routing.py
+++ b/backend/apps/chat/routing.py
@@ -1,0 +1,7 @@
+from django.urls import re_path
+
+from . import consumers
+
+websocket_urlpatterns = [
+    re_path(r"^ws/chat/(?P<room_id>[^/]+)/$", consumers.ChatConsumer.as_asgi()),
+]

--- a/backend/config/asgi.py
+++ b/backend/config/asgi.py
@@ -13,17 +13,18 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
 
 django_asgi_app = get_asgi_application()
 
-from apps.dashboard.routing import \
-    websocket_urlpatterns as dashboard_ws  # noqa: E402
+from apps.chat.routing import websocket_urlpatterns as chat_ws  # noqa: E402
+from apps.dashboard.routing import websocket_urlpatterns as dashboard_ws  # noqa: E402
 from apps.notifications.middleware import JWTAuthMiddleware  # noqa: E402
-from apps.notifications.routing import \
-    websocket_urlpatterns as notifications_ws  # noqa: E402
+from apps.notifications.routing import (
+    websocket_urlpatterns as notifications_ws,
+)  # noqa: E402
 
 application = ProtocolTypeRouter(
     {
         "http": django_asgi_app,
         "websocket": AllowedHostsOriginValidator(
-            JWTAuthMiddleware(URLRouter(notifications_ws + dashboard_ws))
+            JWTAuthMiddleware(URLRouter(notifications_ws + dashboard_ws + chat_ws))
         ),
     }
 )

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -199,6 +199,7 @@ INSTALLED_APPS += [
     "apps.notifications.apps.NotificationsConfig",
     "drf_spectacular",
     "apps.dashboard.apps.DashboardConfig",
+    "apps.chat.apps.ChatConfig",
     "django.contrib.postgres",
     "apps.search.apps.SearchConfig",
 ]

--- a/backend/manage.py
+++ b/backend/manage.py
@@ -5,9 +5,67 @@ import sys
 
 def main() -> None:
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+
+    # Channels 4 removed the runserver WS override.
+    # Intercept `runserver` and hand off to daphne so WebSocket works.
+    if len(sys.argv) >= 2 and sys.argv[1] == "runserver":
+        _run_daphne()
+        return
+
     from django.core.management import execute_from_command_line
 
     execute_from_command_line(sys.argv)
+
+
+def _run_daphne() -> None:
+    import django
+
+    django.setup()
+
+    host = "127.0.0.1"
+    port = "8000"
+
+    for arg in sys.argv[2:]:
+        if arg.startswith("--"):
+            continue
+        if ":" in arg:
+            host, port = arg.split(":", 1)
+        elif arg.isdigit():
+            port = arg
+        else:
+            host = arg
+        break
+
+    no_reload = "--noreload" in sys.argv
+
+    from channels.routing import get_default_application
+
+    application = get_default_application()
+
+    print(f"Daphne: serving on http://{host}:{port} (WebSocket enabled)")
+
+    from daphne import server as daphne_server
+    from daphne.endpoints import build_endpoint_description_strings
+
+    endpoints = build_endpoint_description_strings(host=host, port=int(port))
+    server = daphne_server.Server(
+        application=application,
+        endpoints=endpoints,
+        signal_handlers=not no_reload,
+        action_logger=_daphne_log,
+    )
+    server.run()
+
+
+def _daphne_log(log_level, msg, args):
+    from django.core.management.color import color_style
+
+    style = color_style()
+    fmt = msg % args if args else msg
+    if log_level in ("error", "critical", "exception"):
+        print(style.ERROR(f"[{log_level.upper()}] {fmt}"))
+    else:
+        print(fmt)
 
 
 if __name__ == "__main__":

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Route, Routes, Navigate } from "react-router-dom";
 import { AppLayout } from "../components/layout/AppLayout";
 import { ChallengePage } from "../pages/ChallengePage";
+import { ChatPage } from "../pages/ChatPage";
 import { CommunityPage } from "../pages/CommunityPage";
 import { DashboardPage } from "../pages/DashboardPage";
 import { GitHubAuthCallbackPage } from "../pages/GitHubAuthCallbackPage";
@@ -96,6 +97,14 @@ export function AppRouter() {
           }
         />
         <Route
+          path="/chat"
+          element={
+            <ProtectedRoute>
+              <ChatPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
           path="/challenges"
           element={
             <ProtectedRoute>
@@ -103,7 +112,7 @@ export function AppRouter() {
             </ProtectedRoute>
           }
         />
-        <Routex
+        <Route
           path="/community"
           element={
             <ProtectedRoute>

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -1,0 +1,71 @@
+import { useState, useCallback, KeyboardEvent } from "react";
+import { Send } from "lucide-react";
+
+type ChatInputProps = {
+  onSendMessage: (message: string) => void;
+  onInputChange?: () => void;
+  onInputBlur?: () => void;
+  onInputSubmit?: () => void;
+  placeholder?: string;
+  disabled?: boolean;
+};
+
+export function ChatInput({
+  onSendMessage,
+  onInputChange,
+  onInputBlur,
+  onInputSubmit,
+  placeholder = "Type a message...",
+  disabled = false,
+}: ChatInputProps) {
+  const [text, setText] = useState("");
+
+  const handleSend = useCallback(() => {
+    const trimmed = text.trim();
+    if (!trimmed || disabled) return;
+    onSendMessage(trimmed);
+    setText("");
+    onInputSubmit?.();
+  }, [text, disabled, onSendMessage, onInputSubmit]);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault();
+        handleSend();
+      }
+    },
+    [handleSend],
+  );
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      setText(e.target.value);
+      onInputChange?.();
+    },
+    [onInputChange],
+  );
+
+  return (
+    <div className="flex items-end gap-2 border-t border-outline bg-surface-low px-4 py-3">
+      <textarea
+        value={text}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        onBlur={onInputBlur}
+        placeholder={placeholder}
+        disabled={disabled}
+        rows={1}
+        className="min-h-[40px] flex-1 resize-none rounded-xl border border-outline bg-surface-high px-3 py-2 text-sm text-text placeholder-muted outline-none focus:border-accent disabled:opacity-50"
+      />
+      <button
+        onClick={handleSend}
+        disabled={!text.trim() || disabled}
+        className="flex h-10 w-10 items-center justify-center rounded-xl bg-accent text-black transition-opacity hover:opacity-80 disabled:opacity-40"
+        aria-label="Send message"
+      >
+        <Send size={16} />
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/chat/ChatMessage.tsx
+++ b/frontend/src/components/chat/ChatMessage.tsx
@@ -1,0 +1,43 @@
+import clsx from "clsx";
+
+type ChatMessageProps = {
+  message: string;
+  username: string;
+  isOwn: boolean;
+  timestamp?: string;
+};
+
+export function ChatMessage({
+  message,
+  username,
+  isOwn,
+  timestamp,
+}: ChatMessageProps) {
+  return (
+    <div className={clsx("flex", isOwn ? "justify-end" : "justify-start")}>
+      <div
+        className={clsx(
+          "max-w-[75%] rounded-2xl px-4 py-2",
+          isOwn
+            ? "bg-accent text-black rounded-br-md"
+            : "bg-surface-high text-text rounded-bl-md border border-outline",
+        )}
+      >
+        {!isOwn && (
+          <p className="text-[11px] font-bold text-muted mb-0.5">{username}</p>
+        )}
+        <p className="text-sm leading-snug">{message}</p>
+        {timestamp && (
+          <p
+            className={clsx(
+              "text-[10px] mt-1 text-right",
+              isOwn ? "text-black/60" : "text-muted",
+            )}
+          >
+            {timestamp}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/chat/TypingIndicator.tsx
+++ b/frontend/src/components/chat/TypingIndicator.tsx
@@ -1,0 +1,41 @@
+import clsx from "clsx";
+
+type TypingUser = {
+  username: string;
+  user_id: number;
+};
+
+type TypingIndicatorProps = {
+  users: TypingUser[];
+  className?: string;
+};
+
+export function TypingIndicator({ users, className }: TypingIndicatorProps) {
+  if (users.length === 0) return null;
+
+  const usernames = users.map((u) => u.username);
+  const label =
+    users.length === 1
+      ? `${usernames[0]} is typing...`
+      : users.length === 2
+        ? `${usernames[0]} and ${usernames[1]} are typing...`
+        : `${usernames[0]} and ${users.length - 1} others are typing...`;
+
+  return (
+    <div
+      className={clsx(
+        "flex items-center gap-2 px-1 py-1 text-xs font-bold text-muted",
+        className,
+      )}
+      role="status"
+      aria-live="polite"
+    >
+      <span className="flex gap-0.5">
+        <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-muted" />
+        <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-muted [animation-delay:0.15s]" />
+        <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-muted [animation-delay:0.3s]" />
+      </span>
+      <span>{label}</span>
+    </div>
+  );
+}

--- a/frontend/src/components/layout/Navigation.tsx
+++ b/frontend/src/components/layout/Navigation.tsx
@@ -4,6 +4,7 @@ import {
   BookOpen,
   BriefcaseBusiness,
   LayoutGrid,
+  MessageSquare,
   Search,
   Shield,
   TerminalSquare,
@@ -24,6 +25,7 @@ const navItems = [
   { to: "/lessons/what-is-open-source", label: "Lessons", icon: BookOpen },
   { to: "/challenges", label: "Challenges", icon: Trophy },
   { to: "/community", label: "Community", icon: BriefcaseBusiness },
+  { to: "/chat", label: "Chat", icon: MessageSquare },
   { to: "/profile", label: "Profile Settings", icon: Settings },
 ];
 

--- a/frontend/src/hooks/useChat.ts
+++ b/frontend/src/hooks/useChat.ts
@@ -1,0 +1,120 @@
+import { useState, useCallback, useRef, useEffect } from "react";
+import { useWebSocket } from "./useWebSocket";
+import { useTypingIndicator } from "./useTypingIndicator";
+
+type ChatMessage = {
+  id: string;
+  username: string;
+  user_id: number;
+  message: string;
+  timestamp: string;
+};
+
+type UseChatOptions = {
+  roomId: string;
+  token?: string | null;
+  username?: string;
+};
+
+function getWsUrl(roomId: string): string {
+  const apiBase =
+    import.meta.env.VITE_API_BASE_URL || "http://localhost:8000/api";
+  const host = apiBase.replace(/^https?:\/\//, "").replace(/\/api$/, "");
+  const scheme = apiBase.startsWith("https") ? "wss" : "ws";
+  return `${scheme}://${host}/ws/chat/${roomId}/`;
+}
+
+export function useChat({ roomId, token }: UseChatOptions) {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const messageIdRef = useRef(0);
+  const localUserIdRef = useRef<number | null>(null);
+
+  const onMessage = useCallback((data: unknown) => {
+    const msg = data as Record<string, unknown>;
+    if (msg.type === "new_message") {
+      setMessages((prev) => {
+        const last = prev[prev.length - 1];
+        if (
+          last &&
+          last.id.endsWith("_optimistic") &&
+          last.user_id === (msg.user_id as number) &&
+          last.message === (msg.message as string)
+        ) {
+          return prev.map((m) =>
+            m.id === last.id
+              ? {
+                  ...m,
+                  id: `msg_${messageIdRef.current + 1}`,
+                  username: msg.username as string,
+                }
+              : m,
+          );
+        }
+        messageIdRef.current += 1;
+        return [
+          ...prev,
+          {
+            id: `msg_${messageIdRef.current}`,
+            username: msg.username as string,
+            user_id: msg.user_id as number,
+            message: msg.message as string,
+            timestamp: new Date().toLocaleTimeString(),
+          },
+        ];
+      });
+    }
+  }, []);
+
+  const ws = useWebSocket({
+    url: getWsUrl(roomId),
+    token,
+    onMessage,
+  });
+
+  const typing = useTypingIndicator({
+    send: ws.send,
+  });
+
+  useEffect(() => {
+    if (ws.lastMessage) {
+      const msg = ws.lastMessage as Record<string, unknown>;
+      if (msg.type === "connection_established") {
+        localUserIdRef.current = msg.user_id as number;
+      } else if (msg.type === "typing") {
+        typing.handleTypingMessage(
+          msg as unknown as {
+            action: string;
+            username: string;
+            user_id: number;
+          },
+        );
+      }
+    }
+  }, [ws.lastMessage, typing]);
+
+  const sendMessage = useCallback(
+    (text: string) => {
+      messageIdRef.current += 1;
+      const optimistic: ChatMessage = {
+        id: `msg_${messageIdRef.current}_optimistic`,
+        username: "",
+        user_id: localUserIdRef.current ?? 0,
+        message: text,
+        timestamp: new Date().toLocaleTimeString(),
+      };
+      setMessages((prev) => [...prev, optimistic]);
+      ws.send({ action: "send_message", message: text });
+    },
+    [ws],
+  );
+
+  return {
+    messages,
+    typingUsers: typing.typingUsers,
+    isConnected: ws.isConnected,
+    sendMessage,
+    onInputChange: typing.onInputChange,
+    onInputBlur: typing.onInputBlur,
+    onInputSubmit: typing.onInputSubmit,
+  };
+}

--- a/frontend/src/hooks/useTypingIndicator.ts
+++ b/frontend/src/hooks/useTypingIndicator.ts
@@ -1,0 +1,106 @@
+import { useState, useRef, useCallback } from "react";
+
+type TypingUser = {
+  username: string;
+  user_id: number;
+};
+
+type UseTypingIndicatorOptions = {
+  send: (data: unknown) => void;
+  debounceMs?: number;
+  stopTimeoutMs?: number;
+};
+
+export function useTypingIndicator({
+  send,
+  debounceMs = 1500,
+  stopTimeoutMs = 3000,
+}: UseTypingIndicatorOptions) {
+  const [typingUsers, setTypingUsers] = useState<TypingUser[]>([]);
+  const typingTimersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(
+    new Map(),
+  );
+  const isTypingRef = useRef(false);
+  const typingDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const removeTypingUser = useCallback((username: string) => {
+    setTypingUsers((prev) => prev.filter((u) => u.username !== username));
+    const timer = typingTimersRef.current.get(username);
+    if (timer) {
+      clearTimeout(timer);
+      typingTimersRef.current.delete(username);
+    }
+  }, []);
+
+  const addTypingUser = useCallback(
+    (username: string, userId: number) => {
+      setTypingUsers((prev) => {
+        if (prev.some((u) => u.username === username)) return prev;
+        return [...prev, { username, user_id: userId }];
+      });
+
+      const existingTimer = typingTimersRef.current.get(username);
+      if (existingTimer) clearTimeout(existingTimer);
+
+      const timer = setTimeout(() => {
+        removeTypingUser(username);
+      }, stopTimeoutMs);
+      typingTimersRef.current.set(username, timer);
+    },
+    [removeTypingUser, stopTimeoutMs],
+  );
+
+  const handleTypingMessage = useCallback(
+    (data: { action: string; username: string; user_id: number }) => {
+      if (data.action === "typing_start") {
+        addTypingUser(data.username, data.user_id);
+      } else if (data.action === "typing_stop") {
+        removeTypingUser(data.username);
+      }
+    },
+    [addTypingUser, removeTypingUser],
+  );
+
+  const notifyTyping = useCallback(() => {
+    if (!isTypingRef.current) {
+      isTypingRef.current = true;
+      send({ action: "typing_start" });
+    }
+    if (typingDebounceRef.current) clearTimeout(typingDebounceRef.current);
+    typingDebounceRef.current = setTimeout(() => {
+      isTypingRef.current = false;
+      send({ action: "typing_stop" });
+    }, debounceMs);
+  }, [send, debounceMs]);
+
+  const stopTyping = useCallback(() => {
+    if (isTypingRef.current) {
+      isTypingRef.current = false;
+      send({ action: "typing_stop" });
+    }
+    if (typingDebounceRef.current) {
+      clearTimeout(typingDebounceRef.current);
+      typingDebounceRef.current = null;
+    }
+  }, [send]);
+
+  const onInputChange = useCallback(() => {
+    notifyTyping();
+  }, [notifyTyping]);
+
+  const onInputBlur = useCallback(() => {
+    stopTyping();
+  }, [stopTyping]);
+
+  const onInputSubmit = useCallback(() => {
+    stopTyping();
+  }, [stopTyping]);
+
+  return {
+    typingUsers,
+    handleTypingMessage,
+    onInputChange,
+    onInputBlur,
+    onInputSubmit,
+  };
+}

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -1,0 +1,121 @@
+import { useEffect, useRef, useCallback, useState } from "react";
+
+type UseWebSocketOptions = {
+  url: string;
+  token?: string | null;
+  onMessage?: (data: unknown) => void;
+  reconnectInterval?: number;
+  maxReconnectAttempts?: number;
+};
+
+type WebSocketState = {
+  isConnected: boolean;
+  lastMessage: unknown | null;
+  error: Event | null;
+};
+
+export function useWebSocket({
+  url,
+  token,
+  onMessage,
+  reconnectInterval = 3000,
+  maxReconnectAttempts = 10,
+}: UseWebSocketOptions) {
+  const [state, setState] = useState<WebSocketState>({
+    isConnected: false,
+    lastMessage: null,
+    error: null,
+  });
+
+  const wsRef = useRef<WebSocket | null>(null);
+  const reconnectCountRef = useRef(0);
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const onMessageRef = useRef(onMessage);
+  onMessageRef.current = onMessage;
+
+  const buildUrl = useCallback(() => {
+    if (!token) return url;
+    const separator = url.includes("?") ? "&" : "?";
+    return `${url}${separator}token=${encodeURIComponent(token)}`;
+  }, [url, token]);
+
+  const cleanup = useCallback(() => {
+    if (reconnectTimerRef.current) {
+      clearTimeout(reconnectTimerRef.current);
+      reconnectTimerRef.current = null;
+    }
+    if (wsRef.current) {
+      wsRef.current.onopen = null;
+      wsRef.current.onclose = null;
+      wsRef.current.onerror = null;
+      wsRef.current.onmessage = null;
+      wsRef.current.close();
+      wsRef.current = null;
+    }
+  }, []);
+
+  const connect = useCallback(() => {
+    cleanup();
+
+    if (!token) {
+      setState((s) => ({ ...s, isConnected: false }));
+      return;
+    }
+
+    const wsUrl = buildUrl();
+    const ws = new WebSocket(wsUrl);
+
+    ws.onopen = () => {
+      reconnectCountRef.current = 0;
+      setState((s) => ({ ...s, isConnected: true, error: null }));
+    };
+
+    ws.onclose = () => {
+      setState((s) => ({ ...s, isConnected: false }));
+      if (reconnectCountRef.current < maxReconnectAttempts) {
+        reconnectCountRef.current += 1;
+        reconnectTimerRef.current = setTimeout(connect, reconnectInterval);
+      }
+    };
+
+    ws.onerror = () => {
+      setState((s) => ({ ...s, isConnected: false }));
+    };
+
+    ws.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        setState((s) => ({ ...s, lastMessage: data }));
+        onMessageRef.current?.(data);
+      } catch {
+        console.error("useWebSocket: failed to parse message", event.data);
+      }
+    };
+
+    wsRef.current = ws;
+  }, [buildUrl, cleanup, reconnectInterval, maxReconnectAttempts, token]);
+
+  const disconnect = useCallback(() => {
+    reconnectCountRef.current = maxReconnectAttempts;
+    cleanup();
+    setState((s) => ({ ...s, isConnected: false }));
+  }, [cleanup, maxReconnectAttempts]);
+
+  const send = useCallback((data: unknown) => {
+    if (wsRef.current?.readyState === WebSocket.OPEN) {
+      wsRef.current.send(JSON.stringify(data));
+    }
+  }, []);
+
+  useEffect(() => {
+    connect();
+    return cleanup;
+  }, [connect, cleanup]);
+
+  return {
+    ...state,
+    send,
+    connect,
+    disconnect,
+  };
+}

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useRef } from "react";
+import { useAuth } from "../features/auth/AuthContext";
+import { useChat } from "../hooks/useChat";
+import { ChatMessage } from "../components/chat/ChatMessage";
+import { ChatInput } from "../components/chat/ChatInput";
+import { TypingIndicator } from "../components/chat/TypingIndicator";
+import { SectionCard } from "../components/ui/SectionCard";
+
+function getAccessToken(): string | null {
+  try {
+    return localStorage.getItem("accessToken");
+  } catch {
+    return null;
+  }
+}
+
+export function ChatPage() {
+  const { user } = useAuth();
+  const token = getAccessToken();
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  const roomId = "general";
+
+  const {
+    messages,
+    typingUsers,
+    isConnected,
+    sendMessage,
+    onInputChange,
+    onInputBlur,
+    onInputSubmit,
+  } = useChat({ roomId, token, username: user?.username });
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages, typingUsers]);
+
+  return (
+    <div className="pt-24 max-w-3xl mx-auto px-4 pb-12">
+      <SectionCard
+        eyebrow="Real-time Chat"
+        title="Community Chat"
+        className="flex flex-col h-[calc(100vh-12rem)]"
+      >
+        <div className="flex items-center gap-2 mb-4">
+          <span
+            className={`h-2.5 w-2.5 rounded-full ${
+              isConnected ? "bg-green-500" : "bg-red-500"
+            }`}
+          />
+          <span className="text-xs font-bold text-muted">
+            {isConnected ? "Connected" : "Disconnected"}
+          </span>
+        </div>
+
+        <div className="flex-1 overflow-y-auto space-y-3 px-1">
+          {messages.length === 0 && (
+            <p className="text-center text-sm text-muted py-8">
+              No messages yet. Start the conversation!
+            </p>
+          )}
+          {messages.map((msg) => (
+            <ChatMessage
+              key={msg.id}
+              message={msg.message}
+              username={msg.username}
+              isOwn={msg.user_id === user?.id}
+              timestamp={msg.timestamp}
+            />
+          ))}
+
+          <div ref={messagesEndRef} />
+        </div>
+
+        <TypingIndicator users={typingUsers} className="px-1 pb-1" />
+
+        <ChatInput
+          onSendMessage={sendMessage}
+          onInputChange={onInputChange}
+          onInputBlur={onInputBlur}
+          onInputSubmit={onInputSubmit}
+          disabled={!isConnected}
+        />
+      </SectionCard>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Added a real-time typing indicator to chat using Django Channels and reusable React hooks. A new ChatConsumer broadcasts typing_start, typing_stop, and send_message events to room members over WebSocket. manage.py was updated to use Daphne so WebSocket works out of the box with runserver. On the frontend, useWebSocket, useTypingIndicator, and useChat hooks manage the connection and typing state, with optimistic message sending so senders see their own messages instantly. UI components for the typing indicator, message bubbles, and chat input were added along with a demo /chat page and sidebar nav link.

I also went ahead and implemented the entire interface of Chat in the frontend for visual assurance.

## Related Issue

Closes #442 

## Changes Made

- backend/apps/chat/ (new) — consumer, routing, app config
- backend/config/asgi.py — registered chat routing
- backend/config/settings.py — registered chat app
- backend/manage.py — daphne delegation for WebSocket support
- frontend/src/hooks/useWebSocket.ts (new) — generic WebSocket hook
- frontend/src/hooks/useTypingIndicator.ts (new) — typing state management
- frontend/src/hooks/useChat.ts (new) — chat orchestration hook
- frontend/src/components/chat/ (new) — TypingIndicator, ChatMessage, ChatInput
- frontend/src/pages/ChatPage.tsx (new) — demo chat page
- frontend/src/app/router.tsx — /chat route
- frontend/src/components/layout/Navigation.tsx — Chat nav link

## Testing

- [x] Tested manually 
- [ ] Add new unit/integration test
- [x] verified existing test still pass

## Screenshots

<img width="1468" height="833" alt="Screenshot 2026-06-23 at 3 55 19 AM" src="https://github.com/user-attachments/assets/a40bf24b-0d5a-443e-9a4f-2efa4d6738bc" />

<img width="1470" height="833" alt="Screenshot 2026-06-23 at 3 55 39 AM" src="https://github.com/user-attachments/assets/329e609f-3845-4ed4-8fc7-32fa0d5aaecf" />

## Checklist

- [ ] Tests added or updated
- [ ] Documentation updated if needed
- [x] No secrets committed

