### PR TITLE
feat: implement chunked data transfers for large curriculum downloads

### DIFF
--- a/backend/apps/content/views.py
+++ b/backend/apps/content/views.py
@@ -1,18 +1,5 @@
 from io import BytesIO
 
-from django.http import HttpResponse
-from rest_framework import viewsets, views, response, permissions, generics, filters, status
-from rest_framework.permissions import AllowAny
-from django.db.models import Q
-from django.core.cache import cache
-from django.contrib.contenttypes.models import ContentType
-from django.contrib.postgres.search import SearchQuery, SearchRank, TrigramSimilarity
-from reportlab.lib.styles import getSampleStyleSheet
-from reportlab.platypus import SimpleDocTemplate, Paragraph, Spacer
-
-from . import semantic_search
-from .models import Lesson, Organization
-from .serializers import LessonSearchSerializer, LessonSerializer, OrganizationSerializer
 from apps.challenges.models import Challenge
 from apps.challenges.serializers import ChallengeSerializer
 from apps.progress.models import LessonProgress
@@ -22,8 +9,11 @@ from django.contrib.postgres.search import (SearchQuery, SearchRank,
                                             TrigramSimilarity)
 from django.core.cache import cache
 from django.db.models import Q
-from rest_framework import (filters, generics, permissions, response, views,
-                            viewsets)
+from django.http import FileResponse
+from reportlab.lib.styles import getSampleStyleSheet
+from reportlab.platypus import Paragraph, SimpleDocTemplate, Spacer
+from rest_framework import (filters, generics, permissions, response, status,
+                            views, viewsets)
 from rest_framework.permissions import AllowAny
 
 from . import semantic_search
@@ -203,8 +193,8 @@ class OrganizationListView(generics.ListAPIView):
     serializer_class = OrganizationSerializer
     permission_classes = [AllowAny]
     filter_backends = [filters.OrderingFilter]
-    ordering_fields = ['name', 'date_added', 'popularity_score']
-    ordering = ['-popularity_score']
+    ordering_fields = ["name", "date_added", "popularity_score"]
+    ordering = ["-popularity_score"]
 
 
 class LessonPDFView(views.APIView):
@@ -213,8 +203,7 @@ class LessonPDFView(views.APIView):
             lesson = Lesson.objects.get(pk=pk)
         except Lesson.DoesNotExist:
             return response.Response(
-                {"error": "Lesson not found"},
-                status=status.HTTP_404_NOT_FOUND
+                {"error": "Lesson not found"}, status=status.HTTP_404_NOT_FOUND
             )
 
         buffer = BytesIO()
@@ -230,8 +219,7 @@ class LessonPDFView(views.APIView):
         elements.append(Paragraph(f"Difficulty: {lesson.difficulty}", styles["Normal"]))
         elements.append(
             Paragraph(
-                f"Estimated Minutes: {lesson.estimated_minutes}",
-                styles["Normal"]
+                f"Estimated Minutes: {lesson.estimated_minutes}", styles["Normal"]
             )
         )
         elements.append(Spacer(1, 12))
@@ -245,37 +233,18 @@ class LessonPDFView(views.APIView):
         elements.append(Spacer(1, 12))
 
         if lesson.learning_objectives:
-            elements.append(
-                Paragraph("Learning Objectives", styles["Heading2"])
-            )
+            elements.append(Paragraph("Learning Objectives", styles["Heading2"]))
 
             for item in lesson.learning_objectives:
-                elements.append(
-                    Paragraph(f"- {item}", styles["BodyText"])
-                )
+                elements.append(Paragraph(f"- {item}", styles["BodyText"]))
 
         if lesson.tips:
-            elements.append(
-                Paragraph("Tips", styles["Heading2"])
-            )
+            elements.append(Paragraph("Tips", styles["Heading2"]))
 
             for tip in lesson.tips:
-                elements.append(
-                    Paragraph(f"- {tip}", styles["BodyText"])
-                )
+                elements.append(Paragraph(f"- {tip}", styles["BodyText"]))
 
         doc.build(elements)
 
-        pdf = buffer.getvalue()
-        buffer.close()
-
-        response_obj = HttpResponse(
-            pdf,
-            content_type="application/pdf"
-        )
-
-        response_obj[
-            "Content-Disposition"
-        ] = f'attachment; filename="{lesson.slug}.pdf"'
-
-        return response_obj
+        buffer.seek(0)
+        return FileResponse(buffer, as_attachment=True, filename=f"{lesson.slug}.pdf")


### PR DESCRIPTION
## Summary
Replaces `HttpResponse` with `FileResponse` in `LessonPDFView` to stream generated lesson PDFs progressively in chunks. This reduces server memory usage and improves network performance by not buffering the entire file into memory before sending.

## Related Issue
Closes #439

## Changes Made
- Replaced `django.http.HttpResponse` with `django.http.FileResponse` in `LessonPDFView`.
- Rewound the `BytesIO` buffer pointer with `buffer.seek(0)` instead of loading it entirely into memory via `buffer.getvalue()`.
- Refactored `Content-Disposition` assignments to use `FileResponse`'s native `as_attachment` and `filename` parameters.
- Removed unused `HttpResponse` import from `views.py`.

## Testing
- [x] Tested manually 
- [ ] Add new unit/integration test
- [x] verified existing test still pass

## Screenshots
*(N/A - Backend logic change only)*

## Checklist
- [ ] Tests added or updated
- [ ] Documentation updated if needed
- [x] No secrets committed
