### PR TITLE
feat: Implement fuzzy searching in Search API

### DIFF
--- a/backend/apps/search/migrations/0002_trigram_extension.py
+++ b/backend/apps/search/migrations/0002_trigram_extension.py
@@ -1,0 +1,22 @@
+import django.contrib.postgres.indexes
+import django.contrib.postgres.operations
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("search", "0001_initial"),
+    ]
+
+    operations = [
+        django.contrib.postgres.operations.TrigramExtension(),
+        migrations.AddIndex(
+            model_name="searchdocument",
+            index=django.contrib.postgres.indexes.GinIndex(
+                fields=["title"],
+                name="trigram_title_gin_idx",
+                opclasses=["gin_trgm_ops"],
+            ),
+        ),
+    ]

--- a/backend/apps/search/models.py
+++ b/backend/apps/search/models.py
@@ -29,6 +29,11 @@ class SearchDocument(models.Model):
         # Fast full-text lookups
         indexes = [
             GinIndex(fields=["search_vector"], name="search_vector_gin_idx"),
+            GinIndex(
+                fields=["title"],
+                name="trigram_title_gin_idx",
+                opclasses=["gin_trgm_ops"],
+            ),
         ]
         # Prevent duplicate index entries for the same object
         unique_together = ("content_type", "object_id")


### PR DESCRIPTION
## Summary
Enabled PostgreSQL Trigram Similarity for fuzzy searching in the Search API.

## Related Issue
Closes #579

## Changes Made
- Created a new migration (`0002_trigram_extension.py`) to install the `TrigramExtension` (`pg_trgm`) in PostgreSQL.
- Added a `GinIndex` with the `gin_trgm_ops` operator class to the `title` field on the `SearchDocument` model to optimize trigram similarity queries and prevent full table scans.

## Testing
- [x] Tested manually 
- [ ] Add new unit/integration test
- [x] verified existing test still pass

## Screenshots
N/A (Backend only implementation)

## Checklist
- [x] Tests added or updated (Existing typo-tolerance tests in `test_typo_tolerance_trigram` now execute correctly)
- [ ] Documentation updated if needed
- [x] No secrets committed
