### PR TITLE
chore(frontend): optimize Dockerfile with multi-stage build

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+dist
+.git
+.env
+.env.*
+Dockerfile
+.dockerignore
+playwright-report
+test-results

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,9 +1,20 @@
-FROM node:22-alpine
+FROM node:22-alpine AS builder
 
 WORKDIR /app
 
-COPY package.json package-lock.json* /app/
-RUN npm install
+COPY package.json package-lock.json* ./
+RUN npm ci
 
-COPY . /app/
+COPY . .
 
+RUN npm run build
+
+FROM nginx:alpine AS runner
+
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,25 @@
+server {
+    listen 80;
+    server_name localhost;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Gzip compression for faster load times
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 10240;
+    gzip_proxied expired no-cache no-store private auth;
+    gzip_types text/plain text/css text/xml text/javascript application/x-javascript application/xml application/javascript;
+    gzip_disable "MSIE [1-6]\.";
+
+    # SPA Routing: Fallback to index.html
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Cache static assets
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+        expires 1y;
+        add_header Cache-Control "public, no-transform";
+    }
+}


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this Pull-request does -->
This PR drastically reduces the frontend Docker image size by implementing a multi-stage build. It compiles the Vite application in a Node environment and serves the optimized static assets using an ultra-lightweight Nginx Alpine image.

## Related Issue
<!--What are the issues it solves  -->
Closes #591

## Changes Made
<!--List the changes made -->
* **`frontend/Dockerfile`**: Rewritten to use a two-stage build pipeline (`builder` using `node:22-alpine` and `runner` using `nginx:alpine`).
* **`frontend/.dockerignore`**: Created to exclude `node_modules`, `.env` files, and local build artifacts from being copied into the Docker build context, saving memory and time.
* **`frontend/nginx.conf`**: Created to handle SPA client-side routing (fallback to `index.html`) and enable Gzip compression for faster static asset delivery.

## Testing
<!--Provide instructions on how it has been tested so reviewers can verify you change-->
Reviewers can verify the image size reduction locally by running:
1. `docker build -t atelier-frontend ./frontend`
2. `docker images` (Observe the size is now ~20-30MB instead of >1GB).
3. `docker run -p 8080:80 atelier-frontend` and visit `http://localhost:8080` to ensure the frontend routes correctly.

- [ ] Tested manually 
- [ ] Add new unit/integration test
- [x] verified existing test still pass

## Screenshots
<!-- Add Screenshots of visual changes-->
*N/A - Infrastructure optimization only. No visual changes.*

## Checklist

- [ ] Tests added or updated
- [ ] Documentation updated if needed
- [x] No secrets committed