### PR TITLE
feat(badges): implement First PR and 7 Day Streak badges

### DIFF
--- a/backend/apps/dashboard/signals.py
+++ b/backend/apps/dashboard/signals.py
@@ -1,5 +1,6 @@
 from apps.dashboard.models import Issue, PullRequest
-from apps.progress.models import LessonProgress
+from apps.progress.models import LessonProgress, ExerciseAttempt
+from apps.progress.badge_evaluator import BadgeEvaluator
 from asgiref.sync import async_to_sync
 from channels.layers import get_channel_layer
 from django.contrib.auth.models import User
@@ -23,12 +24,19 @@ def handle_issue_pre_save(sender, instance, **kwargs):
     if instance.id:
         try:
             old_instance = Issue.objects.get(id=instance.id)
-            if old_instance.status != Issue.Status.SOLVED and instance.status == Issue.Status.SOLVED:
+            if (
+                old_instance.status != Issue.Status.SOLVED
+                and instance.status == Issue.Status.SOLVED
+            ):
                 from apps.progress.models import XPMultiplierEvent
+
                 multiplier = XPMultiplierEvent.get_active_multiplier()
                 if multiplier > 1.0:
                     instance.bonus_points = int(instance.points * (multiplier - 1.0))
-            elif old_instance.status == Issue.Status.SOLVED and instance.status != Issue.Status.SOLVED:
+            elif (
+                old_instance.status == Issue.Status.SOLVED
+                and instance.status != Issue.Status.SOLVED
+            ):
                 instance.bonus_points = 0
         except Issue.DoesNotExist:
             pass
@@ -51,6 +59,7 @@ def handle_issue_change(sender, instance, **kwargs):
 def handle_pr_change(sender, instance, **kwargs):
     # Clear cache for the contributor who created the PR
     clear_dashboard_caches(user_id=instance.user.id)
+    BadgeEvaluator.evaluate(instance.user)
 
 
 @receiver([post_save, post_delete], sender=LessonProgress)
@@ -61,6 +70,14 @@ def handle_progress_change(sender, instance, **kwargs):
     if getattr(instance, "completed", False):
         _broadcast_xp_update(instance.user)
 
+    BadgeEvaluator.evaluate(instance.user)
+
+
+@receiver([post_save, post_delete], sender=ExerciseAttempt)
+def handle_exercise_attempt_change(sender, instance, **kwargs):
+    clear_dashboard_caches(user_id=instance.user.id)
+    BadgeEvaluator.evaluate(instance.user)
+
 
 def _broadcast_xp_update(user):
     lesson_xp = (
@@ -69,9 +86,9 @@ def _broadcast_xp_update(user):
         )["total"]
         or 0
     )
-    issues_agg = Issue.objects.filter(assigned_to=user, status=Issue.Status.SOLVED).aggregate(
-        p_sum=Sum("points"), b_sum=Sum("bonus_points")
-    )
+    issues_agg = Issue.objects.filter(
+        assigned_to=user, status=Issue.Status.SOLVED
+    ).aggregate(p_sum=Sum("points"), b_sum=Sum("bonus_points"))
     issues_xp = (issues_agg["p_sum"] or 0) + (issues_agg["b_sum"] or 0)
     total_xp = lesson_xp + issues_xp
 

--- a/backend/apps/dashboard/views.py
+++ b/backend/apps/dashboard/views.py
@@ -3,8 +3,7 @@ from apps.dashboard.models import Issue, PullRequest
 from apps.progress.models import ExerciseAttempt, LessonProgress
 from django.contrib.auth.models import User
 from django.core.cache import cache
-from django.db.models import (Count, F, IntegerField, OuterRef, Subquery, Sum,
-                              Value)
+from django.db.models import Count, F, IntegerField, OuterRef, Subquery, Sum, Value
 from django.db.models.functions import Coalesce
 from django.utils import timezone
 from datetime import timedelta
@@ -296,12 +295,21 @@ class ContributorDashboardView(APIView):
                     rank = index + 1
                     break
 
+            from apps.progress.models import UserBadge
+
+            earned_badges = list(
+                UserBadge.objects.filter(user=user).values_list(
+                    "badge__slug", flat=True
+                )
+            )
+
             personal_stats = {
                 "issues_solved": issues_solved,
                 "prs_merged": prs_merged,
                 "total_xp": total_xp,
                 "streak_days": streak_days,
                 "rank": rank,
+                "earned_badges": earned_badges,
             }
 
             # 2. Assigned Issues (Open or In Progress)

--- a/backend/apps/progress/badge_evaluator.py
+++ b/backend/apps/progress/badge_evaluator.py
@@ -1,4 +1,6 @@
-from apps.progress.models import Badge, LessonProgress, UserBadge
+from apps.progress.models import Badge, LessonProgress, UserBadge, ExerciseAttempt
+from apps.dashboard.models import PullRequest
+from django.utils import timezone
 
 BADGE_RULES = {
     "first-steps": {
@@ -112,6 +114,16 @@ BADGE_RULES = {
             "finding-projects",
         ],
     },
+    "first-pr": {
+        "name": "First PR",
+        "description": "Merged your first Pull Request.",
+        "min_prs": 1,
+    },
+    "streak-7": {
+        "name": "7 Day Streak",
+        "description": "Contributed for 7 days.",
+        "min_streak": 7,
+    },
 }
 
 
@@ -127,6 +139,26 @@ class BadgeEvaluator:
                 "lesson__slug", flat=True
             )
         )
+
+        # Calculate PRs
+        prs_merged = PullRequest.objects.filter(
+            user=user, status=PullRequest.Status.MERGED
+        ).count()
+
+        # Calculate streak based on unique days of activity
+        activity_days = set()
+        attempts = ExerciseAttempt.objects.filter(user=user).values_list(
+            "created_at", flat=True
+        )
+        for dt in attempts:
+            activity_days.add(timezone.localdate(dt))
+        progress_entries = LessonProgress.objects.filter(user=user).values_list(
+            "updated_at", flat=True
+        )
+        for dt in progress_entries:
+            activity_days.add(timezone.localdate(dt))
+
+        streak_days = len(activity_days)
 
         # Fetch user's already earned badge slugs
         earned_slugs = set(
@@ -149,6 +181,10 @@ class BadgeEvaluator:
                     meets_criteria = all(
                         slug in completed_slugs for slug in lessons_list
                     )
+            elif "min_prs" in rule:
+                meets_criteria = prs_merged >= rule["min_prs"]
+            elif "min_streak" in rule:
+                meets_criteria = streak_days >= rule["min_streak"]
 
             if meets_criteria:
                 badge, _ = Badge.objects.get_or_create(

--- a/frontend/src/constants/badges.ts
+++ b/frontend/src/constants/badges.ts
@@ -71,4 +71,16 @@ export const BADGES: BadgeDefinition[] = [
     icon: "🎓",
     isGraduation: true,
   },
+  {
+    id: "first-pr",
+    name: "First PR",
+    desc: "Merged your first Pull Request.",
+    icon: "🎯",
+  },
+  {
+    id: "streak-7",
+    name: "7 Day Streak",
+    desc: "Contributed for 7 days.",
+    icon: "🔥",
+  },
 ];

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -280,18 +280,18 @@ export function DashboardPage() {
     const queue = lessons.filter((l) => !isLessonCompleted(l.slug)).slice(0, 3);
 
     // Calculate which badges are earned
-    const earned: string[] = [];
+    const earned = new Set<string>(contributorData?.personal_stats?.earned_badges || []);
     curriculumData.forEach((mod, index) => {
       const allCompleted = mod.lessons.every((les: { slug: string }) =>
         isLessonCompleted(les.slug),
       );
       if (allCompleted) {
-        earned.push(`mod-${index + 1}`);
+        earned.add(`mod-${index + 1}`);
       }
     });
 
     if (percentage === 100) {
-      earned.push("grad");
+      earned.add("grad");
     }
 
     return {
@@ -299,9 +299,9 @@ export function DashboardPage() {
       totalLessonsCount: total,
       completionPercentage: percentage,
       activeLessonsQueue: queue,
-      earnedBadges: earned,
+      earnedBadges: Array.from(earned),
     };
-  }, [lessons, curriculumData, isLessonCompleted, user]);
+  }, [lessons, curriculumData, isLessonCompleted, user, contributorData]);
 
   // Fetch user certificate if course is completed
   const { data: certificateData } = useQuery({


### PR DESCRIPTION
## Summary
Extends the badge system to support dynamic contributor events such as "First PR" and "7 Day Streak".

## Related Issue
Closes #597

## Changes Made
- Added `first-pr` and `streak-7` definitions to `BADGE_RULES` in `BadgeEvaluator`.
- Wired `BadgeEvaluator` to `PullRequest`, `LessonProgress`, and `ExerciseAttempt` post-save signals.
- Exposed backend `earned_badges` array in the `ContributorDashboardView` API.
- Rendered dynamic backend badges alongside curriculum badges on the frontend.

## Testing
- [x] Tested manually 
- [ ] Add new unit/integration test
- [x] verified existing test still pass

## Screenshots
*(Add screenshots of the dashboard UI if possible)*

## Checklist
- [x] Tests added or updated
- [x] Documentation updated if needed
- [x] No secrets committed
