### PR TITLE
fix: sandbox output never renders - missing postMessage listener in CodeSandbox

### DIFF
--- a/frontend/src/components/ui/CodeSandbox.tsx
+++ b/frontend/src/components/ui/CodeSandbox.tsx
@@ -20,6 +20,24 @@ export function CodeSandbox() {
   useEffect(() => {
     fetchSandboxSnapshots().then(setSnapshots).catch(console.error);
   }, []);
+  useEffect(() => {
+    const handleMessage = (event: MessageEvent) => {
+      // Only accept messages from our own sandbox iframe, never from
+      // other frames/windows, to avoid mixing in unrelated postMessage traffic.
+      if (!iframeRef.current || event.source !== iframeRef.current.contentWindow) {
+        return;
+      }
+
+      const data = event.data as { type?: string; message?: string } | undefined;
+      if (data?.type === "log" || data?.type === "error") {
+        const prefix = data.type === "error" ? "⚠ " : "";
+        setOutput((prev) => [...prev, `${prefix}${data.message ?? ""}`]);
+      }
+    };
+
+    window.addEventListener("message", handleMessage);
+    return () => window.removeEventListener("message", handleMessage);
+  }, []);
 
   const wsUrl = import.meta.env.VITE_API_URL
     ? import.meta.env.VITE_API_URL.replace("http", "ws") + "ws/sandbox/"

--- a/frontend/src/test/CodeSandbox.test.tsx
+++ b/frontend/src/test/CodeSandbox.test.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  cleanup,
+  act,
+} from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { CodeSandbox } from "../components/ui/CodeSandbox";
+import { useWebSocket } from "../hooks/useWebSocket";
+import { fetchSandboxSnapshots, saveSandboxSnapshot } from "../lib/api";
+
+// Mock Monaco editor to avoid pulling in the real editor in jsdom
+vi.mock("@monaco-editor/react", () => ({
+  __esModule: true,
+  default: () => <div data-testid="monaco-editor" />,
+}));
+
+// Mock the collaborative websocket hook, we don't need real sockets here
+vi.mock("../hooks/useWebSocket", () => ({
+  useWebSocket: vi.fn(),
+}));
+
+// Mock the API calls used for snapshot history
+vi.mock("../lib/api", () => ({
+  fetchSandboxSnapshots: vi.fn(),
+  saveSandboxSnapshot: vi.fn(),
+}));
+
+describe("CodeSandbox output capture", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useWebSocket as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      send: vi.fn(),
+      isConnected: false,
+    });
+    (fetchSandboxSnapshots as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    (saveSandboxSnapshot as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      id: 1,
+      code: "",
+      label: "",
+      is_auto: true,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders console.log output posted back from the sandbox iframe", async () => {
+    render(<CodeSandbox />);
+
+    expect(screen.getByText("Output will appear here...")).toBeInTheDocument();
+
+    const iframe = document.querySelector("iframe") as HTMLIFrameElement;
+    expect(iframe).toBeTruthy();
+
+    fireEvent.click(screen.getByText("Run"));
+
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          data: { type: "log", message: "Hello, World!" },
+          source: iframe.contentWindow,
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Hello, World!/)).toBeInTheDocument();
+    });
+  });
+
+  it("ignores postMessage events that do not originate from its own sandbox iframe", async () => {
+    render(<CodeSandbox />);
+
+    fireEvent.click(screen.getByText("Run"));
+
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          data: { type: "log", message: "should not appear" },
+        }),
+      );
+    });
+
+    expect(screen.queryByText(/should not appear/)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
#1045 
## Problem

The Code Sandbox's "Run" button never displayed any output. The sandboxed
iframe correctly posts `console.log` / `console.error` messages back to the
parent via `window.parent.postMessage(...)`, but `CodeSandbox.tsx` never
registered a `window.addEventListener("message", ...)` to receive them —
so `setOutput` was never called from actual code execution, and the panel
always showed the "Output will appear here..." placeholder.

## Note on investigation

I initially suspected this could be a security issue (sandboxed `eval()`
exposing `localStorage`/auth tokens to the iframe), but on closer inspection
the iframe already uses `sandbox="allow-scripts"` **without**
`allow-same-origin`, which gives it a unique opaque origin — so it's
correctly isolated from the parent's storage and DOM by the browser's
same-origin policy. That theory didn't hold up, and the real, reproducible
bug is the missing listener described above.

## Fix 

- Added a `useEffect` that listens for `message` events and appends
  `log`/`error` payloads to the `output` state.
- The listener checks `event.source === iframeRef.current.contentWindow`
  before accepting a message, so it only reacts to messages from this
  component's own sandbox iframe (defense-in-depth — a bare listener with
  no source check would otherwise accept `postMessage` from any origin).
- Listener is cleaned up on unmount.

## Testing

Added `frontend/src/test/CodeSandbox.test.tsx`:
- Confirms output renders after a simulated `postMessage` from the iframe.
- Confirms messages without a matching `source` are ignored.

Both tests pass locally under the jsdom test environment.

## Files changed
- `frontend/src/components/ui/CodeSandbox.tsx`
- `frontend/src/test/CodeSandbox.test.tsx` (new)