### PR TITLE
Fix webhook exponential backoff retry logic and statuses

### DIFF
--- a/backend/apps/webhooks/tasks.py
+++ b/backend/apps/webhooks/tasks.py
@@ -62,23 +62,23 @@ def deliver_webhook(self, delivery_id):
 
         if 200 <= response.status_code < 300:
             delivery.status = "success"
+        elif response.status_code == 429 or response.status_code >= 500:
+            # Trigger retry for rate limits and server errors
+            raise requests.exceptions.RequestException(
+                f"Recoverable error: {response.status_code}"
+            )
         else:
+            # 4xx errors (except 429) are client errors, do not retry
             delivery.status = "failed"
-            # We can decide if we want to retry on 5xx errors
-            if response.status_code >= 500:
-                raise requests.exceptions.RequestException(
-                    f"Server error: {response.status_code}"
-                )
 
     except requests.exceptions.RequestException as e:
-        delivery.status = "failed"
         delivery.response_body = str(e)[:2000]
-        delivery.save()
 
         # Retry with exponential backoff
         try:
-            self.retry(countdown=2**self.request.retries * 60)
+            self.retry(exc=e, countdown=2**self.request.retries * 60)
         except self.MaxRetriesExceededError:
+            delivery.status = "failed"
             logger.error(f"Max retries exceeded for webhook delivery {delivery.id}")
     finally:
         delivery.save()

--- a/backend/apps/webhooks/tests.py
+++ b/backend/apps/webhooks/tests.py
@@ -133,5 +133,43 @@ class TestWebhookDelivery:
         deliver_webhook(delivery.id)
 
         delivery.refresh_from_db()
+        assert delivery.status == "pending"
+        mock_retry.assert_called_once()
+
+    @patch("requests.post")
+    def test_retry_on_429(self, mock_post, endpoint):
+        from celery.exceptions import Retry
+
+        mock_response = MagicMock()
+        mock_response.status_code = 429
+        mock_response.text = "Too Many Requests"
+        mock_post.return_value = mock_response
+
+        delivery = WebhookDelivery.objects.create(
+            endpoint=endpoint, event_type="test.event", payload={"foo": "bar"}
+        )
+
+        with pytest.raises(Retry):
+            deliver_webhook(delivery.id)
+
+        delivery.refresh_from_db()
+        assert delivery.status == "pending"
+        assert delivery.status_code == 429
+
+    @patch("requests.post")
+    @patch("apps.webhooks.tasks.deliver_webhook.retry")
+    def test_max_retries_exceeded(self, mock_retry, mock_post, endpoint):
+        import requests
+        from celery.exceptions import MaxRetriesExceededError
+
+        mock_post.side_effect = requests.exceptions.RequestException("Timeout")
+        mock_retry.side_effect = MaxRetriesExceededError()
+
+        delivery = WebhookDelivery.objects.create(
+            endpoint=endpoint, event_type="test.event", payload={"foo": "bar"}
+        )
+        deliver_webhook(delivery.id)
+
+        delivery.refresh_from_db()
         assert delivery.status == "failed"
         mock_retry.assert_called_once()


### PR DESCRIPTION
## Summary
Fixes the webhook exponential backoff delivery logic to accurately track retry states. Prevents the delivery status from being prematurely marked as "failed" when retries are still pending, and adds support for retrying on HTTP 429 (Too Many Requests).

## Related Issue
Closes #605

## Changes Made
- Updated `deliver_webhook` in `tasks.py` to leave delivery status as `"pending"` during intermediate retries.
- Delivery is only marked as `"failed"` upon unrecoverable 4xx client errors or after exhaustion via `MaxRetriesExceededError`.
- Included HTTP 429 in the retryable status codes block.
- Updated `self.retry()` to preserve the original exception context in Celery worker logs.
- Updated `test_retry_behavior` and added two new tests to verify pending statuses and 429 fallbacks.

## Testing
- [x] Tested manually 
- [x] Add new unit/integration test
- [x] verified existing test still pass

## Checklist
- [x] Tests added or updated
- [x] Documentation updated if needed
- [x] No secrets committed
