### PR TITLE
ci: add workflow to check for linked issues on prs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -65,6 +65,12 @@ Run all checks above before opening a pull request to avoid CI failures.
 ### 6. Submit a Pull Request
 Push your branch to your fork on GitHub and click **New Pull Request**.
 
+> [!IMPORTANT]
+> **Automated PR Check: Linked Issue Required**
+> Every pull request must reference a related issue in its description. If you don't link an issue, the automated **Check Linked Issue** workflow will fail, and a warning comment will be added.
+>
+> You can link an issue by adding one of the following keywords followed by the issue number in the PR description (e.g., `Closes #123`, `Fixes #123`, `Resolves #123`, `related to #123`, or `ref #123`).
+
 Use the template below for your description:
 ```markdown
 ### Summary

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,8 @@
 <!-- Briefly describe what this Pull-request does -->
 
 ## Related Issue
-<!--What are the issues it solves  -->
+<!-- What are the issues it solves? -->
+<!-- ⚠️ IMPORTANT: The check-linked-issue.yml workflow will fail your PR if you do not link an issue below! -->
 Closes #[Issue_Number]
 
 ## Changes Made

--- a/.github/workflows/check-linked-issue.yml
+++ b/.github/workflows/check-linked-issue.yml
@@ -1,0 +1,40 @@
+name: Check Linked Issue
+on:
+  pull_request_target:
+    types: [opened, edited]
+jobs:
+  check-issue:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        with:
+          script: |
+            const body = context.payload.pull_request.body || '';
+            const issuePattern = /\b(closes|fixes|resolves|related to|ref)\b\s*#\d+/i;
+            const warningText = '⚠️ **No linked issue found!**';
+            if (!issuePattern.test(body)) {
+              const comments = await github.paginate(
+                github.rest.issues.listComments,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.payload.pull_request.number
+                }
+              );
+              const alreadyCommented = comments.some(
+                c => c.user.type === 'Bot' && c.body.includes(warningText)
+              );
+              if (!alreadyCommented) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.payload.pull_request.number,
+                  body: `⚠️ **No linked issue found!**\nThis PR cannot be reviewed until a related issue is linked.\nPlease add \`Closes #issue_number\` in your PR description.`
+                });
+              }
+              core.setFailed('PR must reference a linked issue.');
+            } else {
+              console.log('✅ Linked issue found.');
+            }

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ This project is fully configured to be deployed on **Vercel** as a monorepo.
 ## 🧑‍💻 Contributing
 
 We welcome contributions of all levels suitable for **SSOC 2026** and long-term participation! Please review our guides:
-- **[CONTRIBUTING.md](CONTRIBUTING.md)**: Forking, branching guidelines, commit conventions, and review cycles.
-- **[SUPPORT.md](SUPPORT.md)**: How to get help, community channels, and asking questions.
-- **[CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)**: Community participation guidelines.
-- **[SECURITY.md](SECURITY.md)**: Responsible vulnerability disclosure rules.
+- **[CONTRIBUTING.md](.github/CONTRIBUTING.md)**: Forking, branching guidelines, commit conventions, and review cycles.
+- **[SUPPORT.md](.github/SUPPORT.md)**: How to get help, community channels, and asking questions.
+- **[CODE_OF_CONDUCT.md](.github/CODE_OF_CONDUCT.md)**: Community participation guidelines.
+- **[SECURITY.md](.github/SECURITY.md)**: Responsible vulnerability disclosure rules.


### PR DESCRIPTION
## Summary
Introduces a new GitHub Actions workflow to strictly enforce that all pull requests have a linked issue. It also updates the repository documentation and pull request template to clearly communicate this requirement to contributors.

## Related Issue
<!-- What are the issues it solves? -->
<!-- ⚠️ IMPORTANT: The check-linked-issue.yml workflow will fail your PR if you do not link an issue below! -->
Closes #711 

## Changes Made
- **CI Workflow**: Added `.github/workflows/check-linked-issue.yml` which fails the PR build and posts a warning comment if the PR description lacks issue-linking keywords (e.g., `Closes #123`).
- **Contributing Guidelines**: Updated `.github/CONTRIBUTING.md` to document the new automated check and explain how to correctly link issues.
- **PR Template**: Added a bold warning to `.github/pull_request_template.md` reminding users to provide the issue number.
- **Documentation Links**: Fixed broken markdown links in `README.md` that were pointing to `.github/` documentation files incorrectly.

## Testing
- [x] Tested manually 
- [ ] Add new unit/integration test
- [x] verified existing test still pass

## Screenshots
N/A (CI and Documentation updates only)

## Checklist
- [ ] Tests added or updated
- [x] Documentation updated if needed
- [x] No secrets committed