### PR TITLE
fix(security): Harden Dockerfile against sensitive data exposure (docker:S6470)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,22 @@
+# Dependency directories
+node_modules
+.venv
+venv
+__pycache__
+
+# Build outputs
+dist
+build
+.pytest_cache
+
+# Git
+.git
+.gitignore
+
+# Environment files
+.env
+.env.*
+
+# Docker
+Dockerfile
+.dockerignore

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -5,7 +5,9 @@ WORKDIR /app
 COPY package.json package-lock.json* ./
 RUN npm ci
 
-COPY . .
+COPY index.html vite.config.ts tsconfig*.json tailwind.config.ts postcss.config.js eslint.config.js ./
+COPY public/ ./public/
+COPY src/ ./src/
 
 RUN npm run build
 


### PR DESCRIPTION
## Summary
Hardens the frontend `Dockerfile` by removing the overly permissive `COPY . .` command, addressing static analysis warning `docker:S6470`. Creates a `.dockerignore` in the project root to prevent sensitive host files (like `.env` and `.git`) from leaking into the build context.

## Related Issue
Closes #694

## Changes Made
- Created `.dockerignore` at the repository root with standard exclusions.
- Replaced recursive `COPY . .` in `frontend/Dockerfile` with explicit `COPY` instructions for required build configurations, `src/`, and `public/` directories.

## Testing
- [x] Tested manually 

## Checklist
- [x] No secrets committed
