### PR TITLE
feat: add drag-and-drop dashboard widget reordering with localStorage persistance

### DIFF
--- a/frontend/src/components/ui/DraggableWidgetGrid.tsx
+++ b/frontend/src/components/ui/DraggableWidgetGrid.tsx
@@ -1,0 +1,82 @@
+import React, { useState, useRef, useCallback } from "react";
+
+export interface WidgetConfig {
+  id: string;
+  label: string;
+}
+
+interface DraggableWidgetGridProps {
+  widgets: WidgetConfig[];
+  onReorder: (newOrder: WidgetConfig[]) => void;
+  children: React.ReactNode[];
+}
+
+export function DraggableWidgetGrid({
+  widgets,
+  onReorder,
+  children,
+}: DraggableWidgetGridProps) {
+  const dragIndex = useRef<number | null>(null);
+  const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
+
+  const handleDragStart = useCallback((index: number) => {
+    dragIndex.current = index;
+  }, []);
+
+  const handleDragOver = useCallback((e: React.DragEvent, index: number) => {
+    e.preventDefault();
+    if (dragIndex.current === null || dragIndex.current === index) return;
+    setDragOverIndex(index);
+  }, []);
+
+  const handleDrop = useCallback(
+    (index: number) => {
+      if (dragIndex.current === null || dragIndex.current === index) {
+        setDragOverIndex(null);
+        return;
+      }
+      const newWidgets = [...widgets];
+      const [moved] = newWidgets.splice(dragIndex.current, 1);
+      newWidgets.splice(index, 0, moved);
+      dragIndex.current = null;
+      setDragOverIndex(null);
+      onReorder(newWidgets);
+    },
+    [widgets, onReorder]
+  );
+
+  const handleDragEnd = useCallback(() => {
+    dragIndex.current = null;
+    setDragOverIndex(null);
+  }, []);
+
+  return (
+    <div className="space-y-10">
+      {widgets.map((widget, index) => (
+        <div
+          key={widget.id}
+          draggable
+          onDragStart={() => handleDragStart(index)}
+          onDragOver={(e) => handleDragOver(e, index)}
+          onDrop={() => handleDrop(index)}
+          onDragEnd={handleDragEnd}
+          className={`transition-all duration-200 ${
+            dragOverIndex === index
+              ? "ring-4 ring-primary ring-offset-2 rounded-[2rem] scale-[1.01] opacity-80"
+              : ""
+          }`}
+        >
+          <div className="flex justify-end mb-1 pr-1">
+            <span
+              title={`Drag to reorder: ${widget.label}`}
+              className="text-[10px] font-black text-muted/50 hover:text-muted cursor-grab active:cursor-grabbing select-none uppercase tracking-widest flex items-center gap-1 dark:text-[#c4bbae]/40"
+            >
+              ⠿ drag to reorder
+            </span>
+          </div>
+          {children[index]}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import React, { useMemo, useState, useEffect } from "react";
+import React, { useMemo, useState, useEffect, useCallback } from "react";
 import { useAuth } from "../features/auth/AuthContext";
 import { useQuery } from "@tanstack/react-query";
 import { fetchApi } from "../lib/api";
@@ -42,6 +42,10 @@ import {
 } from "recharts";
 import { OnboardingTour } from "../components/ui/OnboardingTour";
 import { NotesWidget } from "../components/ui/NotesWidget";
+import {
+  DraggableWidgetGrid,
+  WidgetConfig,
+} from "../components/ui/DraggableWidgetGrid";
 
 const FACTS = [
   "Git was created in 2005 by Linus Torvalds because he was frustrated with the commercial tool they were using for Linux development.",
@@ -54,6 +58,16 @@ const FACTS = [
 
 const CONTRIBUTORS_CACHE_KEY = "github_contributors_cache";
 const CACHE_EXPIRY = 24 * 60 * 60 * 1000; // 24 hours
+
+const WIDGET_ORDER_KEY = "atelier_dashboard_widget_order";
+
+const DEFAULT_WIDGETS: WidgetConfig[] = [
+  { id: "fact-cert", label: "Fact of the Day & Certificate" },
+  { id: "learning-queue", label: "Learning Queue & Progress" },
+  { id: "bookmarks", label: "Read Later / Bookmarks" },
+  { id: "badges", label: "Achievements & Badges" },
+  { id: "contributors", label: "Contributors & Assigned Issues" },
+];
 
 interface ModuleData {
   id: string;
@@ -94,17 +108,39 @@ export function DashboardPage() {
   const [tourKey, setTourKey] = useState(0);
   const [showScrollTop, setShowScrollTop] = useState(false);
 
+  // Widget order state — persisted in localStorage
+  const [widgetOrder, setWidgetOrder] = useState<WidgetConfig[]>(() => {
+    try {
+      const saved = localStorage.getItem(WIDGET_ORDER_KEY);
+      if (saved) {
+        const parsed: WidgetConfig[] = JSON.parse(saved);
+        const ids = new Set(parsed.map((w) => w.id));
+        return [
+          ...parsed,
+          ...DEFAULT_WIDGETS.filter((w) => !ids.has(w.id)),
+        ];
+      }
+    } catch {
+      // ignore
+    }
+    return DEFAULT_WIDGETS;
+  });
+
+  const handleWidgetReorder = useCallback((newOrder: WidgetConfig[]) => {
+    setWidgetOrder(newOrder);
+    localStorage.setItem(WIDGET_ORDER_KEY, JSON.stringify(newOrder));
+  }, []);
+
   useEffect(() => {
     const handleScroll = () => {
       setShowScrollTop(window.scrollY > 300);
     };
-
     window.addEventListener("scroll", handleScroll);
-
     return () => {
       window.removeEventListener("scroll", handleScroll);
     };
   }, []);
+
   // 1. Fetch static modules catalog
   const [curriculumData, setCurriculumData] = useState<ModuleData[]>([]);
   useEffect(() => {
@@ -120,7 +156,7 @@ export function DashboardPage() {
       );
   }, []);
 
-  // 2. Fetch Admin Dashboard stats (only queries if user is staff)
+  // 2. Fetch Admin Dashboard stats
   const {
     data: adminData,
     isLoading: isAdminLoading,
@@ -131,14 +167,14 @@ export function DashboardPage() {
     enabled: !!user?.is_staff,
   });
 
-  // 3. Fetch paginated leaderboard for admin chart (only queries if user is staff)
+  // 3. Fetch paginated leaderboard for admin chart
   const { data: leaderboardData, isLoading: isLeaderboardLoading } = useQuery({
     queryKey: ["leaderboard", 1],
     queryFn: () => fetchApi("/leaderboard/"),
     enabled: !!user?.is_staff,
   });
 
-  // 4. Fetch Contributor Dashboard stats (only queries if user is NOT staff)
+  // 4. Fetch Contributor Dashboard stats
   const {
     data: contributorData,
     isLoading: isContributorLoading,
@@ -149,7 +185,7 @@ export function DashboardPage() {
     enabled: !!user && !user.is_staff,
   });
 
-  // 5. Fetch standard list of lessons via cache
+  // 5. Fetch standard list of lessons
   const { data: lessons = [], isLoading: isLessonsLoading } = useQuery<
     Lesson[]
   >({
@@ -181,6 +217,7 @@ export function DashboardPage() {
   const [gitHubContributors, setGitHubContributors] = useState<
     { login: string; avatar_url: string; html_url: string }[]
   >([]);
+
   useEffect(() => {
     const fallbackContributors = [
       {
@@ -210,9 +247,7 @@ export function DashboardPage() {
       .then((data) => {
         if (Array.isArray(data)) {
           const contributors = data.slice(0, 8);
-
           setGitHubContributors(contributors);
-
           localStorage.setItem(
             CONTRIBUTORS_CACHE_KEY,
             JSON.stringify({
@@ -224,25 +259,20 @@ export function DashboardPage() {
       })
       .catch(() => {
         const cachedData = localStorage.getItem(CONTRIBUTORS_CACHE_KEY);
-
         if (cachedData) {
           try {
             const parsedCache = JSON.parse(cachedData);
-
             const isCacheValid =
               Date.now() - parsedCache.timestamp < CACHE_EXPIRY;
-
             if (isCacheValid) {
               setGitHubContributors(parsedCache.data);
               return;
             }
-
             localStorage.removeItem(CONTRIBUTORS_CACHE_KEY);
           } catch {
             localStorage.removeItem(CONTRIBUTORS_CACHE_KEY);
           }
         }
-
         setGitHubContributors(fallbackContributors);
       });
   }, []);
@@ -268,7 +298,7 @@ export function DashboardPage() {
   // Certificate Modal state
   const [showCertificate, setShowCertificate] = useState(false);
 
-  // Compute local progress metrics based on frontend curriculum data
+  // Compute local progress metrics
   const {
     completedLessonsCount,
     totalLessonsCount,
@@ -289,13 +319,12 @@ export function DashboardPage() {
     const total = lessons.length;
     const completed = lessons.filter((l) => isLessonCompleted(l.slug)).length;
     const percentage = total > 0 ? Math.round((completed / total) * 100) : 0;
-
-    // Build the lessons queue (uncompleted ones first, up to 3)
     const queue = lessons.filter((l) => !isLessonCompleted(l.slug)).slice(0, 3);
 
-    // Calculate which badges are earned
-    const earned = new Set<string>(contributorData?.personal_stats?.earned_badges || []);
-    curriculumData.forEach((mod, index) => {
+    const earned = new Set<string>(
+      contributorData?.personal_stats?.earned_badges || [],
+    );
+    curriculumData.forEach((mod: ModuleData, index: number) => {
       const allCompleted = mod.lessons.every((les: { slug: string }) =>
         isLessonCompleted(les.slug),
       );
@@ -342,7 +371,7 @@ export function DashboardPage() {
     );
   }
 
-  // Admin Dashboard Render
+  // ─── Admin Dashboard Render ───────────────────────────────────────────────
   if (user?.is_staff) {
     if (adminError || !adminData) {
       return (
@@ -391,7 +420,7 @@ export function DashboardPage() {
             <div className="flex items-center gap-3">
               <span className="text-4xl">🚨</span>
               <div>
-                <h3 className=" text-xs uppercase tracking-widest text-muted dark:text-[#c4bbae]">
+                <h3 className="text-xs uppercase tracking-widest text-muted dark:text-[#c4bbae]">
                   System Issues
                 </h3>
                 <p className="text-4xl font-black text-primary drop-shadow-[2px_2px_0_#000] dark:drop-shadow-none">
@@ -409,7 +438,7 @@ export function DashboardPage() {
             <div className="flex items-center gap-3">
               <span className="text-4xl">💻</span>
               <div>
-                <h3 className=" text-xs uppercase tracking-widest text-muted dark:text-[#c4bbae]">
+                <h3 className="text-xs uppercase tracking-widest text-muted dark:text-[#c4bbae]">
                   Pull Requests
                 </h3>
                 <p className="text-4xl font-black text-tertiary drop-shadow-[2px_2px_0_#000] dark:drop-shadow-none">
@@ -427,7 +456,7 @@ export function DashboardPage() {
             <div className="flex items-center gap-3">
               <span className="text-4xl">👥</span>
               <div>
-                <h3 className=" text-xs uppercase tracking-widest text-muted dark:text-[#c4bbae]">
+                <h3 className="text-xs uppercase tracking-widest text-muted dark:text-[#c4bbae]">
                   Active Contributors
                 </h3>
                 <p className="text-4xl font-black text-accent drop-shadow-[2px_2px_0_#000] dark:drop-shadow-none">
@@ -625,7 +654,7 @@ export function DashboardPage() {
     );
   }
 
-  // Contributor/Student Dashboard Render
+  // ─── Contributor/Student Dashboard Render ────────────────────────────────
   if (contributorError || !contributorData) {
     return (
       <div className="pt-24 max-w-7xl mx-auto px-4">
@@ -643,6 +672,7 @@ export function DashboardPage() {
     <div className="max-w-7xl mx-auto px-4 pt-24 pb-12 space-y-10">
       <OnboardingTour run={showOnboarding} onFinish={handleFinishOnboarding} />
       <NotesWidget />
+
       {/* 1. Header Banner */}
       <section className="grid gap-6 xl:grid-cols-[1.3fr_0.7fr]">
         <div
@@ -668,6 +698,16 @@ export function DashboardPage() {
               </span>
               .
             </p>
+            {/* Reset widget layout button */}
+            <button
+              onClick={() => {
+                setWidgetOrder(DEFAULT_WIDGETS);
+                localStorage.removeItem(WIDGET_ORDER_KEY);
+              }}
+              className="mt-3 text-[10px] font-black text-black/40 underline hover:text-black/70 cursor-pointer dark:text-[#c4bbae]/40 dark:hover:text-[#c4bbae] block"
+            >
+              Reset widget layout
+            </button>
           </div>
           <div className="absolute -right-6 -bottom-6 text-[10rem] opacity-20 rotate-12 pointer-events-none">
             🚀
@@ -718,306 +758,336 @@ export function DashboardPage() {
         </div>
       </section>
 
-      {/* 2. Fact of the Day and Certificate Unlock */}
-      <section className="grid gap-6 md:grid-cols-[1.3fr_0.7fr]">
-        <div
-          id="tour-fact"
-          className="rounded-2xl border-4 border-black bg-surface-low p-6 shadow-card dark:bg-[#1f1c18] dark:border-[#2e2924] dark:shadow-none flex items-start gap-4"
-        >
-          <div className="bg-white p-3 rounded-2xl border-2 border-black flex-shrink-0 text-2xl dark:bg-[#151411] dark:border-[#2e2924]">
-            💡
-          </div>
-          <div>
-            <h4 className="font-mono text-xs text-primary uppercase tracking-wider font-black mb-1">
-              Open Source Fact of the Day
-            </h4>
-            <p className="font-bold text-sm text-text leading-relaxed dark:text-[#c4bbae]">
-              {factOfDay}
-            </p>
-          </div>
-        </div>
-
-        {/* Certificate Card */}
-        <div
-          id="tour-certificate"
-          className="rounded-2xl border-4 border-black bg-white p-6 shadow-card dark:bg-[#1f1c18] dark:border-[#2e2924] dark:shadow-none flex flex-col justify-between"
-        >
-          <div className="flex items-center gap-2">
-            <span className="text-2xl">🎓</span>
-            <div>
-              <h4 className="font-black text-sm text-text dark:text-[#f0ebe2]">
-                Completion Certificate
-              </h4>
-              <p className="text-xs text-muted dark:text-[#c4bbae]">
-                Unlocked at 100% curriculum score
-              </p>
-            </div>
-          </div>
-          {completionPercentage === 100 ? (
-            <button
-              onClick={() => setShowCertificate(true)}
-              className="mt-4 w-full flex items-center justify-center gap-2 rounded-lg bg-green-500 text-black font-black py-3 border-4 border-black shadow-card-sm hover:-translate-y-0.5 transition-all cursor-pointer uppercase tracking-wider text-xs"
-            >
-              <Download size={14} /> Download Certificate
-            </button>
-          ) : (
-            <div className="mt-4 text-xs font-black text-muted bg-surface-low p-3 rounded-lg border-2 border-dashed border-black/35 text-center dark:bg-[#151411] dark:border-[#2e2924]">
-              🔒 Locked ({completionPercentage}% progress)
-            </div>
-          )}
-        </div>
-      </section>
-
-      {/* 3. Learning Queue Sidebar & Course Completion Chart */}
-      <section className="grid gap-6 xl:grid-cols-[1.3fr_0.7fr]">
-        <div
-          id="tour-learning-queue"
-          className="rounded-2xl border-4 border-black bg-white p-6 shadow-card dark:bg-[#1f1c18] dark:border-[#2e2924] dark:shadow-none"
-        >
-          <h2 className="text-3xl font-black mb-6 flex items-center gap-3">
-            <span className="bg-primary text-white w-10 h-10 rounded-full border-2 border-black flex items-center justify-center text-lg dark:bg-primary/20 dark:text-primary">
-              📚
-            </span>
-            Resume Learning Queue
-          </h2>
-          <div className="space-y-4">
-            {activeLessonsQueue.length > 0 ? (
-              activeLessonsQueue.map((lesson: Lesson) => (
-                <Link
-                  key={lesson.slug}
-                  to={`/lessons/${lesson.slug}`}
-                  className="flex flex-col gap-2 p-5 rounded-lg border-4 border-black bg-surface-lowest shadow-card-sm hover:shadow-card hover:-translate-y-1 transition-all cursor-pointer dark:bg-[#151411] dark:border-[#2e2924] dark:hover:bg-[#1f1c18]"
-                >
-                  <div className="flex justify-between items-end">
-                    <h3 className="font-black text-xl dark:text-[#f0ebe2]">
-                      {lesson.title}
-                    </h3>
-                    <span className="font-black text-[9px] bg-black text-white px-2 py-0.5 rounded-full uppercase dark:bg-[#2e2924]">
-                      {lesson.difficulty || "beginner"}
-                    </span>
-                  </div>
-                  <p className="font-bold text-sm text-muted dark:text-[#c4bbae]">
-                    {lesson.description}
-                  </p>
-                  <div className="flex justify-between text-xs font-bold text-primary mt-1">
-                    <span>⏱️ {lesson.estimatedMinutes || 10} min module</span>
-                    <span className="flex items-center gap-1">
-                      Start mission <ArrowRight size={12} />
-                    </span>
-                  </div>
-                </Link>
-              ))
-            ) : (
-              <div className="p-8 text-center bg-surface-low rounded-2xl border-4 border-dashed border-black dark:bg-[#0f0e0c] dark:border-[#2e2924]">
-                <p className="font-bold text-muted dark:text-[#c4bbae]">
-                  All curriculum modules completed! Go fetch your graduation
-                  certificate! 🎓🌟
-                </p>
-              </div>
-            )}
-          </div>
-        </div>
-
-        {/* Circular Progress Gauge */}
-        <div className="rounded-2xl border-4 border-black bg-white p-6 shadow-card dark:bg-[#1f1c18] dark:border-[#2e2924] dark:shadow-none flex flex-col justify-between">
-          <div>
-            <h2 className="text-2xl font-black mb-4 flex items-center gap-2">
-              <span>🎯</span> Completion Progress
-            </h2>
-            <div className="h-[180px] sm:h-[220px] w-full flex items-center justify-center relative">
-              <ResponsiveContainer width="100%" height="100%">
-                <PieChart>
-                  <Pie
-                    data={[
-                      { name: "Completed", value: completedLessonsCount },
-                      {
-                        name: "Remaining",
-                        value: Math.max(
-                          0,
-                          totalLessonsCount - completedLessonsCount,
-                        ),
-                      },
-                    ]}
-                    cx="50%"
-                    cy="50%"
-                    innerRadius="45%"
-                    outerRadius="70%"
-                    paddingAngle={3}
-                    dataKey="value"
-                  >
-                    <Cell fill="#ff3b30" stroke="#000" strokeWidth={2} />
-                    <Cell fill="#fdfbf7" stroke="#e0e0e0" strokeWidth={2} />
-                  </Pie>
-                </PieChart>
-              </ResponsiveContainer>
-              <div className="absolute inset-0 flex flex-col items-center justify-center pointer-events-none">
-                <span className="text-4xl font-black text-text dark:text-[#f0ebe2]">
-                  {completionPercentage}%
-                </span>
-                <span className="text-[10px] uppercase font-bold text-muted dark:text-[#c4bbae]">
-                  SOLVED
-                </span>
-              </div>
-            </div>
-          </div>
-          <div className="mt-4 pt-4 border-t border-dashed border-muted/20 text-center font-bold text-sm text-muted dark:text-[#c4bbae]">
-            📊 Completed {completedLessonsCount} of {totalLessonsCount} total
-            learning modules
-          </div>
-        </div>
-      </section>
-
-      {/* Read Later / Bookmarks */}
-      {bookmarks.length > 0 && (
-        <section className="rounded-[2.5rem] border-4 border-black bg-surface-low p-6 sm:p-8 shadow-card dark:bg-[#151411] dark:border-[#2e2924] dark:shadow-none mt-6">
-          <h2 className="text-3xl font-black mb-6 flex items-center gap-3">
-            <span className="bg-[#c3c0ff] text-black w-10 h-10 rounded-full border-2 border-black flex items-center justify-center text-lg">
-              <Bookmark className="fill-black" size={20} />
-            </span>
-            Read Later
-          </h2>
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            {bookmarks.map((bookmark) => (
-              <Link
-                key={bookmark.lesson_slug}
-                to={`/lessons/${bookmark.lesson_slug}`}
-                className="flex flex-col gap-2 p-5 rounded-lg border-4 border-black bg-white shadow-card-sm hover:shadow-card hover:-translate-y-1 transition-all cursor-pointer dark:bg-[#1f1c18] dark:border-[#2e2924]"
-              >
-                <div className="flex justify-between items-start mb-2">
-                  <h3 className="font-black text-lg leading-tight dark:text-[#f0ebe2] pr-4">
-                    {bookmark.lesson_title}
-                  </h3>
-                  <Bookmark className="fill-primary text-primary shrink-0" size={20} />
-                </div>
-                <div className="flex justify-between items-center mt-auto pt-4">
-                  <span className="font-black text-[10px] bg-black text-white px-2 py-0.5 rounded-full uppercase dark:bg-[#2e2924]">
-                    {bookmark.lesson_category}
-                  </span>
-                  <span className="text-xs font-bold text-muted dark:text-[#c4bbae]">
-                    {bookmark.lesson_estimated_minutes} min
-                  </span>
-                </div>
-              </Link>
-            ))}
-          </div>
-        </section>
-      )}
-
-      {/* 4. Badges / Achievements Shelf */}
-      <section className="mt-6 rounded-[2.5rem] border-4 border-black bg-white p-6 sm:p-8 shadow-card dark:bg-[#151411] dark:border-[#2e2924] dark:shadow-none">
-        <h2 className="text-3xl font-black mb-6 flex items-center gap-3">
-          <Award className="w-8 h-8 text-primary" />
-          Achievements & Badges Drawer
-        </h2>
-        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
-          {BADGES.map((badge) => {
-            const isEarned = earnedBadges.includes(badge.id);
+      {/* ── Draggable Widget Area ── */}
+      <DraggableWidgetGrid widgets={widgetOrder} onReorder={handleWidgetReorder}>
+        {widgetOrder.map((widget) => {
+          // ── Widget: Fact of Day + Certificate ──
+          if (widget.id === "fact-cert") {
             return (
-              <div
-                key={badge.id}
-                className={`relative rounded-2xl border-4 border-black p-5 flex flex-col items-center text-center shadow-card-sm transition-all ${
-                  isEarned
-                    ? "bg-white dark:bg-[#1f1c18] hover:-translate-y-1"
-                    : "bg-surface-low/30 opacity-60 dark:bg-black/20"
-                }`}
-              >
-                <div className={`text-5xl mb-3 ${isEarned ? "" : "grayscale"}`}>
-                  {badge.icon}
+              <section key="fact-cert" className="grid gap-6 md:grid-cols-[1.3fr_0.7fr]">
+                <div
+                  id="tour-fact"
+                  className="rounded-2xl border-4 border-black bg-surface-low p-6 shadow-card dark:bg-[#1f1c18] dark:border-[#2e2924] dark:shadow-none flex items-start gap-4"
+                >
+                  <div className="bg-white p-3 rounded-2xl border-2 border-black flex-shrink-0 text-2xl dark:bg-[#151411] dark:border-[#2e2924]">
+                    💡
+                  </div>
+                  <div>
+                    <h4 className="font-mono text-xs text-primary uppercase tracking-wider font-black mb-1">
+                      Open Source Fact of the Day
+                    </h4>
+                    <p className="font-bold text-sm text-text leading-relaxed dark:text-[#c4bbae]">
+                      {factOfDay}
+                    </p>
+                  </div>
                 </div>
-                <h4 className="font-black text-sm mb-1 text-text dark:text-[#f0ebe2]">
-                  {badge.name}
-                </h4>
-                <p className="text-[10px] font-bold text-muted dark:text-[#c4bbae]">
-                  {badge.desc}
-                </p>
-                {isEarned ? (
-                  <span className="absolute top-2 right-2 bg-green-100 text-green-700 border-2 border-green-700 text-[8px] font-black px-1.5 py-0.5 rounded-full dark:border-none">
-                    UNLOCKED
-                  </span>
-                ) : (
-                  <span className="absolute top-2 right-2 bg-gray-100 text-gray-400 border-2 border-gray-400 text-[8px] font-black px-1.5 py-0.5 rounded-full dark:border-none flex items-center gap-1">
-                    <Lock size={10} />
-                    LOCKED
-                  </span>
-                )}
-              </div>
-            );
-          })}
-        </div>
-      </section>
 
-      {/* 5. Contributor Recognition & Assigned Issues */}
-      <section className="grid gap-6 xl:grid-cols-[1.2fr_0.8fr]">
-        {/* Contributor recognition */}
-        <div className="rounded-2xl border-4 border-black bg-white p-6 shadow-card dark:bg-[#1f1c18] dark:border-[#2e2924] dark:shadow-none">
-          <h2 className="text-2xl font-black mb-4 flex items-center gap-2">
-            <Users className="w-6 h-6 text-primary" />
-            GitHub Contributor Hall of Fame
-          </h2>
-          <p className="text-xs text-muted mb-6 dark:text-[#c4bbae]">
-            Say hello to developers who built this learning ecosystem! Open
-            source relies on collaboration.
-          </p>
-          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
-            {gitHubContributors.map((contrib, i) => (
-              <a
-                key={contrib.login || i}
-                href={contrib.html_url}
-                target="_blank"
-                rel="noreferrer"
-                className="flex items-center gap-2 p-3 rounded-lg border-2 border-black bg-surface hover:-translate-y-0.5 shadow-card-sm transition-all dark:bg-[#151411] dark:border-[#2e2924]"
-              >
-                <img
-                  src={contrib.avatar_url}
-                  alt={contrib.login}
-                  className="w-8 h-8 rounded-full border border-black flex-shrink-0"
-                />
-                <span className="font-black text-xs truncate">
-                  @{contrib.login}
-                </span>
-              </a>
-            ))}
-          </div>
-        </div>
-
-        {/* Local Assigned Issues */}
-        <div className="rounded-2xl border-4 border-black bg-[#ffb5e8] p-6 shadow-card dark:bg-[#1f1c18] dark:border-[#2e2924] dark:shadow-none flex flex-col justify-between">
-          <div>
-            <h2 className="text-2xl font-black mb-3 flex items-center gap-2">
-              <span>🚨</span> Assigned Issues
-            </h2>
-            <div className="space-y-3">
-              {assigned_issues.length > 0 ? (
-                assigned_issues.map(
-                  (issue: { id: number; title: string; points: number }) => (
-                    <div
-                      key={issue.id}
-                      className="p-3 bg-white rounded-lg border-2 border-black dark:bg-[#151411] dark:border-[#2e2924]"
-                    >
-                      <span className="text-[9px] font-black uppercase text-primary">
-                        XP Bounty: {issue.points}
-                      </span>
-                      <h4 className="font-black text-sm mt-1">{issue.title}</h4>
+                <div
+                  id="tour-certificate"
+                  className="rounded-2xl border-4 border-black bg-white p-6 shadow-card dark:bg-[#1f1c18] dark:border-[#2e2924] dark:shadow-none flex flex-col justify-between"
+                >
+                  <div className="flex items-center gap-2">
+                    <span className="text-2xl">🎓</span>
+                    <div>
+                      <h4 className="font-black text-sm text-text dark:text-[#f0ebe2]">
+                        Completion Certificate
+                      </h4>
+                      <p className="text-xs text-muted dark:text-[#c4bbae]">
+                        Unlocked at 100% curriculum score
+                      </p>
                     </div>
-                  ),
-                )
-              ) : (
-                <div className="p-6 text-center bg-white rounded-lg border-2 border-dashed border-black/35 text-xs font-bold text-muted dark:bg-[#151411]">
-                  All issues resolved! Go grab a task in the Challenges board.
+                  </div>
+                  {completionPercentage === 100 ? (
+                    <button
+                      onClick={() => setShowCertificate(true)}
+                      className="mt-4 w-full flex items-center justify-center gap-2 rounded-lg bg-green-500 text-black font-black py-3 border-4 border-black shadow-card-sm hover:-translate-y-0.5 transition-all cursor-pointer uppercase tracking-wider text-xs"
+                    >
+                      <Download size={14} /> Download Certificate
+                    </button>
+                  ) : (
+                    <div className="mt-4 text-xs font-black text-muted bg-surface-low p-3 rounded-lg border-2 border-dashed border-black/35 text-center dark:bg-[#151411] dark:border-[#2e2924]">
+                      🔒 Locked ({completionPercentage}% progress)
+                    </div>
+                  )}
                 </div>
-              )}
-            </div>
-          </div>
-          <Link
-            to="/challenges"
-            className="mt-4 block text-center rounded-lg bg-white border-4 border-black py-2.5 font-black text-xs shadow-card-sm hover:-translate-y-0.5 active:translate-y-0.5 active:shadow-card-sm cursor-pointer dark:bg-[#151411] dark:border-[#2e2924]"
-          >
-            Browse Issues Board
-          </Link>
-        </div>
-      </section>
+              </section>
+            );
+          }
 
-      {/* --- MODAL 1: ONBOARDING GUIDED TOUR --- */}
+          // ── Widget: Learning Queue + Completion Chart ──
+          if (widget.id === "learning-queue") {
+            return (
+              <section key="learning-queue" className="grid gap-6 xl:grid-cols-[1.3fr_0.7fr]">
+                <div
+                  id="tour-learning-queue"
+                  className="rounded-2xl border-4 border-black bg-white p-6 shadow-card dark:bg-[#1f1c18] dark:border-[#2e2924] dark:shadow-none"
+                >
+                  <h2 className="text-3xl font-black mb-6 flex items-center gap-3">
+                    <span className="bg-primary text-white w-10 h-10 rounded-full border-2 border-black flex items-center justify-center text-lg dark:bg-primary/20 dark:text-primary">
+                      📚
+                    </span>
+                    Resume Learning Queue
+                  </h2>
+                  <div className="space-y-4">
+                    {activeLessonsQueue.length > 0 ? (
+                      activeLessonsQueue.map((lesson: Lesson) => (
+                        <Link
+                          key={lesson.slug}
+                          to={`/lessons/${lesson.slug}`}
+                          className="flex flex-col gap-2 p-5 rounded-lg border-4 border-black bg-surface-lowest shadow-card-sm hover:shadow-card hover:-translate-y-1 transition-all cursor-pointer dark:bg-[#151411] dark:border-[#2e2924] dark:hover:bg-[#1f1c18]"
+                        >
+                          <div className="flex justify-between items-end">
+                            <h3 className="font-black text-xl dark:text-[#f0ebe2]">
+                              {lesson.title}
+                            </h3>
+                            <span className="font-black text-[9px] bg-black text-white px-2 py-0.5 rounded-full uppercase dark:bg-[#2e2924]">
+                              {lesson.difficulty || "beginner"}
+                            </span>
+                          </div>
+                          <p className="font-bold text-sm text-muted dark:text-[#c4bbae]">
+                            {lesson.description}
+                          </p>
+                          <div className="flex justify-between text-xs font-bold text-primary mt-1">
+                            <span>⏱️ {lesson.estimatedMinutes || 10} min module</span>
+                            <span className="flex items-center gap-1">
+                              Start mission <ArrowRight size={12} />
+                            </span>
+                          </div>
+                        </Link>
+                      ))
+                    ) : (
+                      <div className="p-8 text-center bg-surface-low rounded-2xl border-4 border-dashed border-black dark:bg-[#0f0e0c] dark:border-[#2e2924]">
+                        <p className="font-bold text-muted dark:text-[#c4bbae]">
+                          All curriculum modules completed! Go fetch your graduation
+                          certificate! 🎓🌟
+                        </p>
+                      </div>
+                    )}
+                  </div>
+                </div>
+
+                {/* Circular Progress Gauge */}
+                <div className="rounded-2xl border-4 border-black bg-white p-6 shadow-card dark:bg-[#1f1c18] dark:border-[#2e2924] dark:shadow-none flex flex-col justify-between">
+                  <div>
+                    <h2 className="text-2xl font-black mb-4 flex items-center gap-2">
+                      <span>🎯</span> Completion Progress
+                    </h2>
+                    <div className="h-[180px] sm:h-[220px] w-full flex items-center justify-center relative">
+                      <ResponsiveContainer width="100%" height="100%">
+                        <PieChart>
+                          <Pie
+                            data={[
+                              { name: "Completed", value: completedLessonsCount },
+                              {
+                                name: "Remaining",
+                                value: Math.max(
+                                  0,
+                                  totalLessonsCount - completedLessonsCount,
+                                ),
+                              },
+                            ]}
+                            cx="50%"
+                            cy="50%"
+                            innerRadius="45%"
+                            outerRadius="70%"
+                            paddingAngle={3}
+                            dataKey="value"
+                          >
+                            <Cell fill="#ff3b30" stroke="#000" strokeWidth={2} />
+                            <Cell fill="#fdfbf7" stroke="#e0e0e0" strokeWidth={2} />
+                          </Pie>
+                        </PieChart>
+                      </ResponsiveContainer>
+                      <div className="absolute inset-0 flex flex-col items-center justify-center pointer-events-none">
+                        <span className="text-4xl font-black text-text dark:text-[#f0ebe2]">
+                          {completionPercentage}%
+                        </span>
+                        <span className="text-[10px] uppercase font-bold text-muted dark:text-[#c4bbae]">
+                          SOLVED
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                  <div className="mt-4 pt-4 border-t border-dashed border-muted/20 text-center font-bold text-sm text-muted dark:text-[#c4bbae]">
+                    📊 Completed {completedLessonsCount} of {totalLessonsCount} total
+                    learning modules
+                  </div>
+                </div>
+              </section>
+            );
+          }
+
+          // ── Widget: Bookmarks ──
+          if (widget.id === "bookmarks") {
+            return bookmarks.length > 0 ? (
+              <section
+                key="bookmarks"
+                className="rounded-[2.5rem] border-4 border-black bg-surface-low p-6 sm:p-8 shadow-card dark:bg-[#151411] dark:border-[#2e2924] dark:shadow-none"
+              >
+                <h2 className="text-3xl font-black mb-6 flex items-center gap-3">
+                  <span className="bg-[#c3c0ff] text-black w-10 h-10 rounded-full border-2 border-black flex items-center justify-center text-lg">
+                    <Bookmark className="fill-black" size={20} />
+                  </span>
+                  Read Later
+                </h2>
+                <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                  {bookmarks.map((bookmark) => (
+                    <Link
+                      key={bookmark.lesson_slug}
+                      to={`/lessons/${bookmark.lesson_slug}`}
+                      className="flex flex-col gap-2 p-5 rounded-lg border-4 border-black bg-white shadow-card-sm hover:shadow-card hover:-translate-y-1 transition-all cursor-pointer dark:bg-[#1f1c18] dark:border-[#2e2924]"
+                    >
+                      <div className="flex justify-between items-start mb-2">
+                        <h3 className="font-black text-lg leading-tight dark:text-[#f0ebe2] pr-4">
+                          {bookmark.lesson_title}
+                        </h3>
+                        <Bookmark className="fill-primary text-primary shrink-0" size={20} />
+                      </div>
+                      <div className="flex justify-between items-center mt-auto pt-4">
+                        <span className="font-black text-[10px] bg-black text-white px-2 py-0.5 rounded-full uppercase dark:bg-[#2e2924]">
+                          {bookmark.lesson_category}
+                        </span>
+                        <span className="text-xs font-bold text-muted dark:text-[#c4bbae]">
+                          {bookmark.lesson_estimated_minutes} min
+                        </span>
+                      </div>
+                    </Link>
+                  ))}
+                </div>
+              </section>
+            ) : (
+              <div key="bookmarks" />
+            );
+          }
+
+          // ── Widget: Badges ──
+          if (widget.id === "badges") {
+            return (
+              <section
+                key="badges"
+                className="rounded-[2.5rem] border-4 border-black bg-white p-6 sm:p-8 shadow-card dark:bg-[#151411] dark:border-[#2e2924] dark:shadow-none"
+              >
+                <h2 className="text-3xl font-black mb-6 flex items-center gap-3">
+                  <Award className="w-8 h-8 text-primary" />
+                  Achievements & Badges Drawer
+                </h2>
+                <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+                  {BADGES.map((badge) => {
+                    const isEarned = earnedBadges.includes(badge.id);
+                    return (
+                      <div
+                        key={badge.id}
+                        className={`relative rounded-2xl border-4 border-black p-5 flex flex-col items-center text-center shadow-card-sm transition-all ${
+                          isEarned
+                            ? "bg-white dark:bg-[#1f1c18] hover:-translate-y-1"
+                            : "bg-surface-low/30 opacity-60 dark:bg-black/20"
+                        }`}
+                      >
+                        <div className={`text-5xl mb-3 ${isEarned ? "" : "grayscale"}`}>
+                          {badge.icon}
+                        </div>
+                        <h4 className="font-black text-sm mb-1 text-text dark:text-[#f0ebe2]">
+                          {badge.name}
+                        </h4>
+                        <p className="text-[10px] font-bold text-muted dark:text-[#c4bbae]">
+                          {badge.desc}
+                        </p>
+                        {isEarned ? (
+                          <span className="absolute top-2 right-2 bg-green-100 text-green-700 border-2 border-green-700 text-[8px] font-black px-1.5 py-0.5 rounded-full dark:border-none">
+                            UNLOCKED
+                          </span>
+                        ) : (
+                          <span className="absolute top-2 right-2 bg-gray-100 text-gray-400 border-2 border-gray-400 text-[8px] font-black px-1.5 py-0.5 rounded-full dark:border-none flex items-center gap-1">
+                            <Lock size={10} />
+                            LOCKED
+                          </span>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              </section>
+            );
+          }
+
+          // ── Widget: Contributors + Assigned Issues ──
+          if (widget.id === "contributors") {
+            return (
+              <section key="contributors" className="grid gap-6 xl:grid-cols-[1.2fr_0.8fr]">
+                <div className="rounded-2xl border-4 border-black bg-white p-6 shadow-card dark:bg-[#1f1c18] dark:border-[#2e2924] dark:shadow-none">
+                  <h2 className="text-2xl font-black mb-4 flex items-center gap-2">
+                    <Users className="w-6 h-6 text-primary" />
+                    GitHub Contributor Hall of Fame
+                  </h2>
+                  <p className="text-xs text-muted mb-6 dark:text-[#c4bbae]">
+                    Say hello to developers who built this learning ecosystem! Open
+                    source relies on collaboration.
+                  </p>
+                  <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+                    {gitHubContributors.map((contrib: GitHubContributor, i: number) => (
+                      <a
+                        key={contrib.login || i}
+                        href={contrib.html_url}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="flex items-center gap-2 p-3 rounded-lg border-2 border-black bg-surface hover:-translate-y-0.5 shadow-card-sm transition-all dark:bg-[#151411] dark:border-[#2e2924]"
+                      >
+                        <img
+                          src={contrib.avatar_url}
+                          alt={contrib.login}
+                          className="w-8 h-8 rounded-full border border-black flex-shrink-0"
+                        />
+                        <span className="font-black text-xs truncate">
+                          @{contrib.login}
+                        </span>
+                      </a>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="rounded-2xl border-4 border-black bg-[#ffb5e8] p-6 shadow-card dark:bg-[#1f1c18] dark:border-[#2e2924] dark:shadow-none flex flex-col justify-between">
+                  <div>
+                    <h2 className="text-2xl font-black mb-3 flex items-center gap-2">
+                      <span>🚨</span> Assigned Issues
+                    </h2>
+                    <div className="space-y-3">
+                      {assigned_issues.length > 0 ? (
+                        assigned_issues.map(
+                          (issue: AssignedIssue) => (
+                            <div
+                              key={issue.id}
+                              className="p-3 bg-white rounded-lg border-2 border-black dark:bg-[#151411] dark:border-[#2e2924]"
+                            >
+                              <span className="text-[9px] font-black uppercase text-primary">
+                                XP Bounty: {issue.points}
+                              </span>
+                              <h4 className="font-black text-sm mt-1">{issue.title}</h4>
+                            </div>
+                          ),
+                        )
+                      ) : (
+                        <div className="p-6 text-center bg-white rounded-lg border-2 border-dashed border-black/35 text-xs font-bold text-muted dark:bg-[#151411]">
+                          All issues resolved! Go grab a task in the Challenges board.
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                  <Link
+                    to="/challenges"
+                    className="mt-4 block text-center rounded-lg bg-white border-4 border-black py-2.5 font-black text-xs shadow-card-sm hover:-translate-y-0.5 active:translate-y-0.5 active:shadow-card-sm cursor-pointer dark:bg-[#151411] dark:border-[#2e2924]"
+                  >
+                    Browse Issues Board
+                  </Link>
+                </div>
+              </section>
+            );
+          }
+
+          return null;
+        })}
+      </DraggableWidgetGrid>
+
+      {/* ── MODAL 1: ONBOARDING GUIDED TOUR ── */}
       {showOnboarding && (
         <div className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4">
           <div className="w-full max-w-lg bg-white rounded-2xl border-4 border-black shadow-card p-6 sm:p-8 space-y-6 relative dark:bg-[#0f0e0c] dark:border-[#2e2924]">
@@ -1049,9 +1119,7 @@ export function DashboardPage() {
             )}
             {onboardingStep === 2 && (
               <div className="space-y-4">
-                <div className="text-5xl text-center">
-                  🌿 Start Contributing
-                </div>
+                <div className="text-5xl text-center">🌿 Start Contributing</div>
                 <h3 className="text-2xl font-black text-center">
                   Ready to Dive In?
                 </h3>
@@ -1062,7 +1130,6 @@ export function DashboardPage() {
                 </p>
               </div>
             )}
-
             <div className="flex items-center justify-between pt-4 border-t-2 border-dashed border-black/15">
               <span className="font-mono text-xs text-muted">
                 Step {onboardingStep + 1} of 3
@@ -1070,7 +1137,7 @@ export function DashboardPage() {
               <div className="flex gap-2">
                 {onboardingStep > 0 && (
                   <button
-                    onClick={() => setOnboardingStep((prev) => prev - 1)}
+                    onClick={() => setOnboardingStep((prev: number) => prev - 1)}
                     className="px-4 py-2 border-2 border-black rounded-lg text-xs font-black hover:bg-surface-low"
                   >
                     Back
@@ -1078,7 +1145,7 @@ export function DashboardPage() {
                 )}
                 {onboardingStep < 2 ? (
                   <button
-                    onClick={() => setOnboardingStep((prev) => prev + 1)}
+                    onClick={() => setOnboardingStep((prev: number) => prev + 1)}
                     className="px-4 py-2 bg-accent text-black border-2 border-black rounded-lg text-xs font-black shadow-card-sm hover:-translate-y-0.5"
                   >
                     Continue
@@ -1097,12 +1164,10 @@ export function DashboardPage() {
         </div>
       )}
 
-      {/* --- MODAL 2: CERTIFICATE OF COMPLETION (A4 Print Layout) --- */}
+      {/* ── MODAL 2: CERTIFICATE OF COMPLETION ── */}
       {showCertificate && (
         <div className="fixed inset-0 bg-black/75 z-50 flex items-center justify-center p-4 overflow-y-auto">
-          {/* Certificate Container */}
           <div className="w-full max-w-4xl bg-[#FFF9F0] rounded-[2rem] border-8 border-black p-8 sm:p-12 relative flex flex-col justify-between items-center text-center shadow-card bg-dot-grid print:border-none print:shadow-none print:p-0">
-            {/* Close Button (Hidden on Print) */}
             <button
               onClick={() => setShowCertificate(false)}
               className="absolute top-4 right-4 bg-white border-2 border-black p-2 rounded-full hover:bg-surface-low transition-colors print:hidden"
@@ -1110,16 +1175,14 @@ export function DashboardPage() {
               <X size={16} />
             </button>
 
-            {/* Certificate Contents */}
             <div className="space-y-6 w-full border-4 border-dashed border-black/35 rounded-2xl p-6 sm:p-10 relative">
               <div className="text-6xl mb-2">🎓</div>
-              <h2 className=" text-4xl sm:text-5xl font-black uppercase tracking-tight text-text">
+              <h2 className="text-4xl sm:text-5xl font-black uppercase tracking-tight text-text">
                 Certificate of Completion
               </h2>
               <p className="font-mono text-xs text-primary uppercase tracking-widest font-black">
                 The Open Source Contribution Atelier
               </p>
-
               <div className="py-4">
                 <p className="text-sm italic text-muted">
                   This is officially awarded to
@@ -1128,13 +1191,11 @@ export function DashboardPage() {
                   {user?.username}
                 </h3>
               </div>
-
               <p className="max-w-xl mx-auto text-sm font-bold leading-relaxed text-text">
                 for successfully resolving issues, demonstrating version control
                 proficiency, respecting open source etiquette, and completing
                 the full 8-module collaborative contribution track.
               </p>
-
               <div className="grid grid-cols-2 gap-4 max-w-md mx-auto pt-6 text-left border-t border-black/10">
                 <div>
                   <span className="block text-[10px] text-muted uppercase font-bold">
@@ -1164,7 +1225,6 @@ export function DashboardPage() {
                   </span>
                 </div>
               </div>
-
               {certificateData?.certificate?.verification_hash && (
                 <div className="mt-4 text-[10px] text-muted font-bold text-center print:block">
                   Verify authenticity at:{" "}
@@ -1176,7 +1236,6 @@ export function DashboardPage() {
               )}
             </div>
 
-            {/* Print trigger button row */}
             <div className="mt-8 flex gap-3 print:hidden">
               <button
                 onClick={() => window.print()}
@@ -1200,6 +1259,8 @@ export function DashboardPage() {
           </div>
         </div>
       )}
+
+      {/* Scroll to Top */}
       {showScrollTop && (
         <button
           onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}


### PR DESCRIPTION
## Summary
Added drag-and-drop widget reordering to the contributor dashboard. Users can now drag widgets to rearrange them, and their preferred layout is saved to localStorage so it persists across page refreshes. A "Reset widget layout" button is also provided to restore the default order.

## Related Issue
Closes #401

## Changes Made

- Created frontend/src/components/ui/DraggableWidgetGrid.tsx — a reusable drag-and-drop wrapper component using native HTML5 drag events (no new dependencies added)
- Updated frontend/src/pages/DashboardPage.tsx:
- Added widgetOrder state with localStorage persistence
- Wrapped all 5 dashboard widgets (Fact/Certificate, Learning Queue, Bookmarks, Badges, Contributors) inside DraggableWidgetGrid
- Added "Reset widget layout" button to restore default order

## Testing

- [x] Tested manually 
- [ ] Add new unit/integration test
- [ ] verified existing test still pass

## Checklist

- [ ] Tests added or updated
- [ ] Documentation updated if needed
- [x] No secrets committed

