### PR TITLE
fix: path traversal vulnerability in scripts/checker.py

### DIFF
--- a/scripts/link_checker/checker.py
+++ b/scripts/link_checker/checker.py
@@ -88,10 +88,19 @@ async def check_url(session, url, file_path, semaphore):
 
 async def process_files(directory_or_files):
     files_to_check = []
+    base_dir = Path.cwd().resolve()
     
     # If a list of files is provided via args
     for item in directory_or_files:
-        path = Path(item)
+        path = Path(item).resolve()
+        
+        # Prevent path traversal outside the current working directory
+        try:
+            path.relative_to(base_dir)
+        except ValueError:
+            print(Fore.RED + f"Security Error: Path '{item}' is outside the allowed directory.")
+            continue
+
         if path.is_file() and path.suffix == '.md':
             files_to_check.append(path)
         elif path.is_dir():


### PR DESCRIPTION
## Summary
Fixes a security vulnerability in the `checker.py` script where flawed or malicious CLI arguments could be used to bypass file system restrictions and traverse out of the intended project directory (S5334 Path Traversal).

## Related Issue
Closes #700

## Changes Made
- Added a `base_dir` resolution to evaluate against the current working directory.
- Refactored `process_files` to use `pathlib.Path.resolve()` and `pathlib.Path.relative_to()` to strictly verify that target paths fall within the intended workspace.

## Testing
- [x] Tested manually 
- [ ] Add new unit/integration test
- [x] verified existing test still pass

## Screenshots
N/A (CLI Security Fix)

## Checklist
- [x] Tests added or updated (N/A)
- [x] Documentation updated if needed (N/A)
- [x] No secrets committed
