### PR TITLE
fix: add unbookmark action from dashboard read-later list

### DIFF
--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -92,7 +92,7 @@ export function DashboardPage() {
 
   const { user } = useAuth();
   const { progress, isLessonCompleted } = useUserProgress();
-  const { bookmarks, isLoading: isLoadingBookmarks } = useBookmarks();
+  const { bookmarks, isLoading: isLoadingBookmarks, toggleBookmark } = useBookmarks();
 
   const [tourKey, setTourKey] = useState(0);
   const [showScrollTop, setShowScrollTop] = useState(false);
@@ -1017,10 +1017,24 @@ export function DashboardPage() {
                   <h3 className="font-black text-lg leading-tight dark:text-[#f0ebe2] pr-4">
                     {bookmark.lesson_title}
                   </h3>
-                  <Bookmark
-                    className="fill-primary text-primary shrink-0"
-                    size={20}
-                  />
+                  <button
+                    type="button"
+                    aria-label="Remove bookmark"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      toggleBookmark.mutate({
+                        slug: bookmark.lesson_slug,
+                        isBookmarked: true,
+                      });
+                    }}
+                    className="shrink-0"
+                  >
+                    <Bookmark
+                      className="fill-primary text-primary hover:opacity-60 transition-opacity"
+                      size={20}
+                    />
+                  </button>
                 </div>
                 <div className="flex justify-between items-center mt-auto pt-4">
                   <span className="font-black text-[10px] bg-black text-white px-2 py-0.5 rounded-full uppercase dark:bg-[#2e2924]">


### PR DESCRIPTION
## 📋 Description of Changes
- Lesson bookmarking (add/remove) was already implemented end-to-end in a prior PR for #927 - model, view, URLs, and toggle button on `LessonPage`.
- This issue's template was left blank with no specific requirements, so after investigating the existing bookmark feature, I found one gap: the "Read Later" bookmark list on the Dashboard showed a bookmark icon with no way to remove a bookmark directly - users had to open the lesson page to unbookmark.
- Wired up the existing `toggleBookmark` mutation to the bookmark icon in `DashboardPage.tsx`'s Read Later section, so users can now remove a bookmark directly from the dashboard.

## 🔗 Related Issue
Closes #942

## 🧪 Proof of Manual Testing (MANDATORY)
<details>
<summary>Click to expand and paste screenshots / logs</summary>

### Frontend / UI Changes
<!-- Paste screenshot of dashboard Read Later card, bookmark icon click removing the entry -->

### Backend / API / CLI Logs
```bash
# Manually tested: clicking the bookmark icon on a Read Later card
# removes it from the list immediately without navigating to the lesson page.
```
</details>

## ⚙️ Verification Logs (Automated Tests)
```bash
# Manual testing performed on dashboard bookmark removal flow.
```

## 📝 Pre-Submission Checklist
- [x] My PR title follows the Conventional Commits format (`feat: ...`, `fix: ...`, etc.).
- [x] My branch name starts with a standard prefix (`feat/`, `fix/`, etc.).
- [x] I have linked a related issue.
- [ ] I have verified that all existing tests pass.
- [ ] I have formatted my changes locally.
- [x] No API keys, credentials, or sensitive configurations are committed.