### PR TITLE
Fix markdown table parsing in MarkdownRenderer

### DIFF
--- a/frontend/src/components/ui/MarkdownRenderer.tsx
+++ b/frontend/src/components/ui/MarkdownRenderer.tsx
@@ -4,6 +4,38 @@ interface MarkdownRendererProps {
   content: string;
 }
 
+// Helper to parse markdown table rows, ignoring pipes inside backticks or escaped pipes.
+function splitTableRow(row: string): string[] {
+  let trimmed = row.trim();
+  if (trimmed.startsWith("|")) {
+    trimmed = trimmed.substring(1);
+  }
+  if (trimmed.endsWith("|") && !trimmed.endsWith("\\|")) {
+    trimmed = trimmed.substring(0, trimmed.length - 1);
+  }
+
+  const cells: string[] = [];
+  let currentCell = "";
+  let inCode = false;
+
+  for (let i = 0; i < trimmed.length; i++) {
+    const char = trimmed[i];
+    const prevChar = i > 0 ? trimmed[i - 1] : "";
+
+    if (char === "`" && prevChar !== "\\") {
+      inCode = !inCode;
+      currentCell += char;
+    } else if (char === "|" && !inCode && prevChar !== "\\") {
+      cells.push(currentCell.trim());
+      currentCell = "";
+    } else {
+      currentCell += char;
+    }
+  }
+  cells.push(currentCell.trim());
+  return cells;
+}
+
 export function MarkdownRenderer({ content }: MarkdownRendererProps) {
   // Helper to parse inline formats: bold, inline code, links
   const parseInline = (text: string): React.ReactNode[] => {
@@ -80,9 +112,7 @@ export function MarkdownRenderer({ content }: MarkdownRendererProps) {
           </div>
 
           <pre className="w-full overflow-x-auto p-4 bg-[#1a1510] text-[#ffebc2] border-4 border-black rounded-2xl font-mono text-sm shadow-card-sm dark:border-[#2e2924]">
-            <code className="block whitespace-pre">
-              {codeContent.trim()}
-            </code>
+            <code className="block whitespace-pre">{codeContent.trim()}</code>
           </pre>
         </div>,
       );
@@ -214,18 +244,11 @@ export function MarkdownRenderer({ content }: MarkdownRendererProps) {
 
       const rows: string[][] = [];
       while (index < lines.length && lines[index].trim().startsWith("|")) {
-        const rowCells = lines[index]
-          .split("|")
-          .map((cell) => cell.trim())
-          .filter((_, i, arr) => i > 0 && i < arr.length - 1); // exclude empty ends
-        rows.push(rowCells);
+        rows.push(splitTableRow(lines[index]));
         index++;
       }
 
-      const headerCells = headerLine
-        .split("|")
-        .map((cell) => cell.trim())
-        .filter((_, i, arr) => i > 0 && i < arr.length - 1);
+      const headerCells = splitTableRow(headerLine);
 
       blocks.push(
         <div


### PR DESCRIPTION
## Summary
Fixes a bug where complex markdown tables in the curriculum (such as those containing code blocks with pipes or escaped pipes) were rendering incorrectly. The renderer was erroneously splitting single cells or dropping valid edge cells.

## Related Issue
Closes #596

## Changes Made
- Added a `splitTableRow` helper function to `MarkdownRenderer` that correctly respects inline code blocks (`` ` ``) and escaped characters (`\`) when splitting by the pipe (`|`) delimiter.
- Updated table row and header parsing to use the new robust splitting logic.
- Prevented valid outer columns and empty edge cells from being unintentionally filtered out.

## Testing
- [x] Tested manually 
- [ ] Add new unit/integration test
- [x] verified existing test still pass

## Screenshots
N/A

## Checklist
- [ ] Tests added or updated
- [ ] Documentation updated if needed
- [x] No secrets committed
