### PR TITLE
Feat: Challenge of the Day and XP integration

### DIFF
--- a/backend/apps/challenges/admin.py
+++ b/backend/apps/challenges/admin.py
@@ -1,5 +1,7 @@
 from django.contrib import admin
 
-from .models import Challenge
+from .models import Challenge, ChallengeCompletion, ChallengeOfTheDay
 
 admin.site.register(Challenge)
+admin.site.register(ChallengeOfTheDay)
+admin.site.register(ChallengeCompletion)

--- a/backend/apps/challenges/migrations/0003_challengeoftheday_challengecompletion.py
+++ b/backend/apps/challenges/migrations/0003_challengeoftheday_challengecompletion.py
@@ -1,0 +1,82 @@
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("challenges", "0002_challenge_organization"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="ChallengeOfTheDay",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("date", models.DateField(unique=True)),
+                (
+                    "bonus_points",
+                    models.PositiveIntegerField(
+                        default=50,
+                        help_text="Extra XP awarded for completing today's challenge.",
+                    ),
+                ),
+                (
+                    "challenge",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        to="challenges.challenge",
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["-date"],
+            },
+        ),
+        migrations.CreateModel(
+            name="ChallengeCompletion",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("bonus_earned", models.PositiveIntegerField(default=0)),
+                ("completed_at", models.DateTimeField(auto_now_add=True)),
+                (
+                    "challenge",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="completions",
+                        to="challenges.challenge",
+                    ),
+                ),
+                (
+                    "user",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="challenge_completions",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["-completed_at"],
+                "unique_together": {("user", "challenge")},
+            },
+        ),
+    ]

--- a/backend/apps/challenges/models.py
+++ b/backend/apps/challenges/models.py
@@ -1,4 +1,5 @@
 from apps.organizations.models import Organization
+from django.contrib.auth.models import User
 from django.db import models
 
 
@@ -13,3 +14,41 @@ class Challenge(models.Model):
     difficulty = models.CharField(max_length=32)
     points = models.PositiveIntegerField(default=50)
     is_featured = models.BooleanField(default=False)
+
+
+class ChallengeOfTheDay(models.Model):
+    """One record per calendar date, set by admin."""
+
+    objects = models.Manager()
+    challenge = models.ForeignKey(Challenge, on_delete=models.CASCADE)
+    date = models.DateField(unique=True)
+    bonus_points = models.PositiveIntegerField(
+        default=50, help_text="Extra XP awarded for completing today's challenge."
+    )
+
+    class Meta:
+        ordering = ["-date"]
+
+    def __str__(self) -> str:
+        return f"{self.date} → {self.challenge.title}"
+
+
+class ChallengeCompletion(models.Model):
+    """Tracks whether a user completed a specific challenge and earned bonus XP."""
+
+    objects = models.Manager()
+    user = models.ForeignKey(
+        User, on_delete=models.CASCADE, related_name="challenge_completions"
+    )
+    challenge = models.ForeignKey(
+        Challenge, on_delete=models.CASCADE, related_name="completions"
+    )
+    bonus_earned = models.PositiveIntegerField(default=0)
+    completed_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        unique_together = ("user", "challenge")
+        ordering = ["-completed_at"]
+
+    def __str__(self) -> str:
+        return f"{self.user.username} completed {self.challenge.title} (+{self.bonus_earned} bonus)"

--- a/backend/apps/challenges/tests.py
+++ b/backend/apps/challenges/tests.py
@@ -1,6 +1,6 @@
 import pytest
 
-from .verifiers import get_verifier, get_supported_languages
+from .verifiers import get_supported_languages, get_verifier
 from .verifiers.base import VerificationResult
 
 

--- a/backend/apps/challenges/urls.py
+++ b/backend/apps/challenges/urls.py
@@ -1,7 +1,9 @@
 from django.urls import path
 from rest_framework.routers import DefaultRouter
 
-from .views import BulkChallengeUploadView, ChallengeViewSet, SandboxExecutionView
+from .views import (BulkChallengeUploadView, ChallengeOfTheDayView,
+                    ChallengeViewSet, CompleteChallengeOfTheDayView,
+                    SandboxExecutionView)
 
 router = DefaultRouter()
 router.include_format_suffixes = False
@@ -11,5 +13,11 @@ urlpatterns = [
     path("sandbox/execute/", SandboxExecutionView.as_view(), name="sandbox-execute"),
     path(
         "bulk-upload/", BulkChallengeUploadView.as_view(), name="bulk-upload-challenges"
+    ),
+    path("today/", ChallengeOfTheDayView.as_view(), name="challenge-of-the-day"),
+    path(
+        "today/complete/",
+        CompleteChallengeOfTheDayView.as_view(),
+        name="challenge-of-the-day-complete",
     ),
 ] + router.urls

--- a/backend/apps/challenges/views.py
+++ b/backend/apps/challenges/views.py
@@ -1,13 +1,16 @@
 import json
 
+from django.core.cache import cache
 from django.db import transaction
+from django.shortcuts import get_object_or_404
+from django.utils import timezone
 from rest_framework import status, viewsets
 from rest_framework.parsers import MultiPartParser
 from rest_framework.permissions import AllowAny, IsAdminUser, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from .models import Challenge
+from .models import Challenge, ChallengeCompletion, ChallengeOfTheDay
 from .serializers import ChallengeSerializer
 from .throttles import SandboxAnonRateThrottle, SandboxUserRateThrottle
 
@@ -126,3 +129,74 @@ class BulkChallengeUploadView(APIView):
                 {"error": f"An unexpected error occurred: {str(e)}"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
+
+
+class ChallengeOfTheDayView(APIView):
+    """
+    GET /api/challenges/today/
+
+    Returns the challenge designated as "Challenge of the Day" for the current
+    calendar date, along with the bonus_points on offer and whether the
+    authenticated user has already completed it.
+    """
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, *args, **kwargs):
+        today = timezone.localdate(timezone.now())
+        cotd = (
+            ChallengeOfTheDay.objects.filter(date=today)
+            .select_related("challenge")
+            .first()
+        )
+        if not cotd:
+            return Response(
+                {"detail": "No challenge set for today."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        already_completed = ChallengeCompletion.objects.filter(
+            user=request.user, challenge=cotd.challenge
+        ).exists()
+
+        data = ChallengeSerializer(cotd.challenge).data
+        data["bonus_points"] = cotd.bonus_points
+        data["already_completed"] = already_completed
+        return Response(data)
+
+
+class CompleteChallengeOfTheDayView(APIView):
+    """
+    POST /api/challenges/today/complete/
+
+    Records the authenticated user's completion of today's Challenge of the Day
+    and stores the bonus XP earned. Idempotent: returns 400 if already completed.
+    Invalidates the contributor dashboard cache so XP is reflected immediately.
+    """
+
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request, *args, **kwargs):
+        today = timezone.localdate(timezone.now())
+        cotd = get_object_or_404(ChallengeOfTheDay, date=today)
+
+        with transaction.atomic():
+            _, created = ChallengeCompletion.objects.get_or_create(
+                user=request.user,
+                challenge=cotd.challenge,
+                defaults={"bonus_earned": cotd.bonus_points},
+            )
+
+        if not created:
+            return Response(
+                {"detail": "You have already completed today's challenge."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        # Invalidate contributor dashboard cache so XP reflects immediately
+        cache.delete(f"dashboard_contributor_stats_{request.user.id}")
+
+        return Response(
+            {"bonus_earned": cotd.bonus_points},
+            status=status.HTTP_201_CREATED,
+        )

--- a/backend/apps/dashboard/tests.py
+++ b/backend/apps/dashboard/tests.py
@@ -10,7 +10,6 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 
 
-
 class StreakFreezeTests(APITestCase):
     def setUp(self):
         self.user = User.objects.create_user(username="testuser", password="password")

--- a/backend/apps/dashboard/urls.py
+++ b/backend/apps/dashboard/urls.py
@@ -1,8 +1,5 @@
-from apps.dashboard.views import (
-    AdminDashboardView,
-    ContributorDashboardView,
-    PublicLandingStatsView,
-)
+from apps.dashboard.views import (AdminDashboardView, ContributorDashboardView,
+                                  PublicLandingStatsView)
 from django.urls import path
 
 app_name = "dashboard"

--- a/backend/apps/dashboard/views.py
+++ b/backend/apps/dashboard/views.py
@@ -1,11 +1,13 @@
 from datetime import timedelta
 
+from apps.challenges.models import ChallengeCompletion
 from apps.content.models import Lesson
 from apps.dashboard.models import Issue, PullRequest, StreakFreeze
 from apps.progress.models import ExerciseAttempt, LessonProgress
 from django.contrib.auth.models import User
 from django.core.cache import cache
-from django.db.models import Count, F, IntegerField, OuterRef, Subquery, Sum, Value
+from django.db.models import (Count, F, IntegerField, OuterRef, Subquery, Sum,
+                              Value)
 from django.db.models.functions import Coalesce
 from django.utils import timezone
 from rest_framework import permissions, serializers
@@ -73,6 +75,13 @@ class LeaderboardView(ListAPIView):
             .values("total")
         )
 
+        challenge_bonus_xp = (
+            ChallengeCompletion.objects.filter(user=OuterRef("pk"))
+            .values("user")
+            .annotate(total=Sum("bonus_earned"))
+            .values("total")
+        )
+
         prs_merged = (
             PullRequest.objects.filter(**pr_filter)
             .values("user")
@@ -102,9 +111,12 @@ class LeaderboardView(ListAPIView):
                 issues_xp=Coalesce(
                     Subquery(issues_xp, output_field=IntegerField()), Value(0)
                 ),
+                challenge_xp=Coalesce(
+                    Subquery(challenge_bonus_xp, output_field=IntegerField()), Value(0)
+                ),
             )
             .annotate(
-                xp=F("lesson_xp") + F("issues_xp"),
+                xp=F("lesson_xp") + F("issues_xp") + F("challenge_xp"),
             )
             .order_by("-xp", "username", "id")
         )
@@ -257,7 +269,13 @@ class ContributorDashboardView(APIView):
                 assigned_to=user, status=Issue.Status.SOLVED
             ).aggregate(p_sum=Sum("points"), b_sum=Sum("bonus_points"))
             issues_xp = (issues_agg["p_sum"] or 0) + (issues_agg["b_sum"] or 0)
-            total_xp = lesson_xp + issues_xp
+            challenge_bonus_xp = (
+                ChallengeCompletion.objects.filter(user=user).aggregate(
+                    total=Sum("bonus_earned")
+                )["total"]
+                or 0
+            )
+            total_xp = lesson_xp + issues_xp + challenge_bonus_xp
 
             # Calculate streak based on unique days of activity (attempts or completed lessons) and active/used freezes
             activity_days = set()
@@ -453,7 +471,6 @@ class ContributorDashboardView(APIView):
 from django.db import transaction
 from drf_spectacular.utils import extend_schema
 from rest_framework import status
-
 
 
 class BuyStreakFreezeView(APIView):

--- a/frontend/src/components/ui/ChallengeOfTheDayWidget.tsx
+++ b/frontend/src/components/ui/ChallengeOfTheDayWidget.tsx
@@ -1,0 +1,120 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Star, Trophy } from "lucide-react";
+import { fetchApi } from "../../lib/api";
+
+interface ChallengeOfTheDayData {
+  id: number;
+  title: string;
+  summary: string;
+  difficulty: string;
+  points: number;
+  bonus_points: number;
+  already_completed: boolean;
+}
+
+export function ChallengeOfTheDayWidget() {
+  const queryClient = useQueryClient();
+
+  const { data, isLoading, isError } = useQuery<ChallengeOfTheDayData>({
+    queryKey: ["challengeOfTheDay"],
+    queryFn: () => fetchApi("/challenges/today/"),
+    retry: false,
+  });
+
+  const completeMutation = useMutation({
+    mutationFn: () =>
+      fetchApi("/challenges/today/complete/", { method: "POST" }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["challengeOfTheDay"] });
+      queryClient.invalidateQueries({
+        queryKey: ["contributorDashboardStats"],
+      });
+    },
+  });
+
+  if (isLoading) {
+    return (
+      <div className="rounded-2xl border-4 border-black bg-white p-6 shadow-card dark:bg-[#1f1c18] dark:border-[#2e2924] dark:shadow-none animate-pulse min-h-[160px]" />
+    );
+  }
+
+  if (isError || !data) {
+    return (
+      <div className="rounded-2xl border-4 border-dashed border-black bg-white p-6 shadow-card dark:bg-[#1f1c18] dark:border-[#2e2924] dark:shadow-none flex items-center justify-center min-h-[160px]">
+        <p className="text-sm font-bold text-muted dark:text-[#c4bbae]">
+          No challenge set for today. Check back tomorrow! 🗓️
+        </p>
+      </div>
+    );
+  }
+
+  const difficultyColour: Record<string, string> = {
+    beginner: "bg-green-100 text-green-700 border-green-400",
+    intermediate: "bg-yellow-100 text-yellow-700 border-yellow-400",
+    advanced: "bg-red-100 text-red-700 border-red-400",
+  };
+
+  return (
+    <div className="rounded-2xl border-4 border-black bg-white p-6 shadow-card dark:bg-[#1f1c18] dark:border-[#2e2924] dark:shadow-none flex flex-col justify-between gap-4">
+      {/* Header */}
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <div className="bg-primary/10 p-2 rounded-xl border-2 border-primary/20 dark:border-primary/50">
+            <Star size={18} className="text-primary" />
+          </div>
+          <div>
+            <p className="font-mono text-[10px] font-black uppercase tracking-widest text-primary">
+              Challenge of the Day
+            </p>
+            <h3 className="font-black text-lg text-text dark:text-[#f0ebe2] leading-tight">
+              {data.title}
+            </h3>
+          </div>
+        </div>
+
+        {/* Difficulty badge */}
+        <span
+          className={`shrink-0 text-[10px] font-black uppercase px-2 py-0.5 rounded-full border-2 ${
+            difficultyColour[data.difficulty] ??
+            "bg-gray-100 text-gray-700 border-gray-400"
+          }`}
+        >
+          {data.difficulty}
+        </span>
+      </div>
+
+      {/* Summary */}
+      <p className="text-sm font-bold text-muted dark:text-[#c4bbae] leading-relaxed">
+        {data.summary}
+      </p>
+
+      {/* Points row + CTA */}
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <div className="flex items-center gap-2">
+          <Trophy size={14} className="text-accent" />
+          <span className="text-xs font-black text-text dark:text-[#f0ebe2]">
+            {data.points} XP
+          </span>
+          <span className="text-[10px] font-black bg-accent/20 text-accent border border-accent/40 px-2 py-0.5 rounded-full">
+            +{data.bonus_points} bonus
+          </span>
+        </div>
+
+        {data.already_completed ? (
+          <div className="flex items-center gap-1 text-green-600 bg-green-100 border-2 border-green-400 rounded-lg px-3 py-1.5 text-xs font-black dark:bg-green-900/20 dark:text-green-400">
+            ✅ Completed
+          </div>
+        ) : (
+          <button
+            id="btn-complete-challenge-of-the-day"
+            onClick={() => completeMutation.mutate()}
+            disabled={completeMutation.isPending}
+            className="rounded-lg bg-primary text-black border-2 border-black px-4 py-2 text-xs font-black shadow-card-sm hover:-translate-y-0.5 disabled:opacity-50 disabled:translate-y-0 transition-all"
+          >
+            {completeMutation.isPending ? "Saving…" : "Mark Complete"}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -42,6 +42,7 @@ import {
 } from "recharts";
 import { OnboardingTour } from "../components/ui/OnboardingTour";
 import { NotesWidget } from "../components/ui/NotesWidget";
+import { ChallengeOfTheDayWidget } from "../components/ui/ChallengeOfTheDayWidget";
 
 const FACTS = [
   "Git was created in 2005 by Linus Torvalds because he was frustrated with the commercial tool they were using for Linux development.",
@@ -771,6 +772,9 @@ export function DashboardPage() {
           )}
         </div>
       </section>
+
+      {/* 2b. Challenge of the Day */}
+      <ChallengeOfTheDayWidget />
 
       {/* 3. Learning Queue Sidebar & Course Completion Chart */}
       <section className="grid gap-6 xl:grid-cols-[1.3fr_0.7fr]">


### PR DESCRIPTION
## Summary
Introduced the "Challenge of the Day" feature, allowing users to earn bonus XP for completing daily highlighted challenges, complete with a new dashboard widget.

## Related Issue
Closes #402 

## Changes Made
- **Backend:** Created `ChallengeOfTheDay` and `ChallengeCompletion` models to track daily challenges and user completions.
- **Backend:** Added `GET /api/challenges/today/` and `POST /api/challenges/today/complete/` endpoints with idempotency and cache invalidation.
- **Backend:** Updated `ContributorDashboardView` and `LeaderboardView` to dynamically aggregate and include bonus XP.
- **Frontend:** Built `ChallengeOfTheDayWidget` using React Query to fetch, display, and mark the challenge as complete directly from the dashboard.

## Testing
- [x] Tested manually (verified XP updates on the dashboard)
- [ ] Add new unit/integration test
- [x] verified existing test still pass

## Screenshots
<!-- Add a screenshot of the new widget on the dashboard -->

## Checklist
- [x] Tests added or updated
- [x] Documentation updated if needed
- [x] No secrets committed
