### PR TITLE
fix(scripts): enforce secure SSL/TLS verification for GitHub API requests

### DIFF
--- a/scripts/close_duplicates.py
+++ b/scripts/close_duplicates.py
@@ -7,8 +7,6 @@ from dotenv import load_dotenv
 load_dotenv()
 
 ctx = ssl.create_default_context()
-ctx.check_hostname = False
-ctx.verify_mode = ssl.CERT_NONE
 
 token = os.environ.get("GITHUB_TOKEN")
 headers = {

--- a/scripts/dry_run_duplicates.py
+++ b/scripts/dry_run_duplicates.py
@@ -7,8 +7,6 @@ from dotenv import load_dotenv
 load_dotenv()
 
 ctx = ssl.create_default_context()
-ctx.check_hostname = False
-ctx.verify_mode = ssl.CERT_NONE
 
 token = os.environ.get("GITHUB_TOKEN")
 headers = {

--- a/scripts/find_duplicates.py
+++ b/scripts/find_duplicates.py
@@ -3,8 +3,6 @@ import json
 import ssl
 
 ctx = ssl.create_default_context()
-ctx.check_hostname = False
-ctx.verify_mode = ssl.CERT_NONE
 
 url = "https://api.github.com/repos/goyaljiiiiii/Open-Source-Contribution-Atelier/issues?state=all&per_page=100"
 req = urllib.request.Request(url)


### PR DESCRIPTION
## Summary
Removes explicit downgrading of SSL/TLS certificate validation and hostname verification in maintenance scripts to prevent MitM vulnerabilities (SonarQube S5527).

## Related Issue
Closes #699

## Changes Made
- Removed `ctx.check_hostname = False` and `ctx.verify_mode = ssl.CERT_NONE` from `find_duplicates.py`, `dry_run_duplicates.py`, and `close_duplicates.py`.

## Testing
- [x] Tested manually (Verified syntax and successful execution from project root)
- [ ] Add new unit/integration test
- [x] verified existing test still pass

## Screenshots
N/A

## Checklist
- [ ] Tests added or updated
- [ ] Documentation updated if needed
- [x] No secrets committed
