### PR TITLE
feat:leaderboard-redis-caching

### DIFF
--- a/backend/apps/dashboard/views.py
+++ b/backend/apps/dashboard/views.py
@@ -31,10 +31,29 @@ class LeaderboardSerializer(serializers.ModelSerializer):
 class LeaderboardView(ListAPIView):
     """
     Paginated contributor leaderboard ordered by total XP.
+
+    Results are cached per-page in Redis for 5 minutes, since the
+    underlying query involves several correlated subqueries across
+    LessonProgress, Issue, and PullRequest and is expensive to
+    recompute on every request.
     """
 
     serializer_class = LeaderboardSerializer
     pagination_class = LeaderboardPagination
+
+    def list(self, request, *args, **kwargs):
+        page_number = request.query_params.get("page", "1")
+        cache_key = f"leaderboard_page_{page_number}"
+        data = cache.get(cache_key)
+
+        if data is None:
+            response = super().list(request, *args, **kwargs)
+            data = response.data
+            # Cache for 5 minutes
+            cache.set(cache_key, data, 300)
+            return Response(data)
+
+        return Response(data)
 
     def get_queryset(self):
         lesson_xp = (

--- a/backend/tests/test_leaderboard_cache.py
+++ b/backend/tests/test_leaderboard_cache.py
@@ -1,0 +1,57 @@
+from unittest.mock import patch
+
+import pytest
+from django.contrib.auth.models import User
+from django.core.cache import cache
+from rest_framework.test import APIClient
+
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    cache.clear()
+    yield
+    cache.clear()
+
+
+@pytest.mark.django_db
+class TestLeaderboardCaching:
+    def test_returns_200(self, api_client):
+        response = api_client.get("/api/leaderboard/")
+        assert response.status_code == 200
+
+    def test_caches_response_on_first_call(self, api_client):
+        api_client.get("/api/leaderboard/")
+        assert cache.get("leaderboard_page_1") is not None
+
+    def test_second_call_uses_cache_not_db(self, api_client):
+        api_client.get("/api/leaderboard/")
+
+        with patch(
+            "apps.dashboard.views.LeaderboardView.get_queryset"
+        ) as mock_get_queryset:
+            response = api_client.get("/api/leaderboard/")
+            mock_get_queryset.assert_not_called()
+        assert response.status_code == 200
+
+    def test_different_pages_cached_separately(self, api_client):
+        for i in range(25):
+            User.objects.create_user(username=f"user{i}", password="pw12345!")
+
+        api_client.get("/api/leaderboard/?page=1")
+        api_client.get("/api/leaderboard/?page=2")
+
+        assert cache.get("leaderboard_page_1") is not None
+        assert cache.get("leaderboard_page_2") is not None
+        assert cache.get("leaderboard_page_1") != cache.get("leaderboard_page_2")
+
+    def test_cache_expires_after_ttl(self, api_client):
+        with patch("apps.dashboard.views.cache.set") as mock_set:
+            api_client.get("/api/leaderboard/")
+            mock_set.assert_called_once()
+            _, _, ttl = mock_set.call_args[0]
+            assert ttl == 300


### PR DESCRIPTION
## Summary
Adds Redis caching to the leaderboard API endpoint to avoid recomputing the expensive ranking query (which uses several correlated subqueries across LessonProgress, Issue, and PullRequest) on every request.

## Related Issue
Closes #437

## Changes Made
- LeaderboardView now caches each paginated response in Redis, keyed per page (leaderboard_page_<n>)
- Cache TTL set to 5 minutes (300 seconds)
- On cache hit, the expensive get_queryset() ranking computation is skipped entirely and the cached response is returned directly
- Added backend/tests/test_leaderboard_cache.py covering cache population, cache hit behavior, per-page cache isolation, and TTL value

## Testing
- [x] Tested manually
- [x] Add new unit/integration test
- [x] Verified existing tests still pass

Manual test: called GET /api/leaderboard/ twice in a row and confirmed via Django shell that cache.get("leaderboard_page_1") returns the cached response after the first call.

## Screenshots
N/A — backend-only change, no UI changes.

## Checklist
- [x] Tests added or updated
- [ ] Documentation updated if needed
- [x] No secrets committed