### PR TITLE
fix: prevent duplicate badge notifications generation

### DIFF
--- a/backend/apps/notifications/signals.py
+++ b/backend/apps/notifications/signals.py
@@ -64,7 +64,7 @@ def _push_notification(notification: Notification):
 from apps.progress.models import UserBadge
 
 
-@receiver(post_save, sender=UserBadge)
+@receiver(post_save, sender=UserBadge, dispatch_uid="on_badge_awarded_notification")
 def on_badge_awarded(sender, instance, created, **kwargs):
     if not created:
         return


### PR DESCRIPTION
## Summary
Fixes the bug where identical notifications are generated for a single event (like earning a badge) due to Django signals registering multiple times.

## Related Issue
Closes #583

## Changes Made
- Added a unique `dispatch_uid` to the `on_badge_awarded` signal receiver in `backend/apps/notifications/signals.py` to guarantee it registers only once.

## Testing
- [x] Tested manually
- [ ] Add new unit/integration test
- [x] verified existing test still pass

## Screenshots
N/A

## Checklist
- [ ] Tests added or updated
- [ ] Documentation updated if needed
- [x] No secrets committed
