### PR TITLE
Add per‑field caching & query optimisations to Contributor Dashboard

### DIFF
--- a/backend/apps/challenges/views.py
+++ b/backend/apps/challenges/views.py
@@ -194,7 +194,9 @@ class CompleteChallengeOfTheDayView(APIView):
             )
 
         # Invalidate contributor dashboard cache so XP reflects immediately
-        cache.delete(f"dashboard_contributor_stats_{request.user.id}")
+        from apps.dashboard.signals import clear_dashboard_caches
+
+        clear_dashboard_caches(user_id=request.user.id)
 
         return Response(
             {"bonus_earned": cotd.bonus_points},

--- a/backend/apps/dashboard/signals.py
+++ b/backend/apps/dashboard/signals.py
@@ -17,6 +17,10 @@ def clear_dashboard_caches(user_id=None):
     # If a specific user is affected, clear their specific contributor stats cache
     if user_id:
         cache.delete(f"dashboard_contributor_stats_{user_id}")
+        cache.delete(f"dashboard_contributor_personal_stats_{user_id}")
+        cache.delete(f"dashboard_contributor_assigned_issues_{user_id}")
+        cache.delete(f"dashboard_contributor_recent_prs_{user_id}")
+        cache.delete(f"dashboard_contributor_progress_tracker_{user_id}")
 
 
 @receiver(pre_save, sender=Issue)

--- a/backend/apps/dashboard/views.py
+++ b/backend/apps/dashboard/views.py
@@ -4,22 +4,30 @@ from apps.challenges.models import ChallengeCompletion
 from apps.content.models import Lesson
 from apps.dashboard.models import Issue, PullRequest, StreakFreeze
 from apps.progress.models import (
+    CodeSubmission,
     ExerciseAttempt,
     LessonProgress,
     QuizAttempt,
-    CodeSubmission,
 )
+
+from apps.rbac.permissions import HasRole
+from apps.rbac.models import UserRole
+
 from django.contrib.auth.models import User
 from django.core.cache import cache
-from django.db.models import Count, F, IntegerField, OuterRef, Subquery, Sum, Value
-from django.db.models.functions import Coalesce
+from django.db import models, transaction
+from django.db.models import Count, F, IntegerField, OuterRef, Q, Subquery, Sum, Value
+from django.db.models.functions import Coalesce, TruncDate
+
 from django.utils import timezone
-from django.db.models.functions import TruncDate
-from rest_framework import permissions, serializers
-from apps.rbac.permissions import HasRole
+
+from drf_spectacular.utils import extend_schema
+from rest_framework import permissions, serializers, status
 from rest_framework.generics import ListAPIView
 from rest_framework.pagination import CursorPagination
 from rest_framework.response import Response
+from rest_framework.views import APIView
+
 from rest_framework.views import APIView
 
 
@@ -251,13 +259,8 @@ class ContributorDashboardView(APIView):
 
     permission_classes = [permissions.IsAuthenticated]
 
-    def get(self, request):
-        user = request.user
-        cache_key = f"dashboard_contributor_stats_{user.id}"
-        data = cache.get(cache_key)
-
-        if data is None:
-            # 1. Personal stats
+    def _calculate_field(self, user, field):
+        if field == "personal_stats":
             issues_solved = Issue.objects.filter(
                 assigned_to=user, status=Issue.Status.SOLVED
             ).count()
@@ -302,40 +305,41 @@ class ContributorDashboardView(APIView):
             streak_days = 0
             current_day = today
 
-            with transaction.atomic():
-                while True:
-                    if current_day < join_date:
-                        break
+            all_freezes = list(
+                StreakFreeze.objects.filter(user=user).order_by("purchased_at")
+            )
+            consumed_freezes_by_date = {
+                f.used_on_date: f for f in all_freezes if f.used_on_date is not None
+            }
+            unused_freezes = [f for f in all_freezes if f.used_on_date is None]
+            modified_freezes = []
 
-                    if current_day in activity_days:
+            while True:
+                if current_day < join_date:
+                    break
+
+                if current_day in activity_days:
+                    streak_days += 1
+                elif current_day == today:
+                    # If today has no activity, we just skip it (does not break the streak and does not count towards it)
+                    pass
+                else:
+                    # Check if there is already a consumed freeze for this date
+                    if current_day in consumed_freezes_by_date:
                         streak_days += 1
-                    elif current_day == today:
-                        # If today has no activity, we just skip it (does not break the streak and does not count towards it)
-                        pass
+                    elif unused_freezes:
+                        unused_freeze = unused_freezes.pop(0)
+                        unused_freeze.used_on_date = current_day
+                        modified_freezes.append(unused_freeze)
+                        consumed_freezes_by_date[current_day] = unused_freeze
+                        streak_days += 1
                     else:
-                        # Check if there is already a consumed freeze for this date
-                        consumed_freeze = StreakFreeze.objects.filter(
-                            user=user, used_on_date=current_day
-                        ).exists()
-                        if consumed_freeze:
-                            streak_days += 1
-                        else:
-                            # Check if there is an unused freeze to consume
-                            unused_freeze = (
-                                StreakFreeze.objects.filter(
-                                    user=user, used_on_date__isnull=True
-                                )
-                                .order_by("purchased_at")
-                                .first()
-                            )
-                            if unused_freeze:
-                                unused_freeze.used_on_date = current_day
-                                unused_freeze.save()
-                                streak_days += 1
-                            else:
-                                # No activity and no freeze available, the streak is broken
-                                break
-                    current_day -= timedelta(days=1)
+                        break
+                current_day -= timedelta(days=1)
+
+            if modified_freezes:
+                with transaction.atomic():
+                    StreakFreeze.objects.bulk_update(modified_freezes, ["used_on_date"])
 
             # Determine Rank based on user XP vs others
             lesson_xp_sub = (
@@ -352,24 +356,38 @@ class ContributorDashboardView(APIView):
                 .annotate(total=Sum("points") + Sum("bonus_points"))
                 .values("total")
             )
-
-            all_users = User.objects.filter(is_staff=False).annotate(
-                u_lxp=Coalesce(
-                    Subquery(lesson_xp_sub, output_field=IntegerField()), Value(0)
-                ),
-                u_ixp=Coalesce(
-                    Subquery(issues_xp_sub, output_field=IntegerField()), Value(0)
-                ),
+            challenge_xp_sub = (
+                ChallengeCompletion.objects.filter(user=OuterRef("pk"))
+                .values("user")
+                .annotate(total=Sum("bonus_earned"))
+                .values("total")
             )
 
-            user_ranks = [(u.id, u.u_lxp + u.u_ixp) for u in all_users]
-
-            user_ranks.sort(key=lambda x: x[1], reverse=True)
-            rank = 1
-            for index, (uid, u_xp) in enumerate(user_ranks):
-                if uid == user.id:
-                    rank = index + 1
-                    break
+            better_users_count = (
+                User.objects.filter(is_staff=False)
+                .annotate(
+                    u_lxp=Coalesce(
+                        Subquery(lesson_xp_sub, output_field=IntegerField()), Value(0)
+                    ),
+                    u_ixp=Coalesce(
+                        Subquery(issues_xp_sub, output_field=IntegerField()), Value(0)
+                    ),
+                    u_cxp=Coalesce(
+                        Subquery(challenge_xp_sub, output_field=IntegerField()),
+                        Value(0),
+                    ),
+                )
+                .annotate(
+                    user_total_xp=F("u_lxp") + F("u_ixp") + F("u_cxp"),
+                )
+                .filter(
+                    Q(user_total_xp__gt=total_xp)
+                    | Q(user_total_xp=total_xp, username__lt=user.username)
+                    | Q(user_total_xp=total_xp, username=user.username, id__lt=user.id)
+                )
+                .count()
+            )
+            rank = better_users_count + 1
 
             from apps.progress.models import UserBadge
 
@@ -385,11 +403,9 @@ class ContributorDashboardView(APIView):
                 or 0
             )
             available_points = total_xp - spent_points
-            unused_freezes = StreakFreeze.objects.filter(
-                user=user, used_on_date__isnull=True
-            ).count()
+            unused_freezes_count = len(unused_freezes)
 
-            personal_stats = {
+            return {
                 "issues_solved": issues_solved,
                 "prs_merged": prs_merged,
                 "total_xp": total_xp,
@@ -397,10 +413,10 @@ class ContributorDashboardView(APIView):
                 "rank": rank,
                 "earned_badges": earned_badges,
                 "available_points": available_points,
-                "unused_freezes": unused_freezes,
+                "unused_freezes": unused_freezes_count,
             }
 
-            # 2. Assigned Issues (Open or In Progress)
+        elif field == "assigned_issues":
             assigned_issues_qs = (
                 Issue.objects.filter(assigned_to=user)
                 .exclude(status=Issue.Status.SOLVED)
@@ -419,8 +435,9 @@ class ContributorDashboardView(APIView):
                         "created_at": issue.created_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
                     }
                 )
+            return assigned_issues
 
-            # 3. Recent PRs
+        elif field == "recent_prs":
             recent_prs_qs = (
                 PullRequest.objects.filter(user=user)
                 .select_related("issue")
@@ -443,8 +460,9 @@ class ContributorDashboardView(APIView):
                         ),
                     }
                 )
+            return recent_prs
 
-            # 4. Progress tracker
+        elif field == "progress_tracker":
             completed_lessons = LessonProgress.objects.filter(
                 user=user, completed=True
             ).count()
@@ -455,26 +473,45 @@ class ContributorDashboardView(APIView):
                 else 0
             )
 
-            progress_tracker = {
+            return {
                 "completed_lessons": completed_lessons,
                 "total_lessons": total_lessons,
                 "completion_percentage": completion_percentage,
             }
 
-            data = {
-                "personal_stats": personal_stats,
-                "assigned_issues": assigned_issues,
-                "recent_prs": recent_prs,
-                "progress_tracker": progress_tracker,
-            }
+    def get(self, request):
+        user = request.user
+        fields_param = request.query_params.get("fields")
+        if fields_param:
+            requested_fields = [f.strip() for f in fields_param.split(",") if f.strip()]
+        else:
+            requested_fields = [
+                "personal_stats",
+                "assigned_issues",
+                "recent_prs",
+                "progress_tracker",
+            ]
 
-            # Cache for 5 minutes
-            cache.set(cache_key, data, 300)
+        data = {}
+        for field in requested_fields:
+            if field not in [
+                "personal_stats",
+                "assigned_issues",
+                "recent_prs",
+                "progress_tracker",
+            ]:
+                continue
+
+            cache_key = f"dashboard_contributor_{field}_{user.id}"
+            field_data = cache.get(cache_key)
+            if field_data is None:
+                field_data = self._calculate_field(user, field)
+                cache.set(cache_key, field_data, 300)
+            data[field] = field_data
 
         return Response(data)
 
 
-from django.db import transaction
 from drf_spectacular.utils import extend_schema
 from rest_framework import status
 
@@ -544,7 +581,9 @@ class BuyStreakFreezeView(APIView):
             StreakFreeze.objects.create(user=user, cost=FREEZE_COST)
 
             # Invalidate cache for dashboard
-            cache.delete(f"dashboard_contributor_stats_{user.id}")
+            from apps.dashboard.signals import clear_dashboard_caches
+
+            clear_dashboard_caches(user_id=user.id)
 
             return Response(
                 {
@@ -556,8 +595,9 @@ class BuyStreakFreezeView(APIView):
             )
 
 
-from django.db import models
 from apps.rbac.models import UserRole
+from django.db import models
+
 
 
 class IsModeratorOrAdmin(permissions.BasePermission):


### PR DESCRIPTION
## Description

This PR addresses performance bottlenecks in the Dashboard API by:
- Adding **sparse‑field caching** to allow clients to request only the data they need.
- Optimising **streak** and **rank** calculations (bulk updates, reduced N+1 queries).
- Introducing **field‑level cache invalidation** in `backend/apps/dashboard/signals.py`.
- Refactoring imports and removing duplicate code to keep the module clean.

## Related Issue(s)

- Fixes #799 – “Optimize API performance for contributor dashboard”.

## Scope of Changes

- `backend/apps/challenges/views.py`
- `backend/apps/dashboard/signals.py`
- `backend/apps/dashboard/views.py`

Only these three files were modified to keep the change scoped to the issue.

## Testing

- Ran the full backend test suite: `pytest` – all tests pass.
- Executed the frontend lint and test pipeline:
  ```bash
  npm run lint
  npm run format:check
  npm run test
```


## 📝 Pre-Submission Checklist
<!-- Please check all boxes that apply. If not checked, the PR may be rejected. -->

- [ ] My PR title follows the Conventional Commits format (e.g. `feat: ...`, `fix: ...`, `docs: ...`, `refactor: ...`).
- [ ] My branch name starts with a standard prefix (`feat/`, `fix/`, `docs/`, `refactor/`).
- [ ] I have linked a related issue in the "Related Issue" section above.
- [ ] I have verified that all existing tests pass and added new tests if applicable.
- [ ] I have formatted my changes locally (`cd frontend && npm run format` and `cd backend && black . && isort .`).
- [ ] No API keys, credentials, or sensitive configurations are committed.
