### PR TITLE
fix: Handle promise rejections in ChatContainer on websocket failures

### DIFF
--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback, KeyboardEvent } from "react";
 import { Send } from "lucide-react";
 
 type ChatInputProps = {
-  onSendMessage: (message: string) => void;
+  onSendMessage: (message: string) => void | Promise<void>;
   onInputChange?: () => void;
   onInputBlur?: () => void;
   onInputSubmit?: () => void;
@@ -23,7 +23,16 @@ export function ChatInput({
   const handleSend = useCallback(() => {
     const trimmed = text.trim();
     if (!trimmed || disabled) return;
-    onSendMessage(trimmed);
+    
+    try {
+      const result = onSendMessage(trimmed);
+      if (result instanceof Promise) {
+        result.catch((err) => console.error("Failed to send message:", err));
+      }
+    } catch (err) {
+      console.error("Failed to send message:", err);
+    }
+    
     setText("");
     onInputSubmit?.();
   }, [text, disabled, onSendMessage, onInputSubmit]);

--- a/frontend/src/hooks/useChat.ts
+++ b/frontend/src/hooks/useChat.ts
@@ -44,69 +44,73 @@ export function useChat({ roomId, token }: UseChatOptions) {
   const knownUsersRef = useRef<Set<number>>(new Set());
 
   const onMessage = useCallback(async (data: unknown) => {
-    const msg = data as Record<string, unknown>;
-    if (msg.type === "new_message") {
-      let plaintext = msg.message as string;
-      const senderId = msg.user_id as number;
-      const myId = localUserIdRef.current;
-      let matchedLocalId: string | null = null;
+    try {
+      const msg = data as Record<string, unknown>;
+      if (msg.type === "new_message") {
+        let plaintext = msg.message as string;
+        const senderId = msg.user_id as number;
+        const myId = localUserIdRef.current;
+        let matchedLocalId: string | null = null;
 
-      if (plaintext.startsWith("{")) {
-        try {
-          const payload = JSON.parse(plaintext);
-          if (payload.ciphertexts) {
-            matchedLocalId = payload.local_id;
-            if (senderId === myId) {
-              setMessages((prev) => {
-                const last = prev[prev.length - 1];
-                if (last && last.id === matchedLocalId) {
-                  return prev.map((m) =>
-                    m.id === matchedLocalId
-                      ? {
-                          ...m,
-                          id: `msg_${messageIdRef.current + 1}`,
-                          username: msg.username as string,
-                        }
-                      : m,
-                  );
-                }
-                return prev;
-              });
-              return;
-            } else if (
-              myId &&
-              payload.ciphertexts[myId] &&
-              sharedKeysRef.current[senderId]
-            ) {
-              const { ciphertext, iv } = payload.ciphertexts[myId];
-              plaintext = await decryptMessage(
-                ciphertext,
-                iv,
-                sharedKeysRef.current[senderId],
-              );
-            } else {
-              plaintext = "[Encrypted message - key not found]";
+        if (plaintext.startsWith("{")) {
+          try {
+            const payload = JSON.parse(plaintext);
+            if (payload.ciphertexts) {
+              matchedLocalId = payload.local_id;
+              if (senderId === myId) {
+                setMessages((prev) => {
+                  const last = prev[prev.length - 1];
+                  if (last && last.id === matchedLocalId) {
+                    return prev.map((m) =>
+                      m.id === matchedLocalId
+                        ? {
+                            ...m,
+                            id: `msg_${messageIdRef.current + 1}`,
+                            username: msg.username as string,
+                          }
+                        : m,
+                    );
+                  }
+                  return prev;
+                });
+                return;
+              } else if (
+                myId &&
+                payload.ciphertexts[myId] &&
+                sharedKeysRef.current[senderId]
+              ) {
+                const { ciphertext, iv } = payload.ciphertexts[myId];
+                plaintext = await decryptMessage(
+                  ciphertext,
+                  iv,
+                  sharedKeysRef.current[senderId],
+                );
+              } else {
+                plaintext = "[Encrypted message - key not found]";
+              }
             }
+          } catch {
+            // Fallback to plaintext if JSON parse fails
           }
-        } catch {
-          // Fallback to plaintext if JSON parse fails
         }
-      }
 
-      setMessages((prev) => {
-        messageIdRef.current += 1;
-        return [
-          ...prev,
-          {
-            id: `msg_${messageIdRef.current}`,
-            username: msg.username as string,
-            user_id: msg.user_id as number,
-            message: msg.message as string,
-            timestamp: msg.created_at ? new Date(msg.created_at as string).toLocaleTimeString() : new Date().toLocaleTimeString(),
-            created_at: msg.created_at as string | undefined,
-          },
-        ];
-      });
+        setMessages((prev) => {
+          messageIdRef.current += 1;
+          return [
+            ...prev,
+            {
+              id: `msg_${messageIdRef.current}`,
+              username: msg.username as string,
+              user_id: msg.user_id as number,
+              message: plaintext,
+              timestamp: msg.created_at ? new Date(msg.created_at as string).toLocaleTimeString() : new Date().toLocaleTimeString(),
+              created_at: msg.created_at as string | undefined,
+            },
+          ];
+        });
+      }
+    } catch (err) {
+      console.error("Error processing incoming message", err);
     }
   }, []);
 
@@ -166,7 +170,7 @@ export function useChat({ roomId, token }: UseChatOptions) {
         }
       };
       
-      handleMsg();
+      handleMsg().catch((err) => console.error("Error handling websocket message:", err));
     }
   }, [ws.lastMessage, typing, ws]);
 


### PR DESCRIPTION
## Summary
Resolves an issue where a failed websocket connection or missing encryption keys would result in unhandled promise rejections. It gracefully catches and logs errors when sending messages, deriving cryptographic keys, or decrypting incoming messages.

## Related Issue
Closes #567

## Changes Made
- Updated `ChatInputProps` type definition to allow `onSendMessage` to return `void | Promise<void>`.
- Wrapped `onSendMessage` in `ChatInput.tsx` with a `try/catch` and added an explicit `.catch()` for unhandled promise rejections.
- Added `.catch(console.error)` to the asynchronous `handleMsg` invocation inside the `useChat.ts` websocket effect.
- Wrapped the entire incoming `onMessage` parsing logic in `useChat.ts` in a `try/catch` to prevent unhandled decryption errors.
- Fixed a bug where successfully decrypted messages were being ignored in favor of their original ciphertexts.

## Testing
- [x] Tested manually 
- [ ] Add new unit/integration test
- [x] verified existing test still pass

## Screenshots
*(N/A - Background logic and error handling changes only)*

## Checklist
- [ ] Tests added or updated
- [ ] Documentation updated if needed
- [x] No secrets committed
