### PR TITLE
fix: Stale closure and exhaustive-deps warning in AuthContext

### DIFF
--- a/frontend/src/features/auth/AuthContext.tsx
+++ b/frontend/src/features/auth/AuthContext.tsx
@@ -34,41 +34,35 @@ type AuthContextType = {
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
+function sanitizeStorageData(value: string): string {
+  if (!value) return value;
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#x27;");
+}
+
+function safeSetItem(key: string, value: string) {
+  try {
+    localStorage.setItem(key, sanitizeStorageData(value));
+  } catch {
+    /* localStorage unavailable */
+  }
+}
+
+function safeRemoveItem(key: string) {
+  try {
+    localStorage.removeItem(key);
+  } catch {
+    /* localStorage unavailable */
+  }
+}
+
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
   const [isLoading, setIsLoading] = useState(true);
-
-  function safeGetItem(key: string): string | null {
-    try {
-      return localStorage.getItem(key);
-    } catch {
-      return null;
-    }
-  }
-  function sanitizeStorageData(value: string): string {
-    if (!value) return value;
-    return value
-      .replace(/&/g, "&amp;")
-      .replace(/</g, "&lt;")
-      .replace(/>/g, "&gt;")
-      .replace(/"/g, "&quot;")
-      .replace(/'/g, "&#x27;");
-  }
-
-  function safeSetItem(key: string, value: string) {
-    try {
-      localStorage.setItem(key, sanitizeStorageData(value));
-    } catch {
-      /* localStorage unavailable */
-    }
-  }
-  function safeRemoveItem(key: string) {
-    try {
-      localStorage.removeItem(key);
-    } catch {
-      /* localStorage unavailable */
-    }
-  }
 
   const login = (tokens: { access: string; refresh: string }) => {
     safeSetItem("accessToken", tokens.access);


### PR DESCRIPTION
## 📋 Description of Changes
- Extracted local storage utility functions (`safeSetItem`, `safeRemoveItem`, `sanitizeStorageData`) outside the `AuthProvider` component to stabilize their references.
- Removed unused `safeGetItem` function to resolve dead code warnings.
- Removed `safeSetItem` from `checkUser`'s `useCallback` dependency array since it is now a stable top-level function.

These changes resolve the `react-hooks/exhaustive-deps` warning and eliminate the risk of stale closures without causing infinite render loops in the Auth context.

## 🔗 Related Issue
Closes #1028

## 🧪 Proof of Manual Testing (MANDATORY)
<details>
<summary>Click to expand and paste screenshots / logs</summary>

### Frontend / UI Changes
No visual UI changes; this is a pure refactor/bug fix in the state management layer.

### Backend / API / CLI Logs
```bash
N/A - Frontend only change

```
</details>

## ⚙️ Verification Logs (Automated Tests)
```bash
PS E:\OPEN SOURCE\Open-Source-Contribution-Atelier\frontend> npm run test

> vitest run
 ✓  storybook (chromium)  src/stories/Header.stories.ts (2 tests) 2373ms
   ✓ Logged In  2231ms
 ✓  storybook (chromium)  src/stories/Button.stories.ts (4 tests) 2518ms
   ✓ Primary  2204ms
 ✓  storybook (chromium)  src/stories/Page.stories.ts (2 tests) 2600ms
   ✓ Logged Out  2282ms
   ✓ Logged In  310ms

 Test Files  3 passed (3)
      Tests  8 passed (8)

```

## 📝 Pre-Submission Checklist
- [x] My PR title follows the Conventional Commits format (`feat: ...`, `fix: ...`, etc.).
- [x] My branch name starts with a standard prefix (`feat/`, `fix/`, etc.).
- [x] I have linked a related issue.
- [x] I have verified that all existing tests pass.
- [x] I have formatted my changes locally.
- [x] No API keys, credentials, or sensitive configurations are committed.
