### PR TITLE
feat: real-time badge notifications via WebSockets

### DIFF
--- a/frontend/src/components/ui/BadgeToastNotifier.tsx
+++ b/frontend/src/components/ui/BadgeToastNotifier.tsx
@@ -1,21 +1,47 @@
 import { useAuth } from "../../features/auth/AuthContext";
 import { BadgeToastContainer } from "./BadgeToast";
 import { useBadgeToast } from "../../hooks/useBadgeToast";
-import { useEarnedBadges } from "../../hooks/useEarnedBadges";
 import { BADGES } from "../../constants/badges";
+import { useWebSocket } from "../../hooks/useWebSocket";
+
+function getNotificationsWsUrl(): string {
+  const apiBase =
+    import.meta.env.VITE_API_BASE_URL || "http://localhost:8000/api";
+  const host = apiBase.replace(/^https?:\/\//, "").replace(/\/api$/, "");
+  const scheme = apiBase.startsWith("https") ? "wss" : "ws";
+  return `${scheme}://${host}/ws/notifications/`;
+}
 
 export function BadgeToastNotifier() {
   const { user } = useAuth();
-  const { earnedBadges, isLessonsLoading, curriculumData } = useEarnedBadges();
+  const { toasts, addToast, dismissToast } = useBadgeToast(BADGES);
 
-  // Wait for lessons and curriculum data to load before checking for new badges.
-  const isDataReady = !isLessonsLoading && curriculumData.length > 0;
+  // Re-use standard approach for getting tokens as in AuthContext.
+  let token: string | null = null;
+  try {
+    token = localStorage.getItem("accessToken");
+  } catch {
+    /* localStorage unavailable */
+  }
 
-  const { toasts, dismissToast } = useBadgeToast(
-    earnedBadges,
-    BADGES,
-    isDataReady,
-  );
+  useWebSocket({
+    url: getNotificationsWsUrl(),
+    token: user && !user.is_staff ? token : null,
+    onMessage: (data: unknown) => {
+      const msg = data as Record<string, unknown>;
+      if (
+        msg?.type === "notification" &&
+        (msg.notification as Record<string, unknown>)?.notif_type === "badge"
+      ) {
+        const notif = msg.notification as Record<string, unknown>;
+        const meta = notif.meta as Record<string, unknown>;
+        const slug = meta?.badge_slug as string | undefined;
+        if (slug) {
+          addToast(slug);
+        }
+      }
+    },
+  });
 
   if (!user || user.is_staff) return null;
 

--- a/frontend/src/hooks/useBadgeToast.ts
+++ b/frontend/src/hooks/useBadgeToast.ts
@@ -1,52 +1,28 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import type { BadgeToastData } from "../components/ui/BadgeToast";
 import type { BadgeDefinition } from "../constants/badges";
 
 interface UseBadgeToastReturn {
   toasts: BadgeToastData[];
+  addToast: (slug: string) => void;
   dismissToast: (id: string) => void;
 }
 
-export function useBadgeToast(
-  earnedBadgeIds: string[],
-  allBadges: BadgeDefinition[],
-  isDataReady: boolean = false,
-): UseBadgeToastReturn {
+export function useBadgeToast(allBadges: BadgeDefinition[]): UseBadgeToastReturn {
   const [toasts, setToasts] = useState<BadgeToastData[]>([]);
 
-  // To ensure that only new entries trigger toast
-  const sessionBaselineRef = useRef<Set<string> | null>(null);
-  const earnedKey = earnedBadgeIds.join(",");
+  const addToast = useCallback(
+    (slug: string) => {
+      const badge = allBadges.find((b) => b.id === slug);
+      if (!badge) return;
 
-  useEffect(() => {
-    if (!isDataReady) return;
-
-    if (sessionBaselineRef.current === null) {
-      sessionBaselineRef.current = new Set(earnedBadgeIds);
-      return;
-    }
-
-    const newlyEarned = earnedBadgeIds.filter(
-      (id) => !sessionBaselineRef.current!.has(id),
-    );
-    if (newlyEarned.length === 0) return;
-
-    newlyEarned.forEach((id) => sessionBaselineRef.current!.add(id));
-
-    const badgeMap = new Map(allBadges.map((b) => [b.id, b]));
-    const newToasts: BadgeToastData[] = newlyEarned
-      .map((id) => badgeMap.get(id))
-      .filter((b): b is BadgeDefinition => b !== undefined);
-
-    if (newToasts.length === 0) return;
-
-    setToasts((prev) => {
-      const queuedIds = new Set(prev.map((t) => t.id));
-      const deduped = newToasts.filter((t) => !queuedIds.has(t.id));
-      return deduped.length > 0 ? [...prev, ...deduped] : prev;
-    });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isDataReady, earnedKey]);
+      setToasts((prev) => {
+        if (prev.some((t) => t.id === badge.id)) return prev;
+        return [...prev, badge];
+      });
+    },
+    [allBadges],
+  );
 
   // Dev-only: dispatch window event "badge:test" with { id } to trigger a toast from DevTools.
   useEffect(() => {
@@ -54,27 +30,16 @@ export function useBadgeToast(
 
     const handler = (e: Event) => {
       const { id } = (e as CustomEvent<{ id: string }>).detail;
-      const badge = allBadges.find((b) => b.id === id);
-      if (!badge) {
-        console.warn(
-          `[badge:test] Unknown badge id "${id}". Valid:`,
-          allBadges.map((b) => b.id),
-        );
-        return;
-      }
-      setToasts((prev) => {
-        if (prev.some((t) => t.id === id)) return prev;
-        return [...prev, badge];
-      });
+      addToast(id);
     };
 
     window.addEventListener("badge:test", handler);
     return () => window.removeEventListener("badge:test", handler);
-  }, [allBadges]);
+  }, [addToast]);
 
   const dismissToast = useCallback((id: string) => {
     setToasts((prev) => prev.filter((t) => t.id !== id));
   }, []);
 
-  return { toasts, dismissToast };
+  return { toasts, addToast, dismissToast };
 }


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this Pull-request does -->
This PR transitions the badge unlocked notifications from a polling-based approach to a real-time WebSocket push model. Users will now instantly see a "Badge Unlocked" popup when an achievement is awarded, without requiring a page reload or data refetch.

## Related Issue
<!--What are the issues it solves  -->
Closes #443

## Changes Made
<!--List the changes made -->
- Refactored `BadgeToastNotifier.tsx` to connect to `/ws/notifications/` using the `useWebSocket` hook.
- Added message parsing logic to instantly trigger badge toasts when a `"badge"` event is received over the socket.
- Simplified `useBadgeToast.ts` by removing the pseudo-polling session difference checking and `useEarnedBadges` dependency, turning it into a straightforward push-driven toast queue.
- Reused existing WebSocket endpoints (`NotificationConsumer`) and UI components without introducing new dependencies.

## Testing
<!--Provide instructions on how it has been tested so reviewers can verify you change-->
- [x] Tested manually 
- [ ] Add new unit/integration test
- [x] verified existing test still pass
*(Note: Minor pre-existing TypeScript compilation errors in `main` on unrelated pages were intentionally left untouched to prevent scope creep.)*

## Screenshots
<!-- Add Screenshots of visual changes-->
*No visual UI changes; the toast itself looks identical, just appears in real-time.*

## Checklist

- [ ] Tests added or updated
- [ ] Documentation updated if needed
- [x] No secrets committed
