### PR TITLE
feat: Async user badge evaluation via Celery

### DIFF
--- a/backend/apps/progress/tasks.py
+++ b/backend/apps/progress/tasks.py
@@ -1,0 +1,25 @@
+import logging
+
+from celery import shared_task
+from django.contrib.auth import get_user_model
+
+from .badge_evaluator import BadgeEvaluator
+
+logger = logging.getLogger(__name__)
+User = get_user_model()
+
+
+@shared_task
+def evaluate_user_badges_task(user_id):
+    """
+    Asynchronously evaluates and awards badges for a given user.
+    """
+    try:
+        user = User.objects.get(id=user_id)
+        BadgeEvaluator.evaluate(user)
+    except User.DoesNotExist:
+        logger.warning(
+            f"User with id {user_id} does not exist. Badge evaluation skipped."
+        )
+    except Exception as e:
+        logger.error(f"Error evaluating badges for user {user_id}: {e}")

--- a/backend/apps/progress/views.py
+++ b/backend/apps/progress/views.py
@@ -74,9 +74,9 @@ class MyProgressView(APIView):
             },
         )
 
-        from .badge_evaluator import BadgeEvaluator
+        from .tasks import evaluate_user_badges_task
 
-        BadgeEvaluator.evaluate(request.user)
+        evaluate_user_badges_task.delay(request.user.id)
 
         serializer = LessonProgressSerializer(progress)
 
@@ -121,9 +121,9 @@ class BulkSyncProgressView(APIView):
 
                 synced.append(progress.id)
 
-            from .badge_evaluator import BadgeEvaluator
+            from .tasks import evaluate_user_badges_task
 
-            BadgeEvaluator.evaluate(request.user)
+            evaluate_user_badges_task.delay(request.user.id)
 
         return Response(
             {"synced_count": len(synced), "progress_ids": synced},
@@ -246,9 +246,9 @@ class BulkProgressUpdateView(APIView):
                     )
                     success_ids.extend([p.id for p in progress_to_update])
 
-                from .badge_evaluator import BadgeEvaluator
+                from .tasks import evaluate_user_badges_task
 
-                BadgeEvaluator.evaluate(request.user)
+                evaluate_user_badges_task.delay(request.user.id)
 
         except ValueError as ve:
             return Response(

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -7,3 +7,8 @@ def _disable_auth_throttle(settings):
     rates["auth_signup"] = "10000/hour"
     settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"] = rates
 
+
+@pytest.fixture(autouse=True)
+def celery_eager(settings):
+    settings.CELERY_TASK_ALWAYS_EAGER = True
+    settings.CELERY_TASK_STORE_EAGER_RESULT = False


### PR DESCRIPTION
## Summary
Moves the synchronous badge evaluation logic to a background Celery task to improve API response times when updating lesson progress. 

## Related Issue
Closes #346

## Changes Made
- Created `evaluate_user_badges_task` Celery task in `apps/progress/tasks.py`.
- Refactored `MyProgressView`, `BulkSyncProgressView`, and `BulkProgressUpdateView` to dispatch the evaluation task asynchronously using `.delay()`.
- Updated `conftest.py` to run Celery tasks eagerly during testing without requiring a Redis result backend.

## Testing
- [ ] Tested manually 
- [ ] Add new unit/integration test
- [x] Verified existing tests still pass (48/48 passed)

## Screenshots
N/A (Backend only)

## Checklist
- [x] Tests added or updated
- [ ] Documentation updated if needed
- [x] No secrets committed
