### PR TITLE
perf(backend): throttle recommendation generation with cache manager

### DIFF
--- a/backend/apps/recommendations/engine.py
+++ b/backend/apps/recommendations/engine.py
@@ -6,21 +6,28 @@ from apps.challenges.models import Challenge
 from apps.content.models import Lesson
 from apps.progress.models import ExerciseAttempt, LessonProgress, QuizAttempt
 
+from apps.cache.services.cache_manager import CacheManager
+
 from .models import Recommendation
 
 
 class RecommendationEngine:
     def __init__(self, user):
         self.user = user
+        self.cache_manager = CacheManager()
 
     def generate_recommendations(self):
-        # Clear old generated ones that are not dismissed maybe?
-        # For simplicity, we just generate new ones and rely on unique_together to avoid duplicates
-        # or we just get or create
+        # Throttle generation using cache
+        cache_key = self.cache_manager.get_cache_key("recs", self.user.id)
+        if self.cache_manager.get(cache_key):
+            return
 
         self._generate_remedial_recommendations()
         self._generate_advanced_recommendations()
         self._generate_streak_recommendations()
+
+        # Cache for 1 hour
+        self.cache_manager.set(cache_key, True, ttl=3600)
 
     def _generate_remedial_recommendations(self):
         # Find recently failed quizzes


### PR DESCRIPTION
## Description
Implements a throttling caching strategy for the `RecommendationEngine` to prevent redundant execution and expensive database queries.

Changes:
- Uses the existing `CacheManager` infrastructure to check for a user-specific cache key (`recs:<user_id>`) before generation.
- Short-circuits the generation process if recent recommendations were already processed.
- Applies a 1-hour TTL lock after successful generation, dramatically reducing database load for rapid, repeated API requests or background tasks.

Fixes #1038

## Type of Change
- [x] ⚡ Performance optimization

## How Has This Been Tested?
### Automated Tests
- Run backend tests: `cd backend && pytest`

### Manual Verification
- Invoked the generation process. Subsequent requests within 1 hour immediately exit without triggering `QuizAttempt`, `ExerciseAttempt`, or `Recommendation` queries.

## Pre-Push Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or console errors
- [x] I have run `git diff` locally and verified my changes
