### PR TITLE
fix(websocket): validate streaming connection parameters to prevent SSRF

### DIFF
--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -34,9 +34,24 @@ export function useWebSocket({
   onMessageRef.current = onMessage;
 
   const buildUrl = useCallback(() => {
-    if (!token) return url;
-    const separator = url.includes("?") ? "&" : "?";
-    return `${url}${separator}token=${encodeURIComponent(token)}`;
+    try {
+      const parsedUrl = new URL(url, window.location.origin);
+      if (parsedUrl.protocol !== "ws:" && parsedUrl.protocol !== "wss:") {
+        console.error("useWebSocket: Invalid protocol");
+        return null;
+      }
+      if (token) {
+        if (!/^[A-Za-z0-9\-_.]+$/.test(token)) {
+          console.error("useWebSocket: Invalid token format");
+          return null;
+        }
+        parsedUrl.searchParams.set("token", token);
+      }
+      return parsedUrl.toString();
+    } catch (e) {
+      console.error("useWebSocket: Invalid URL", e);
+      return null;
+    }
   }, [url, token]);
 
   const cleanup = useCallback(() => {
@@ -63,6 +78,10 @@ export function useWebSocket({
     }
 
     const wsUrl = buildUrl();
+    if (!wsUrl) {
+      setState((s) => ({ ...s, isConnected: false }));
+      return;
+    }
     const ws = new WebSocket(wsUrl);
 
     ws.onopen = () => {


### PR DESCRIPTION
## Summary
This PR addresses a security vulnerability (SSRF/Hijacking) in the `useWebSocket.ts` hook where streaming connection parameters were being constructed using unvalidated user-supplied values (SonarQube S8480).

## Related Issue
Closes #697

## Changes Made
- Wrapped the WebSocket URL construction logic inside a `try/catch` block and used the native `URL` API to strictly parse and validate provided connection URLs.
- Added explicit enforcement ensuring the protocol is exactly `ws:` or `wss:`.
- Added a format regex validation (`/^[A-Za-z0-9\-_.]+$/`) for connection tokens to prevent injection strings while allowing standard formats like JWTs.
- Handled query string building safely using `URLSearchParams.set()`.
- Added a fail-safe early return to the `connect()` function, halting the connection if URL validation fails.

## Testing
- [x] Tested manually 
- [ ] Add new unit/integration test
- [x] verified existing test still pass

## Screenshots
*N/A - backend/logic changes only*

## Checklist

- [ ] Tests added or updated
- [ ] Documentation updated if needed
- [x] No secrets committed
