### PR TITLE
feat: add report typo button to lesson page

### DIFF
--- a/frontend/src/pages/LessonPage.tsx
+++ b/frontend/src/pages/LessonPage.tsx
@@ -509,15 +509,30 @@ export function LessonPage() {
                 <MarkdownRenderer content={markdownContent} />
               </React.Suspense>
             </article>
+            {/* Report Typo Button */}
+            <div className="mt-4 flex justify-end">
+              <button
+                onClick={() => alert("Thanks for reporting the typo")}
+                className="px-4 py-2 bg-red-500 text-white rounded-lg font-bold border-2 border-black hover:opacity-90 transition"
+              >
+                Report Typo 🐛
+              </button>
+            </div>
 
             {/* Exercises & validation section */}
             <div className="pt-8 space-y-6">
               {lesson.pythonExercise ? (
                 <div className="mt-8">
-                  {new URLSearchParams(window.location.search).get("session") ? (
+                  {new URLSearchParams(window.location.search).get(
+                    "session",
+                  ) ? (
                     <CollabPythonSandbox
                       exercise={lesson.pythonExercise}
-                      roomId={new URLSearchParams(window.location.search).get("session")!}
+                      roomId={
+                        new URLSearchParams(window.location.search).get(
+                          "session",
+                        )!
+                      }
                       onSuccess={() => {
                         syncProgress({
                           lesson_slug: lesson.slug,


### PR DESCRIPTION
<!-- 
  IMPORTANT: Please review the guidelines below. 
  PRs that do not contain proof of manual testing or do not link to a valid issue will be closed automatically.
-->

> Please checkmark if you are contributing under SSoC 2026:
- [x] I am a SSoC26 contributor

## 📋 Description of Changes
- Added a new "Report Typo" button below lesson content on LessonPage.tsx
- Added click handler to acknowledge user feedback when reporting a typo
- Improved lesson page UI by giving users a way to report content mistakes

## 🔗 Related Issue
Closes #410


## 🧪 Proof of Manual Testing (MANDATORY)
   - Ran frontend locally using `npm run dev`
   - Verified lesson page renders correctly
   - Confirmed "Report Typo" button appears below markdown content
   - Confirmed clicking button shows acknowledgement alert
Screenshot attached below.
<img width="1818" height="222" alt="image" src="https://github.com/user-attachments/assets/8ba48565-d851-498c-93ec-f5fd716abd11" />

## ⚙️ Verification Logs (Automated Tests)

```bash
cd frontend
npm install
npm run dev

> contribution-atelier-frontend@0.1.0 dev
> vite

VITE v8.1.0 ready in 786 ms

Local: http://localhost:5173/
```
## 📝 Pre-Submission Checklist
<!-- Please check all boxes that apply. If not checked, the PR may be rejected. -->

- [x] My PR title follows the Conventional Commits format (e.g. `feat: ...`, `fix: ...`, `docs: ...`, `refactor: ...`).
- [ ] My branch name starts with a standard prefix (`feat/`, `fix/`, `docs/`, `refactor/`).
- [x] I have linked a related issue in the "Related Issue" section above.
- [ ] I have verified that all existing tests pass and added new tests if applicable.
- [ ] I have formatted my changes locally (`cd frontend && npm run format` and `cd backend && black . && isort .`).
- [x] No API keys, credentials, or sensitive configurations are committed.
