### PR TITLE
feat(ui): implement global toast notifications & api interceptor (#368)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
         "lucide-react": "^0.474.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-hot-toast": "^2.6.0",
         "react-router-dom": "^7.17.0",
         "recharts": "^3.8.1",
         "zxcvbn": "^4.4.2"
@@ -2112,7 +2113,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -2834,6 +2834,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/goober": {
+      "version": "2.1.19",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.19.tgz",
+      "integrity": "sha512-U7veizMqxyKlM58+Z5j2ngJBH/r9siDmxpvNxSw0PylF6WQvrASJEZrxh1hidRBJc2jqoBVSyOban5u8m+6Rxg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
       }
     },
     "node_modules/has-flag": {
@@ -4158,6 +4167,23 @@
       },
       "peerDependencies": {
         "react": "^19.2.7"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.6.0.tgz",
+      "integrity": "sha512-bH+2EBMZ4sdyou/DPrfgIouFpcRLCJ+HoCA32UoAYHn6T3Ur5yfcDCeSr5mwldl6pFOsiocmrXMuoCJ1vV8bWg==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.1.3",
+        "goober": "^2.1.16"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-is": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "lucide-react": "^0.474.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-hot-toast": "^2.6.0",
     "react-router-dom": "^7.17.0",
     "recharts": "^3.8.1",
     "zxcvbn": "^4.4.2"

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -1,5 +1,6 @@
 import { QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter } from "react-router-dom";
+import { Toaster } from "react-hot-toast"; // <-- YEH HUMNE ADD KIYA HAI
 import { AppRouter } from "./router";
 import ScrollToTop from "../components/ScrollToTop";
 import { queryClient } from "../lib/queryClient";
@@ -9,6 +10,20 @@ export function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>
+        {/* Global Toast Configuration */}
+        <Toaster 
+          position="top-right"
+          toastOptions={{
+            className: 'bg-gray-900 text-white border border-gray-800 shadow-xl font-sans text-sm',
+            duration: 4000,
+            success: {
+              iconTheme: { primary: '#10B981', secondary: '#ffffff' },
+            },
+            error: {
+              iconTheme: { primary: '#EF4444', secondary: '#ffffff' },
+            },
+          }} 
+        />
         <AppRouter />
         <ScrollToTop />
         <CommandPalette />

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,5 @@
 import { queueProgressSync } from "./offlineQueue";
+import toast from "react-hot-toast"; // <-- YEH HUMNE ADD KIYA HAI
 
 const API_BASE =
   import.meta.env.VITE_API_BASE_URL?.trim() ||
@@ -34,13 +35,43 @@ export async function fetchApi(endpoint: string, options: RequestOptions = {}) {
 
     if (!response.ok) {
       const errorBody = await response.json().catch(() => ({}));
-      throw new Error(
-        errorBody.detail || errorBody.error || "An error occurred",
-      );
+      const errorMessage = errorBody.detail || errorBody.error || errorBody.message || "An error occurred";
+      
+      // --- HUMARA GLOBAL TOAST NOTIFICATION LOGIC ---
+      switch (response.status) {
+        case 400:
+          toast.error(errorMessage || 'Invalid request. Please check your inputs.');
+          break;
+        case 401:
+          toast.error('Session expired. Please log in again.');
+          break;
+        case 403:
+          toast.error('You do not have permission to perform this action.');
+          break;
+        case 429:
+          toast.error(errorMessage || 'Too many requests. Please slow down!');
+          break;
+        case 500:
+          toast.error('Server error. Our team has been notified.');
+          break;
+        default:
+          toast.error(errorMessage);
+      }
+      // ----------------------------------------------
+
+      throw new Error(errorMessage);
+    }
+    
+    return await response.json().catch(() => ({}));
+    
+  } catch (error) {
+    // Prevent toast spam if it's specifically the offline background sync firing a network error
+    if (error instanceof TypeError || !navigator.onLine) {
+        if (endpoint !== "/progress/me/") {
+            toast.error('Network error. Please check your connection.');
+        }
     }
 
-    return response.json().catch(() => ({}));
-  } catch (error) {
     if (endpoint === "/progress/me/" && config.method === "POST") {
       const isOfflineOrNetworkError =
         !navigator.onLine || error instanceof TypeError;
@@ -59,7 +90,6 @@ export async function fetchApi(endpoint: string, options: RequestOptions = {}) {
               completed: bodyObj.completed,
               headers: Object.fromEntries(headers.entries()),
             });
-            // Return mock success response so callers (e.g. React Query mutation) succeed
             return {
               lesson_slug,
               completed: bodyObj.completed ?? true,


### PR DESCRIPTION
Summary
This Pull Request introduces a centralized global toast notification system for the frontend. By integrating react-hot-toast and updating our native fetchApi wrapper, the application now automatically catches and displays standard HTTP and network errors across the entire app without requiring repetitive error-handling logic in individual components.

Related Issue
Closes #368

Changes Made
Installed react-hot-toast to handle UI notifications.

Injected the <Toaster /> component into the root frontend/src/app/App.tsx with custom styling to match the project's premium neobrutalist aesthetic.

Upgraded the fetchApi wrapper in frontend/src/lib/api.ts to act as an interceptor. It now automatically triggers appropriate error toasts for 400, 401, 403, 429, and 500 status codes, as well as general network disconnection errors, while preserving the existing offline queue sync logic.

Testing
[x] Tested manually

[ ] Add new unit/integration test

[x] Verified existing tests still pass

Test Steps Executed:

Simulated offline environment via browser DevTools to trigger and verify the "Network error" toast.

Verified that the background queue sync logic remains uninterrupted during offline mode.

Screenshots
<img width="1917" height="936" alt="image" src="https://github.com/user-attachments/assets/f9e9495e-db2d-4056-9af7-015ae23eb558" />


Checklist
[ ] Tests added or updated

[ ] Documentation updated if needed

[x] No secrets committed