### PR TITLE
Fix: Add maxLength Limit and Character Counter to ChatInput Textarea

### DIFF
--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -57,6 +57,7 @@ export function ChatInput({
 
   return (
     <div className="flex items-end gap-2 border-t border-outline bg-surface-low px-4 py-3">
+    <div className="flex flex-1 flex-col gap-1">
       <textarea
         value={text}
         onChange={handleChange}
@@ -64,9 +65,14 @@ export function ChatInput({
         onBlur={onInputBlur}
         placeholder={placeholder}
         disabled={disabled}
+         maxLength={2000}
         rows={1}
-        className="min-h-[40px] flex-1 resize-none rounded-xl border border-outline bg-surface-high px-3 py-2 text-sm text-text placeholder-muted outline-none focus:border-accent disabled:opacity-50"
+        className="min-h-[40px] w-full resize-none rounded-xl border border-outline bg-surface-high px-3 py-2 text-sm text-text placeholder-muted outline-none focus:border-accent disabled:opacity-50"
       />
+      <span className={`text-right text-xs ${text.length >= 1800 ? "text-red-500" : "text-muted"}`}>
+  {text.length}/2000
+     </span>
+      </div>
       <button
         onClick={handleSend}
         disabled={!text.trim() || disabled}


### PR DESCRIPTION
### Problem
The `ChatInput.tsx` textarea had no character limit, which could cause:
- Performance issues on every keystroke
- Server overload from unlimited input
- Database bloat
- Potential DOS attacks

### Changes Made
- Added `maxLength={2000}` to the `<textarea>` element
- Wrapped textarea in a `<div>` to stack counter below it
- Added character counter `{text.length}/2000` below the textarea
- Counter turns **red** when user reaches `1800+` characters as an early warning
- Changed `flex-1` to `w-full` on textarea since wrapper div handles flex now

### Code Changes

**Before:**
```tsx
<textarea
  value={text}
  onChange={handleChange}
  rows={1}
  className="min-h-[40px] flex-1 resize-none ..."
/>
```

**After:**
```tsx
<div className="flex flex-1 flex-col gap-1">
  <textarea
    value={text}
    onChange={handleChange}
    maxLength={2000}
    rows={1}
    className="min-h-[40px] w-full resize-none ..."
  />
  <span className={`text-right text-xs ${text.length >= 1800 ? "text-red-500" : "text-muted"}`}>
    {text.length}/2000
  </span>
</div>
```

### Type of Change
- [x] Enhancement / New Feature

### Testing
- Typed beyond 2000 characters — input stops at limit 
- Counter displays correctly as user types 
- Counter turns red at 1800+ characters 
- Send button still works normally 
- Layout is not broken 


### Related Issue
Closes #668
