### PR TITLE
feat(frontend): add reusable tooltip component

### DIFF
--- a/frontend/src/components/ui/CopyButton.tsx
+++ b/frontend/src/components/ui/CopyButton.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-
+import Tooltip from "./Tooltip";
 type CopyButtonProps = {
   text: string;
 };
@@ -22,12 +22,14 @@ export default function CopyButton({ text }: CopyButtonProps) {
   };
 
   return (
-    <button
-      type="button"
-      onClick={handleCopy}
-      className="rounded-lg border-2 border-black bg-surface-low px-3 py-1 text-xs font-black text-black shadow-card-sm hover:-translate-y-0.5 active:translate-y-0 transition-all cursor-pointer"
-    >
-      {copied ? "Copied!" : "Copy"}
-    </button>
+    <Tooltip content={copied ? "Copied!" : "Copy code"}>
+      <button
+        type="button"
+        onClick={handleCopy}
+        className="rounded-lg border-2 border-black bg-surface-low px-3 py-1 text-xs font-black text-black shadow-card-sm hover:-translate-y-0.5 active:translate-y-0 transition-all cursor-pointer"
+      >
+        {copied ? "Copied!" : "Copy"}
+      </button>
+    </Tooltip>
   );
 }

--- a/frontend/src/components/ui/Tooltip.tsx
+++ b/frontend/src/components/ui/Tooltip.tsx
@@ -1,0 +1,21 @@
+import { ReactNode } from "react";
+
+type TooltipProps = {
+  content: string;
+  children: ReactNode;
+};
+
+export default function Tooltip({ content, children }: TooltipProps) {
+  return (
+    <div className="relative inline-flex items-center group">
+      {children}
+
+      <div
+        role="tooltip"
+        className="absolute bottom-full left-1/2 mb-2 -translate-x-1/2 whitespace-nowrap rounded-md bg-black px-2 py-1 text-xs font-medium text-white opacity-0 transition-opacity duration-200 group-hover:opacity-100 group-focus-within:opacity-100 pointer-events-none z-50"
+      >
+        {content}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Fixes #570 by introducing a reusable Tooltip component that can be shared across the application.

### Changes Made

* Added a reusable `Tooltip` component at `frontend/src/components/ui/Tooltip.tsx`.
* Integrated the Tooltip into `CopyButton` so code-copy actions display a helpful tooltip.
* Kept the existing copy-to-clipboard functionality unchanged.
* Implemented the component using Tailwind CSS to match the project's current frontend stack.

### Testing

* ✅ Ran `npm run dev` successfully.
* ✅ Ran `npm run build` successfully.
* ✅ Verified the application compiles without TypeScript or build errors.
* ✅ Confirmed the Copy button continues to function correctly after the integration.
* ✅ Confirmed the Tooltip renders on hover for the Copy button.

Fixes #570
