### PR TITLE
fix: resolve mobile navigation z-index collision (#606)

### DIFF
--- a/frontend/src/pages/LessonPage.tsx
+++ b/frontend/src/pages/LessonPage.tsx
@@ -326,7 +326,7 @@ export function LessonPage() {
   return (
     <div className="min-h-screen pt-20 flex flex-col lg:flex-row relative">
       {/* 1. Mobile Sidebar Toggle */}
-      <div className="lg:hidden bg-white border-b-4 border-black dark:bg-[#151411] dark:border-[#2e2924] p-4 flex items-center justify-between z-10">
+      <div className="lg:hidden bg-white border-b-4 border-black dark:bg-[#151411] dark:border-[#2e2924] p-4 flex items-center justify-between z-[80]">
         <button
           onClick={() => setIsSidebarOpen((prev) => !prev)}
           aria-expanded={isSidebarOpen}
@@ -344,7 +344,7 @@ export function LessonPage() {
       {/* Backdrop overlay — closes drawer on click-outside on mobile */}
       {isSidebarOpen && (
         <div
-          className="fixed inset-0 z-10 bg-black/40 lg:hidden"
+          className="fixed inset-0 z-[90] bg-black/40 lg:hidden"
           aria-hidden="true"
           onClick={closeSidebar}
         />
@@ -354,7 +354,7 @@ export function LessonPage() {
       <aside
         id="course-sidebar"
         ref={sidebarRef}
-        className={`fixed top-0 left-0 h-full w-[300px] border-r-4 border-black bg-white dark:bg-[#151411] dark:border-[#2e2924] overflow-y-auto p-6 transition-transform duration-300 ease-in-out z-20 pt-20
+        className={`fixed top-0 left-0 h-full w-[300px] border-r-4 border-black bg-white dark:bg-[#151411] dark:border-[#2e2924] overflow-y-auto p-6 transition-transform duration-300 ease-in-out z-[100] pt-20
           ${isSidebarOpen ? "translate-x-0" : "-translate-x-full"}
           lg:relative lg:top-auto lg:left-auto lg:h-auto lg:w-[320px] lg:flex-shrink-0 lg:translate-x-0 lg:block lg:max-h-[calc(100vh-80px)]`}
       >


### PR DESCRIPTION
> Please checkmark if you are contributing under SSoC 2026:

* [x] I am a SSoC26 contributor

## 📋 Description of Changes

* Updated the z-index hierarchy for the mobile lesson navigation drawer to ensure it appears above sticky page elements.
* Increased the stacking order of the mobile header, backdrop overlay, and course directory sidebar to prevent z-index collisions on mobile devices.

## 🔗 Related Issue

Closes #606

## 🧪 Proof of Manual Testing (MANDATORY)

<details>
<summary><b>Click to expand and paste screenshots / logs</b></summary>

### Visual Changes (UI/Frontend)

**Manual Testing Performed**

* Opened the application in a mobile viewport using browser DevTools.
* Navigated to a lesson page.
* Opened the **Course Directory** using the hamburger menu.
* Verified that the sidebar drawer is displayed above sticky page content.
* Verified that the backdrop overlay covers the page correctly.
* Verified that the drawer can be closed using both the close button and click-outside behavior.

> **Attach screenshots or a short GIF here before submitting the PR.**

### API / Terminal / Test Logs

```bash
npm install

npm run dev

VITE v8.1.0 ready

Local: http://localhost:5173/
```

</details>

## ⚙️ Verification Logs (Automated Tests)

```bash
Not run (UI-only z-index fix).
```

## 📝 Pre-Submission Checklist

* [x] My PR title follows the Conventional Commits format (e.g. `feat: ...`, `fix: ...`, `docs: ...`, `refactor: ...`).
* [x] My branch name starts with a standard prefix (`feat/`, `fix/`, `docs/`, `refactor/`).
* [x] I have linked a related issue in the "Related Issue" section above.
* [ ] I have verified that all existing tests pass and added new tests if applicable.
* [ ] I have formatted my changes locally (`cd frontend && npm run format` and `cd backend && black . && isort .`).
* [x] No API keys, credentials, or sensitive configurations are committed.
