### PR TITLE
fix: Resolve 500 error when submitting invalid Sandbox code

### DIFF
--- a/backend/apps/sandbox/linter.py
+++ b/backend/apps/sandbox/linter.py
@@ -77,7 +77,7 @@ def lint_command(command: str) -> LintResult:
     # Use difflib for smart typo detection
     if sub_command not in COMMAND_RULES:
         suggestions = difflib.get_close_matches(
-            sub_command, COMMAND_RULES.keys(), n=1, cutoff=0.7
+            sub_command, list(COMMAND_RULES.keys()), n=1, cutoff=0.7
         )
         if suggestions:
             return LintResult(


### PR DESCRIPTION
## Summary
Resolves a 500 Server Error in the Sandbox verifier that occurred when a user submitted a Git command with a typo. 

## Related Issue
Closes #580

## Changes Made
- Cast `COMMAND_RULES.keys()` to a `list` before passing to `difflib.get_close_matches()` in `apps/sandbox/linter.py`. This prevents `TypeError: 'dict_keys' object is not subscriptable` in environments where dictionary views are not accepted as sequences.

## Testing
- [x] Tested manually
- [ ] Add new unit/integration test
- [ ] verified existing test still pass

## Screenshots
N/A

## Checklist
- [ ] Tests added or updated
- [ ] Documentation updated if needed
- [x] No secrets committed
