### PR TITLE
feat: enable GZip response compression for DRF APIs

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -63,6 +63,7 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     "corsheaders.middleware.CorsMiddleware",
     "django.middleware.security.SecurityMiddleware",
+    "django.middleware.gzip.GZipMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",


### PR DESCRIPTION
## Summary
Enabled built-in GZip middleware to automatically compress large JSON responses from the Django REST Framework, reducing payload sizes and bandwidth usage. 

## Related Issue
Closes #440

## Changes Made
- Added `django.middleware.gzip.GZipMiddleware` to the `MIDDLEWARE` list in `backend/config/settings.py`, right below `SecurityMiddleware`. This zero-dependency solution handles `Accept-Encoding` safely and automatically bypasses payloads smaller than 200 bytes.

## Testing
- [ ] Tested manually 
- [ ] Add new unit/integration test
- [x] verified existing test still pass

## Screenshots
N/A

## Checklist

- [ ] Tests added or updated
- [ ] Documentation updated if needed
- [x] No secrets committed
