### PR TITLE
perf(ui): lazy load React Markdown renderer component

### DIFF
--- a/frontend/src/pages/LessonPage.tsx
+++ b/frontend/src/pages/LessonPage.tsx
@@ -15,8 +15,13 @@ import SkeletonLesson from "../components/ui/skeletons/SkeletonLesson";
 import { useUserProgress } from "../hooks/useUserProgress";
 import { fetchApi } from "../lib/api";
 import { Lesson, fetchLessonsApi, fetchLessonContent } from "../lib/lessons";
-import { MarkdownRenderer } from "../components/ui/MarkdownRenderer";
 import { RichTextEditor } from "../components/ui/RichTextEditor";
+
+const MarkdownRenderer = React.lazy(() =>
+  import("../components/ui/MarkdownRenderer").then((module) => ({
+    default: module.MarkdownRenderer,
+  }))
+);
 import { GitGraph } from "../components/ui/GitGraph";
 
 import {
@@ -447,9 +452,15 @@ export function LessonPage() {
 
             <hr className="border-2 border-black/10 dark:border-[#2e2924]/40" />
 
-            {/* Markdown rendering logic */}
+          {/* Markdown rendering logic */}
             <article className="prose max-w-none">
-              <MarkdownRenderer content={markdownContent} />
+              <React.Suspense 
+                fallback={
+                  <div className="w-full h-64 animate-pulse rounded-2xl border-4 border-black/20 bg-surface-low dark:border-[#2e2924]/50 dark:bg-[#151411]" />
+                }
+              >
+                <MarkdownRenderer content={markdownContent} />
+              </React.Suspense>
             </article>
 
             {/* Exercises & validation section */}


### PR DESCRIPTION
## Summary
This PR optimizes the initial load time of the application by splitting the heavy markdown parsing dependencies out of the main JavaScript bundle. The parser is now only fetched when a user actively navigates to a lesson page.

## Related Issue
Closes #441

## Changes Made
* **Frontend (`frontend/src/pages/LessonPage.tsx`)**: Replaced the static import of `MarkdownRenderer` with a dynamic `React.lazy()` import mapped to the named export.
* **Frontend (`frontend/src/pages/LessonPage.tsx`)**: Wrapped the component in a `<React.Suspense>` boundary featuring a pulsing skeleton block that matches the app's brutalist design system while the chunk loads.

## Testing
1. Pull the branch locally and start the dev server (`npm run dev`).
2. Open your browser's Network tab and filter by "JS".
3. Load the root/login page. Confirm that the heavy markdown chunk is *not* downloaded.
4. Log in and navigate to a lesson (e.g., `/lessons/what-is-open-source`). 
5. Confirm that the new chunk is requested over the network, the skeleton loader flashes briefly, and the lesson content parses and renders correctly.

- [x] Tested manually 
- [ ] Add new unit/integration test
- [x] verified existing test still pass

## Screenshots
*No permanent UI changes. Adds a skeleton loader during chunk fetching.*

## Checklist

- [ ] Tests added or updated
- [ ] Documentation updated if needed
- [x] No secrets committed