### PR TITLE
feat: Implement dynamic lesson content fetching

### DIFF
--- a/frontend/src/hooks/useEarnedBadges.ts
+++ b/frontend/src/hooks/useEarnedBadges.ts
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import { useAuth } from "../features/auth/AuthContext";
 import { useQuery } from "@tanstack/react-query";
-import { fetchLessonsApi, Lesson } from "../lib/lessons";
+import { fetchLessonsApi, Lesson, buildModulesFromLessons } from "../lib/lessons";
 import { useUserProgress } from "./useUserProgress";
 
 export interface CurriculumModule {
@@ -15,18 +15,6 @@ export function useEarnedBadges() {
   const { user } = useAuth();
   const { isLessonCompleted } = useUserProgress();
 
-  const { data: curriculumData = [], isLoading: isCurriculumLoading } =
-    useQuery<CurriculumModule[]>({
-      queryKey: ["curriculum"],
-      queryFn: async () => {
-        const res = await fetch("/content/curriculum.json");
-        if (!res.ok) throw new Error("Failed to fetch curriculum");
-        const data = await res.json();
-        return data.modules || [];
-      },
-      enabled: !!user && !user.is_staff,
-    });
-
   const { data: lessons = [], isLoading: isLessonsLoading } = useQuery<
     Lesson[]
   >({
@@ -34,6 +22,8 @@ export function useEarnedBadges() {
     queryFn: fetchLessonsApi,
     enabled: !!user && !user.is_staff,
   });
+
+  const curriculumData = useMemo(() => buildModulesFromLessons(lessons) as any, [lessons]);
 
   const progressMetrics = useMemo(() => {
     if (!user || user.is_staff || !lessons.length || !curriculumData.length) {
@@ -79,6 +69,6 @@ export function useEarnedBadges() {
     ...progressMetrics,
     lessons,
     curriculumData,
-    isLessonsLoading: isLessonsLoading || isCurriculumLoading,
+    isLessonsLoading,
   };
 }

--- a/frontend/src/lib/lessons.ts
+++ b/frontend/src/lib/lessons.ts
@@ -1,3 +1,5 @@
+import { fetchApi } from "./api";
+
 export interface Exercise {
   id?: number;
   title: string;
@@ -43,6 +45,7 @@ export interface Lesson {
   }>;
   conflictScenario?: ConflictScenario;
   pythonExercise?: PythonExercise;
+  category?: string;
 }
 
 // Small built-in fallback lessons (used if API unreachable)
@@ -69,48 +72,59 @@ export const lessons: Lesson[] = [
   },
 ];
 
-// Fetch lessons from local curriculum JSON asset
+// Fetch lessons from live API
 export async function fetchLessonsApi(): Promise<Lesson[]> {
   try {
-    const response = await fetch("/content/curriculum.json");
-    if (!response.ok) {
-      throw new Error("Failed to load curriculum.json");
-    }
-    const data = await response.json();
-    if (!data || !Array.isArray(data.modules)) return lessons;
+    const data = await fetchApi("/content/lessons/", { requireAuth: false });
+    if (!Array.isArray(data)) return lessons;
 
-    const allLessons: Lesson[] = [];
-    let orderIndex = 0;
-
-    for (const mod of data.modules) {
-      if (!Array.isArray(mod.lessons)) continue;
-      for (const les of mod.lessons) {
-        allLessons.push({
-          slug: les.slug,
-          title: les.title,
-          description: les.description || "",
-          explanation: "", // Will load dynamically from markdown content
-          expected: les.expected || "",
-          hint: les.hint || "Read the lesson contents and solve the check.",
-          difficulty: les.difficulty || "beginner",
-          points: les.points || 15,
-          estimatedMinutes: les.estimatedMinutes || 10,
-          learningObjectives: les.learningObjectives || [],
-          tips: les.tips || [],
-          exercises: les.exercises || [],
-          quizzes: les.quizzes || [],
-          conflictScenario: les.conflictScenario || undefined,
-          pythonExercise: les.pythonExercise || undefined,
-          order: orderIndex++,
-          filePath: les.filePath,
-        });
-      }
-    }
-    return allLessons;
+    return data.map((les: any, index: number) => {
+      const firstExercise = les.exercises?.[0];
+      return {
+        slug: les.slug,
+        title: les.title,
+        description: les.summary || "",
+        explanation: les.content || "", // Will load dynamically from backend
+        expected: firstExercise?.expectedCommand || "",
+        hint: firstExercise?.explanation || "Read the lesson contents and solve the check.",
+        difficulty: les.difficulty || "beginner",
+        points: firstExercise?.points || 15,
+        estimatedMinutes: les.estimatedMinutes || 10,
+        learningObjectives: les.learningObjectives || [],
+        tips: les.tips || [],
+        exercises: les.exercises || [],
+        quizzes: les.quizzes || [],
+        conflictScenario: les.conflictScenario || undefined,
+        pythonExercise: les.pythonExercise || undefined,
+        order: les.order || index,
+        category: les.category || "general",
+        filePath: les.filePath,
+      };
+    });
   } catch (err) {
-    console.error("Error loading curriculum JSON:", err);
+    console.error("Error loading live curriculum:", err);
     return lessons;
   }
+}
+
+export function buildModulesFromLessons(lessonsList: Lesson[]) {
+  const modulesMap = new Map<string, any>();
+  lessonsList.forEach((les) => {
+    const cat = les.category || "general";
+    if (!modulesMap.has(cat)) {
+      modulesMap.set(cat, {
+        id: cat,
+        title: cat.charAt(0).toUpperCase() + cat.slice(1).replace(/-/g, " "),
+        lessons: [],
+      });
+    }
+    modulesMap.get(cat).lessons.push({
+      slug: les.slug,
+      title: les.title,
+      difficulty: les.difficulty,
+    });
+  });
+  return Array.from(modulesMap.values());
 }
 
 // Fetch markdown text content for a lesson

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -9,7 +9,7 @@ import SkeletonAdminDashboard from "../components/ui/skeletons/SkeletonAdminDash
 import SkeletonContributorDashboard from "../components/ui/skeletons/SkeletonContributorDashboard";
 import { useRef } from "react";
 import { useElementSize } from "../hooks/useElementSize";
-import { fetchLessonsApi, Lesson } from "../lib/lessons";
+import { fetchLessonsApi, Lesson, buildModulesFromLessons } from "../lib/lessons";
 import { useUserProgress } from "../hooks/useUserProgress";
 import { useBookmarks } from "../hooks/useBookmarks";
 import { BADGES } from "../constants/badges";
@@ -105,20 +105,8 @@ export function DashboardPage() {
       window.removeEventListener("scroll", handleScroll);
     };
   }, []);
-  // 1. Fetch static modules catalog
+  // 1. Curriculum data is now derived dynamically from the lessons query below.
   const [curriculumData, setCurriculumData] = useState<ModuleData[]>([]);
-  useEffect(() => {
-    fetch("/content/curriculum.json")
-      .then((res) => res.json())
-      .then((data) => {
-        if (data && data.modules) {
-          setCurriculumData(data.modules);
-        }
-      })
-      .catch((err) =>
-        console.error("Error loading dashboard curriculum:", err),
-      );
-  }, []);
 
   // 2. Fetch Admin Dashboard stats (only queries if user is staff)
   const {
@@ -157,6 +145,12 @@ export function DashboardPage() {
     queryFn: fetchLessonsApi,
     enabled: !user?.is_staff,
   });
+
+  useEffect(() => {
+    if (lessons.length > 0) {
+      setCurriculumData(buildModulesFromLessons(lessons) as any);
+    }
+  }, [lessons]);
 
   const isLoading = isAdminLoading || isContributorLoading || isLessonsLoading;
 

--- a/frontend/src/pages/LessonPage.tsx
+++ b/frontend/src/pages/LessonPage.tsx
@@ -19,7 +19,7 @@ import { useUserProgress } from "../hooks/useUserProgress";
 import { useBookmarks } from "../hooks/useBookmarks";
 import { useLessonNote } from "../hooks/useLessonNote";
 import { fetchApi } from "../lib/api";
-import { Lesson, fetchLessonsApi, fetchLessonContent } from "../lib/lessons";
+import { Lesson, fetchLessonsApi, fetchLessonContent, buildModulesFromLessons } from "../lib/lessons";
 import { RichTextEditor } from "../components/ui/RichTextEditor";
 
 const MarkdownRenderer = React.lazy(() =>
@@ -136,14 +136,6 @@ export function LessonPage() {
   // 1. Fetch modules catalog & lessons
   useEffect(() => {
     setIsLoading(true);
-    fetch("/content/curriculum.json")
-      .then((res) => res.json())
-      .then((data) => {
-        if (data && data.modules) {
-          setModules(data.modules);
-        }
-      })
-      .catch((err) => console.error("Error fetching curriculum catalog:", err));
 
     fetchLessonsApi()
       .then((data) => {
@@ -154,6 +146,7 @@ export function LessonPage() {
           return;
         }
         setLesson(found);
+        setModules(buildModulesFromLessons(data) as any);
       })
       .catch(() => {
         navigate("/dashboard", { replace: true });
@@ -178,12 +171,14 @@ export function LessonPage() {
     setSelectedOption(null);
     setQuizFeedback(null);
 
-    if (lesson.filePath) {
+    if (lesson.explanation) {
+      setMarkdownContent(lesson.explanation);
+    } else if (lesson.filePath) {
       fetchLessonContent(lesson.filePath).then((content) => {
         setMarkdownContent(content);
       });
     } else {
-      setMarkdownContent(`# ${lesson.title}\n\n${lesson.explanation}`);
+      setMarkdownContent(`# ${lesson.title}\n\n`);
     }
   }, [lesson]);
 


### PR DESCRIPTION
## Summary
Transitions the frontend from fetching static JSON (`/content/curriculum.json`) and Markdown files to dynamically pulling live lesson content directly from the Django backend API.

## Related Issue
Closes #698

## Changes Made
- Updated `fetchLessonsApi` in `frontend/src/lib/lessons.ts` to fetch from `/content/lessons/`
- Mapped backend camelCased fields cleanly to the existing `Lesson` interface
- Implemented `buildModulesFromLessons` to dynamically aggregate lessons into nested modules based on their `category`, preserving UI functionality without needing backend schema changes
- Replaced static `curriculum.json` fetches in `DashboardPage.tsx` and `useEarnedBadges.ts` with dynamically derived data based on the react-query cache
- Updated `LessonPage.tsx` to conditionally render the backend-provided `explanation` property

## Testing
- [x] Tested manually 
- [ ] Add new unit/integration test
- [x] verified existing test still pass

## Screenshots
N/A (Backend integration refactor, no structural visual UI changes)

## Checklist

- [ ] Tests added or updated
- [ ] Documentation updated if needed
- [x] No secrets committed
