### PR TITLE
feat(logging): mask sensitive PII data in application logs

### DIFF
--- a/backend/config/logging_filters.py
+++ b/backend/config/logging_filters.py
@@ -1,0 +1,66 @@
+import logging
+import re
+import traceback
+
+class SensitiveDataFilter(logging.Filter):
+    """
+    Logging filter to obscure sensitive PII data (emails and tokens) from logs.
+    """
+    
+    # 1. Email pattern
+    EMAIL_PATTERN = re.compile(r'\b[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}\b')
+    
+    # 2. JWT pattern (eyJ... followed by base64-like characters, dot, etc.)
+    JWT_PATTERN = re.compile(r'\beyJ[A-Za-z0-9-_=]+\.eyJ[A-Za-z0-9-_=]+\.[A-Za-z0-9-_.+/=]+\b')
+    
+    # 3. Authorization header / token patterns in text/logs
+    # Matches patterns like: Authorization: Bearer <token>, Token: <token>, token = <token>, access_token = <token>
+    TOKEN_KEYVALUE_PATTERN = re.compile(
+        r'(?i)\b(authorization|bearer|token|password|secret|access_token|refresh_token|otp_token)\b(\s*[:=]\s*|\s+)(["\']?)(?P<value>[a-zA-Z0-9-_+/=]{8,})\3'
+    )
+
+    def mask_text(self, text: str) -> str:
+        if not isinstance(text, str):
+            return text
+            
+        # Mask JWT tokens
+        text = self.JWT_PATTERN.sub('[MASKED_TOKEN]', text)
+        
+        # Mask emails
+        text = self.EMAIL_PATTERN.sub('[MASKED_EMAIL]', text)
+        
+        # Mask token/secret key-value pairs
+        def replace_kv(match):
+            key = match.group(1)
+            separator = match.group(2)
+            quote = match.group(3)
+            return f"{key}{separator}{quote}[MASKED]{quote}"
+            
+        text = self.TOKEN_KEYVALUE_PATTERN.sub(replace_kv, text)
+        
+        return text
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        # Pre-format message if args exist to prevent formatting issues after masking
+        if record.args:
+            try:
+                record.msg = record.msg % record.args
+                record.args = ()
+            except Exception:
+                pass
+                
+        if isinstance(record.msg, str):
+            record.msg = self.mask_text(record.msg)
+            
+        # If traceback exists, pre-format and mask it so it won't be formatted with unmasked data later
+        if record.exc_info:
+            try:
+                exc_list = traceback.format_exception(*record.exc_info)
+                exc_text = "".join(exc_list)
+                record.exc_text = self.mask_text(exc_text)
+            except Exception:
+                pass
+        elif getattr(record, 'exc_text', None) and isinstance(record.exc_text, str):
+            record.exc_text = self.mask_text(record.exc_text)
+            
+        return True

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -279,3 +279,52 @@ CELERY_RESULT_BACKEND = CELERY_BROKER_URL
 CELERY_ACCEPT_CONTENT = ["json"]
 CELERY_TASK_SERIALIZER = "json"
 CELERY_RESULT_SERIALIZER = "json"
+
+
+# ──────────────────────────────────────────
+# Logging Configuration
+# ──────────────────────────────────────────
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "filters": {
+        "mask_sensitive_data": {
+            "()": "config.logging_filters.SensitiveDataFilter",
+        },
+    },
+    "formatters": {
+        "verbose": {
+            "format": "{levelname} {asctime} {module} {process:d} {thread:d} {message}",
+            "style": "{",
+        },
+    },
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "filters": ["mask_sensitive_data"],
+            "formatter": "verbose",
+        },
+    },
+    "loggers": {
+        "django": {
+            "handlers": ["console"],
+            "level": "INFO",
+            "propagate": False,
+        },
+        "django.server": {
+            "handlers": ["console"],
+            "level": "INFO",
+            "propagate": False,
+        },
+        "apps": {
+            "handlers": ["console"],
+            "level": "INFO",
+            "propagate": False,
+        },
+    },
+    "root": {
+        "handlers": ["console"],
+        "level": "INFO",
+    },
+}
+


### PR DESCRIPTION
## Summary
Implements a custom Django logging filter to automatically redact sensitive Personally Identifiable Information (PII) from application logs. This ensures that user emails and authentication tokens (like JWTs or Bearer tokens) are never printed to the console or log files, preventing accidental data leakage.

## Related Issue
Closes #458

## Changes Made
- Created `SensitiveDataFilter` in `backend/config/logging_filters.py` with regex-based masking for emails, JWT tokens, and common authentication headers/keys.
- Added logic to the filter to pre-format and safely mask exception tracebacks (`exc_info`) so errors do not leak sensitive variables.
- Configured the global `LOGGING` dictionary in `backend/config/settings.py` to route backend loggers (`django`, `django.server`, `apps`) through this new filter.

## Testing
- [x] Tested manually 
- [ ] Add new unit/integration test
- [x] verified existing test still pass

## Screenshots
N/A (Backend logging configuration only)

## Checklist

- [ ] Tests added or updated
- [ ] Documentation updated if needed
- [x] No secrets committed