### PR TITLE
ci: add GitHub Actions workflow for frontend lint and tests

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,0 +1,40 @@
+name: Frontend CI
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  frontend-checks:
+    name: Frontend Quality Checks
+    runs-on: ubuntu-latest
+    
+    defaults:
+      run:
+        working-directory: ./frontend
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Run ESLint
+        run: npm run lint
+
+      - name: Run Prettier check
+        run: npm run format:check
+
+      - name: Run Vitest
+        run: npm run test
+
+      - name: Verify Production Build
+        run: npm run build


### PR DESCRIPTION
## Summary
This Pull Request introduces an automated GitHub Actions CI pipeline for the React/Vite frontend. It automatically triggers on PRs to run the frontend checklist (lint, format:check, test, and build) to prevent regressions from accidentally being merged into `main`.

## Related Issue
Closes #505

## Changes Made
- Added a new GitHub Actions workflow at `.github/workflows/frontend-ci.yml`.
- Configured the job to use `ubuntu-latest` and Node.js v20.
- Automated the sequence: `npm ci --legacy-peer-deps`, `npm run lint`, `npm run format:check`, `npm run test`, and `npm run build`. 
*(Note: `--legacy-peer-deps` was added to bypass the current upstream dependency conflicts locally.)*

## Testing
- [x] Tested manually (Verified the pipeline steps via local CLI runs in the `frontend/` directory).
- [ ] Add new unit/integration test
- [ ] Verified existing test still pass (Note: tests are currently failing on `main` natively, the CI is correctly enforcing failure when they are red).

## Screenshots
N/A

## Checklist
- [x] Tests added or updated (Pipeline now runs existing Vitest tests)
- [ ] Documentation updated if needed
- [x] No secrets committed
