### PR TITLE
feat: blend semantic embeddings with trigram similarity

### DIFF
--- a/backend/apps/content/semantic_search.py
+++ b/backend/apps/content/semantic_search.py
@@ -74,8 +74,35 @@ class SemanticSearchService:
         if query_vec is None:
             return []
 
-        scores = compute_similarity(query_vec[0], self._doc_embeddings)
-        indexed = sorted(enumerate(scores), key=lambda x: x[1], reverse=True)
+        embedding_scores = compute_similarity(
+            query_vec[0],
+            self._doc_embeddings,
+        )
+
+        combined_scores = []
+
+        for idx, embedding_score in enumerate(embedding_scores):
+            lesson = self.lessons[idx]
+
+            trigram_score = getattr(
+                lesson,
+                "trigram_similarity",
+                0.0,
+            )
+
+            # Blend semantic relevance with typo-tolerant lexical similarity.
+            final_score = (
+                embedding_score * 0.7
+                + float(trigram_score) * 0.3
+            )
+
+            combined_scores.append((idx, final_score))
+
+        indexed = sorted(
+            combined_scores,
+            key=lambda x: x[1],
+            reverse=True,
+        )
 
         results = []
         for idx, score in indexed:

--- a/backend/apps/content/views.py
+++ b/backend/apps/content/views.py
@@ -108,9 +108,16 @@ class SemanticSearchView(views.APIView):
             )
 
         # Apply multi-tenant filtering
-        lessons = Lesson.objects.filter(
-            embedding__isnull=False, organization=request.user.organization
-        ).prefetch_related("exercises")
+        lessons = (
+            Lesson.objects.filter(
+                embedding__isnull=False,
+                organization=request.user.organization,
+            )
+            .annotate(
+                trigram_similarity=TrigramSimilarity("title", query)
+            )
+            .prefetch_related("exercises")
+        )
         if not lessons.exists():
             return response.Response({"query": query, "results": []})
 


### PR DESCRIPTION
## Summary

Enhance the semantic search endpoint by blending PostgreSQL Trigram similarity with semantic embedding similarity to improve typo tolerance and result relevance.

## Related Issue

Closes #414

## Changes Made

* Added PostgreSQL `TrigramSimilarity` scoring to semantic search results.
* Annotated lessons with trigram similarity scores before ranking.
* Combined semantic embedding similarity and trigram similarity into a hybrid ranking score.
* Ranked results using:

  * 70% semantic embedding similarity
  * 30% trigram similarity
* Preserved the existing semantic search workflow and API response format.

## Testing

* [x] Tested manually
* [ ] Add new unit/integration test
* [ ] Verified existing tests still pass

### Verification

```bash
python -m compileall apps/content
```

Compilation completed successfully.

## Screenshots

N/A (Backend search enhancement)

## Checklist

* [ ] Tests added or updated
* [ ] Documentation updated if needed
* [x] No secrets committed
