### PR TITLE
 Feat #427 add health check endpoint for PostgreSQL and Redis

### DIFF
--- a/backend/config/health_view.py
+++ b/backend/config/health_view.py
@@ -1,0 +1,60 @@
+import os
+from typing import Any
+
+import redis
+from django.conf import settings
+from django.db import connections
+from django.db.utils import OperationalError
+from django.http import JsonResponse, HttpRequest
+
+
+def _check_postgres() -> dict[str, Any]:
+    engine = settings.DATABASES["default"].get("ENGINE", "")
+    if "postgresql" not in engine and "postgis" not in engine:
+        return {
+            "status": "not_configured",
+            "detail": "PostgreSQL is not the active database engine",
+        }
+
+    try:
+        conn = connections["default"]
+        conn.ensure_connection()
+        with conn.cursor() as cursor:
+            cursor.execute("SELECT 1")
+        return {"status": "ok"}
+    except OperationalError as exc:
+        return {"status": "error", "detail": str(exc)}
+
+
+def _check_redis() -> dict[str, Any]:
+    redis_url = os.getenv("REDIS_URL") or getattr(settings, "CELERY_BROKER_URL", "")
+    if not redis_url:
+        return {"status": "not_configured", "detail": "REDIS_URL is not set"}
+
+    try:
+        client = redis.from_url(redis_url, socket_connect_timeout=2, socket_timeout=2)
+        client.ping()
+        return {"status": "ok"}
+    except Exception as exc:
+        return {"status": "error", "detail": str(exc)}
+
+
+def _overall_status(services: dict[str, dict[str, Any]]) -> tuple[str, int]:
+    if any(service["status"] == "error" for service in services.values()):
+        return "unhealthy", 503
+    if all(service["status"] == "ok" for service in services.values()):
+        return "healthy", 200
+    return "degraded", 200
+
+
+def health_view(request: HttpRequest) -> JsonResponse:
+    """Returns connection status for PostgreSQL and Redis."""
+    services = {
+        "postgres": _check_postgres(),
+        "redis": _check_redis(),
+    }
+    overall, status_code = _overall_status(services)
+    return JsonResponse(
+        {"status": overall, "services": services},
+        status=status_code,
+    )

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -5,10 +5,12 @@ from django.views.decorators.csrf import csrf_exempt
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 from graphene_django.views import GraphQLView
 
+from .health_view import health_view
 from .version_view import version_view
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("health/", health_view, name="health"),
     path("api/version/", version_view, name="version"),
     path("api/leaderboard/", LeaderboardView.as_view(), name="leaderboard"),
     path("api/auth/", include("apps.accounts.urls")),

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,0 +1,167 @@
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.test import RequestFactory
+
+from config.health_view import health_view
+
+
+@pytest.fixture
+def request_factory():
+    return RequestFactory()
+
+
+def _payload(response):
+    return json.loads(response.content)
+
+
+class TestHealthEndpoint:
+    def test_returns_json_response(self, request_factory):
+        with (
+            patch("config.health_view._check_postgres", return_value={"status": "ok"}),
+            patch("config.health_view._check_redis", return_value={"status": "ok"}),
+        ):
+            response = health_view(request_factory.get("/health/"))
+        assert response.status_code == 200
+
+    def test_response_shape(self, request_factory):
+        with (
+            patch("config.health_view._check_postgres", return_value={"status": "ok"}),
+            patch("config.health_view._check_redis", return_value={"status": "ok"}),
+        ):
+            response = health_view(request_factory.get("/health/"))
+        payload = _payload(response)
+        assert "status" in payload
+        assert "services" in payload
+        assert "postgres" in payload["services"]
+        assert "redis" in payload["services"]
+
+    def test_healthy_when_postgres_and_redis_ok(self, request_factory):
+        with (
+            patch(
+                "config.health_view._check_postgres",
+                return_value={"status": "ok"},
+            ),
+            patch(
+                "config.health_view._check_redis",
+                return_value={"status": "ok"},
+            ),
+        ):
+            response = health_view(request_factory.get("/health/"))
+
+        assert response.status_code == 200
+        assert _payload(response)["status"] == "healthy"
+
+    def test_unhealthy_when_postgres_fails(self, request_factory):
+        with (
+            patch(
+                "config.health_view._check_postgres",
+                return_value={"status": "error", "detail": "connection refused"},
+            ),
+            patch(
+                "config.health_view._check_redis",
+                return_value={"status": "ok"},
+            ),
+        ):
+            response = health_view(request_factory.get("/health/"))
+
+        assert response.status_code == 503
+        assert _payload(response)["status"] == "unhealthy"
+
+    def test_unhealthy_when_redis_fails(self, request_factory):
+        with (
+            patch(
+                "config.health_view._check_postgres",
+                return_value={"status": "ok"},
+            ),
+            patch(
+                "config.health_view._check_redis",
+                return_value={"status": "error", "detail": "connection refused"},
+            ),
+        ):
+            response = health_view(request_factory.get("/health/"))
+
+        assert response.status_code == 503
+        assert _payload(response)["status"] == "unhealthy"
+
+    def test_degraded_when_services_not_configured(self, request_factory):
+        with (
+            patch(
+                "config.health_view._check_postgres",
+                return_value={
+                    "status": "not_configured",
+                    "detail": "PostgreSQL is not the active database engine",
+                },
+            ),
+            patch(
+                "config.health_view._check_redis",
+                return_value={"status": "not_configured", "detail": "REDIS_URL is not set"},
+            ),
+        ):
+            response = health_view(request_factory.get("/health/"))
+
+        assert response.status_code == 200
+        assert _payload(response)["status"] == "degraded"
+
+
+class TestPostgresCheck:
+    def test_reports_not_configured_for_non_postgres_engine(self):
+        from config.health_view import _check_postgres
+
+        with patch("config.health_view.settings") as mock_settings:
+            mock_settings.DATABASES = {
+                "default": {"ENGINE": "django.db.backends.sqlite3"}
+            }
+            result = _check_postgres()
+
+        assert result["status"] == "not_configured"
+
+    def test_reports_ok_when_query_succeeds(self):
+        from config.health_view import _check_postgres
+
+        mock_cursor = MagicMock()
+        mock_cursor.__enter__.return_value = mock_cursor
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+
+        with (
+            patch("config.health_view.settings") as mock_settings,
+            patch("config.health_view.connections") as mock_connections,
+        ):
+            mock_settings.DATABASES = {
+                "default": {"ENGINE": "django.db.backends.postgresql"}
+            }
+            mock_connections.__getitem__.return_value = mock_conn
+            result = _check_postgres()
+
+        assert result == {"status": "ok"}
+        mock_conn.ensure_connection.assert_called_once()
+        mock_cursor.execute.assert_called_once_with("SELECT 1")
+
+
+class TestRedisCheck:
+    def test_reports_not_configured_when_url_missing(self):
+        from config.health_view import _check_redis
+
+        with (
+            patch("config.health_view.os.getenv", return_value=""),
+            patch("config.health_view.settings.CELERY_BROKER_URL", ""),
+        ):
+            result = _check_redis()
+
+        assert result["status"] == "not_configured"
+
+    def test_reports_ok_when_ping_succeeds(self):
+        from config.health_view import _check_redis
+
+        mock_client = MagicMock()
+
+        with (
+            patch("config.health_view.os.getenv", return_value="redis://127.0.0.1:6379/0"),
+            patch("config.health_view.redis.from_url", return_value=mock_client),
+        ):
+            result = _check_redis()
+
+        assert result == {"status": "ok"}
+        mock_client.ping.assert_called_once()


### PR DESCRIPTION
Feat #427
## Summary
Adds a public `GET /health/` endpoint that reports PostgreSQL and Redis connection status for load balancers, Docker healthchecks, and ops monitoring.


## Changes Made
- Added `backend/config/health_view.py` with Postgres (`SELECT 1`) and Redis (`PING`) connectivity checks
- Registered the route at `/health/` in `backend/config/urls.py`
- Added `backend/tests/test_health.py` covering healthy, unhealthy, degraded, and not-configured states

**Response shape:**
```json
{
  "status": "healthy",
  "services": {
    "postgres": { "status": "ok" },
    "redis": { "status": "ok" }
  }
}
```

**Status codes:**
- `200` + `healthy` — both services connected
- `200` + `degraded` — services not configured (e.g. local SQLite dev) but no connection errors
- `503` + `unhealthy` — one or more services failed to connect