### PR TITLE
feat: implement send_bulk_email celery task for weekly summaries

### DIFF
--- a/backend/apps/notifications/signals.py
+++ b/backend/apps/notifications/signals.py
@@ -25,9 +25,9 @@ channel_layer = get_channel_layer()
 def _push_notification(notification: Notification):
     """Send a notification object to the user's WebSocket group."""
     data = NotificationSerializer(notification).data
-    group_name = f"notifications_{notification.recipient_id}" # type: ignore
+    group_name = f"notifications_{notification.recipient_id}"  # type: ignore
     try:
-        async_to_sync(channel_layer.group_send)( # type: ignore
+        async_to_sync(channel_layer.group_send)(  # type: ignore
             group_name,
             {
                 "type": "send_notification",  # matches consumer method
@@ -35,7 +35,7 @@ def _push_notification(notification: Notification):
             },
         )
         logger.info(
-            "Pushed notification id=%s to group=%s", notification.id, group_name # type: ignore
+            "Pushed notification id=%s to group=%s", notification.id, group_name  # type: ignore
         )
     except Exception as exc:
         logger.error("Failed to push notification: %s", exc)
@@ -45,14 +45,14 @@ def _push_notification(notification: Notification):
         url = "/"
         if notification.notif_type == "badge":
             url = "/profile"
-        elif notification.meta and "contribution_id" in notification.meta: # type: ignore
-            url = f"/contributions/{notification.meta['contribution_id']}" # type: ignore
-            
-        send_web_push_notification.delay( # type: ignore
-            user_id=notification.recipient_id, # type: ignore
+        elif notification.meta and "contribution_id" in notification.meta:  # type: ignore
+            url = f"/contributions/{notification.meta['contribution_id']}"  # type: ignore
+
+        send_web_push_notification.delay(  # type: ignore
+            user_id=notification.recipient_id,  # type: ignore
             title=notification.title,
             message=notification.message,
-            url=url
+            url=url,
         )
     except Exception as exc:
         logger.error("Failed to enqueue web push notification: %s", exc)
@@ -90,7 +90,7 @@ def on_badge_awarded(sender, instance, created, **kwargs):
     from celery import current_app
 
     current_app.send_task(
-        "tasks.send_bulk_email",
+        "apps.notifications.tasks.send_bulk_email",
         kwargs={
             "payload": {
                 "template_id": "badge_earned_email",

--- a/backend/apps/notifications/tasks.py
+++ b/backend/apps/notifications/tasks.py
@@ -1,8 +1,12 @@
 import json
-from celery import shared_task # type: ignore
+
+from celery import shared_task  # type: ignore
 from django.conf import settings
-from pywebpush import webpush, WebPushException # type: ignore
+from django.core.mail import send_mail
+from pywebpush import WebPushException, webpush  # type: ignore
+
 from .models import PushSubscription
+
 
 @shared_task(bind=True, max_retries=3, default_retry_delay=60)
 def send_web_push_notification(self, user_id, title, message, url=None):
@@ -15,7 +19,7 @@ def send_web_push_notification(self, user_id, title, message, url=None):
 
     vapid_private_key = getattr(settings, "VAPID_PRIVATE_KEY", None)
     vapid_admin_email = getattr(settings, "VAPID_ADMIN_EMAIL", None)
-    
+
     if not vapid_private_key or not vapid_admin_email:
         # VAPID not configured
         return
@@ -34,14 +38,11 @@ def send_web_push_notification(self, user_id, title, message, url=None):
             webpush(
                 subscription_info={
                     "endpoint": sub.endpoint,
-                    "keys": {
-                        "p256dh": sub.p256dh,
-                        "auth": sub.auth
-                    }
+                    "keys": {"p256dh": sub.p256dh, "auth": sub.auth},
                 },
                 data=payload,
                 vapid_private_key=vapid_private_key,
-                vapid_claims={"sub": vapid_admin_email}
+                vapid_claims={"sub": vapid_admin_email},
             )
         except WebPushException as ex:
             # If the endpoint is no longer valid (e.g. 410 Gone, or 404 Not Found),
@@ -53,3 +54,45 @@ def send_web_push_notification(self, user_id, title, message, url=None):
                 pass
         except Exception:
             pass
+
+
+@shared_task(bind=True, max_retries=3, default_retry_delay=60)
+def send_bulk_email(self, payload):
+    """
+    Sends bulk emails based on payload data.
+    """
+    template_id = payload.get("template_id")
+    recipients = payload.get("recipients", [])
+    data = payload.get("data", {})
+
+    if not recipients:
+        return
+
+    subject = "Open Source Contribution Atelier Update"
+    message = "You have an update from OSCA."
+
+    if template_id == "weekly_progress_summary":
+        subject = "Your Weekly Progress Summary"
+        message = (
+            f"Hi {data.get('username')},\n\n"
+            f"Here is your progress over the last 7 days:\n"
+            f"- Lessons completed: {data.get('lessons_completed', 0)}\n"
+            f"- XP earned: {data.get('xp_earned', 0)}\n"
+            f"- Badges earned: {data.get('badges_earned', 0)}\n"
+        )
+        if data.get("badge_names"):
+            badges_str = ", ".join(data["badge_names"])
+            message += f"- New badges: {badges_str}\n"
+
+        message += "\nKeep up the great work!\n"
+
+    try:
+        send_mail(
+            subject=subject,
+            message=message,
+            from_email=getattr(settings, "DEFAULT_FROM_EMAIL", "noreply@atelier.dev"),
+            recipient_list=recipients,
+            fail_silently=False,
+        )
+    except Exception as exc:
+        raise self.retry(exc=exc)

--- a/backend/apps/progress/tasks.py
+++ b/backend/apps/progress/tasks.py
@@ -1,16 +1,18 @@
-from celery import shared_task # type: ignore
+from datetime import timedelta
+
+from apps.progress.models import LessonProgress, UserBadge
+from celery import current_app  # type: ignore
+from celery import shared_task  # type: ignore
 from django.contrib.auth import get_user_model
 from django.utils import timezone
-from datetime import timedelta
-from apps.progress.models import LessonProgress, UserBadge
-from celery import current_app # type: ignore
 
 User = get_user_model()
+
 
 @shared_task
 def send_weekly_progress_summary():
     """
-    Celery cron task to calculate learning progress over the past 7 days 
+    Celery cron task to calculate learning progress over the past 7 days
     for each active user, and dispatch an email summary.
     """
     seven_days_ago = timezone.now() - timedelta(days=7)
@@ -21,16 +23,13 @@ def send_weekly_progress_summary():
     for user in users:
         # Get progress in the last 7 days
         recent_progress = LessonProgress.objects.filter(
-            user=user, 
-            updated_at__gte=seven_days_ago, 
-            completed=True
+            user=user, updated_at__gte=seven_days_ago, completed=True
         )
-        
+
         recent_badges = UserBadge.objects.filter(
-            user=user, 
-            earned_at__gte=seven_days_ago
+            user=user, earned_at__gte=seven_days_ago
         )
-        
+
         lessons_completed = recent_progress.count()
         xp_earned = sum(progress.score for progress in recent_progress)
         badges_earned = recent_badges.count()
@@ -46,14 +45,14 @@ def send_weekly_progress_summary():
                     "xp_earned": xp_earned,
                     "badges_earned": badges_earned,
                     "badge_names": badge_names,
-                }
+                },
             }
-            
+
             # Dispatch email using the existing bulk email worker
             current_app.send_task(
-                "tasks.send_bulk_email",
-                kwargs={"payload": payload}
+                "apps.notifications.tasks.send_bulk_email", kwargs={"payload": payload}
             )
+
 
 @shared_task
 def evaluate_user_badges_task(user_id):

--- a/backend/apps/progress/test_weekly_summary.py
+++ b/backend/apps/progress/test_weekly_summary.py
@@ -1,41 +1,44 @@
-import pytest
-from django.contrib.auth import get_user_model
-from django.utils import timezone
 from datetime import timedelta
 from unittest.mock import patch
 
+import pytest
 from apps.content.models import Lesson
-from apps.progress.models import LessonProgress, Badge, UserBadge
+from apps.progress.models import Badge, LessonProgress, UserBadge
 from apps.progress.tasks import send_weekly_progress_summary
+from django.contrib.auth import get_user_model
+from django.utils import timezone
 
 User = get_user_model()
+
 
 @pytest.fixture
 def mock_users():
     u1 = User.objects.create_user(username="active_user", email="active@example.com")
-    u2 = User.objects.create_user(username="inactive_user", email="inactive@example.com")
+    u2 = User.objects.create_user(
+        username="inactive_user", email="inactive@example.com"
+    )
     return u1, u2
+
 
 @pytest.fixture
 def mock_lesson():
     return Lesson.objects.create(
-        slug="test-lesson",
-        title="Test Lesson",
-        difficulty="beginner"
+        slug="test-lesson", title="Test Lesson", difficulty="beginner"
     )
+
 
 @pytest.fixture
 def mock_badge():
-    return Badge.objects.create(
-        name="Test Badge",
-        slug="test-badge"
-    )
+    return Badge.objects.create(name="Test Badge", slug="test-badge")
+
 
 @pytest.mark.django_db
 @patch("apps.progress.tasks.current_app.send_task")
-def test_send_weekly_progress_summary_active_user(mock_send_task, mock_users, mock_lesson, mock_badge):
+def test_send_weekly_progress_summary_active_user(
+    mock_send_task, mock_users, mock_lesson, mock_badge
+):
     """
-    Test that an active user gets an email with correct progress aggregated 
+    Test that an active user gets an email with correct progress aggregated
     for the last 7 days.
     """
     active_user, inactive_user = mock_users
@@ -49,7 +52,7 @@ def test_send_weekly_progress_summary_active_user(mock_send_task, mock_users, mo
         score=20,
         # Default auto_now will be now
     )
-    
+
     # Create badge within last 7 days for active user
     UserBadge.objects.create(
         user=active_user,
@@ -63,19 +66,20 @@ def test_send_weekly_progress_summary_active_user(mock_send_task, mock_users, mo
 
     # Verify the payload
     bulk_email_calls = [
-        call for call in mock_send_task.call_args_list 
-        if call.args[0] == "tasks.send_bulk_email"
+        call
+        for call in mock_send_task.call_args_list
+        if call.args[0] == "apps.notifications.tasks.send_bulk_email"
     ]
     assert len(bulk_email_calls) == 1
-    
+
     call_kwargs = bulk_email_calls[0].kwargs
     task_kwargs = call_kwargs.get("kwargs", {})
     payload = task_kwargs.get("payload")
-    
+
     assert payload is not None
     assert payload["template_id"] == "weekly_progress_summary"
     assert payload["recipients"] == [active_user.email]
-    
+
     data = payload["data"]
     assert data["username"] == "active_user"
     assert data["lessons_completed"] == 1
@@ -83,9 +87,12 @@ def test_send_weekly_progress_summary_active_user(mock_send_task, mock_users, mo
     assert data["badges_earned"] == 1
     assert data["badge_names"] == ["Test Badge"]
 
+
 @pytest.mark.django_db
 @patch("apps.progress.tasks.current_app.send_task")
-def test_send_weekly_progress_summary_inactive_user(mock_send_task, mock_users, mock_lesson, mock_badge):
+def test_send_weekly_progress_summary_inactive_user(
+    mock_send_task, mock_users, mock_lesson, mock_badge
+):
     """
     Test that users with no activity (or activity outside 7 days) do not get an email.
     """
@@ -93,7 +100,7 @@ def test_send_weekly_progress_summary_inactive_user(mock_send_task, mock_users, 
 
     # Create progress OLDER than 7 days
     old_date = timezone.now() - timedelta(days=10)
-    
+
     with patch("django.utils.timezone.now", return_value=old_date):
         lp = LessonProgress.objects.create(
             user=inactive_user,
@@ -116,7 +123,8 @@ def test_send_weekly_progress_summary_inactive_user(mock_send_task, mock_users, 
 
     # Should not send any bulk emails since the progress is 10 days old
     bulk_email_calls = [
-        call for call in mock_send_task.call_args_list 
-        if call.args and call.args[0] == "tasks.send_bulk_email"
+        call
+        for call in mock_send_task.call_args_list
+        if call.args and call.args[0] == "apps.notifications.tasks.send_bulk_email"
     ]
     assert len(bulk_email_calls) == 0


### PR DESCRIPTION
## Summary
Implements the missing `send_bulk_email` Celery task in `notifications/tasks.py` to handle email dispatching for weekly progress summaries, and corrects the broken task references.

## Related Issue
Closes #575

## Changes Made
- Added `send_bulk_email` task in `notifications/tasks.py` using Django's `send_mail`.
- Updated `current_app.send_task` paths in `progress/tasks.py` and `notifications/signals.py` to use fully qualified `apps.notifications.tasks.send_bulk_email`.
- Updated `test_weekly_summary.py` assertions to match the corrected task path.

## Testing
- [ ] Tested manually 
- [x] verified existing test still pass

## Checklist
- [x] Tests added or updated
- [x] Documentation updated if needed
- [x] No secrets committed
