### PR TITLE
fix(security): disable CORS_ALLOW_ALL_ORIGINS to enforce allowlist

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -50,7 +50,7 @@ CORS_ALLOWED_ORIGINS = [
     if origin.strip()
 ]
 CORS_ALLOW_CREDENTIALS = True
-CORS_ALLOW_ALL_ORIGINS = True
+CORS_ALLOW_ALL_ORIGINS = False
 
 INSTALLED_APPS = [
     "django_prometheus",

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -1,8 +1,11 @@
 import os
+import sys
 from datetime import timedelta
 from pathlib import Path
 
 import dj_database_url
+
+TESTING = "test" in sys.argv or "pytest" in sys.modules
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 
@@ -49,8 +52,13 @@ CORS_ALLOWED_ORIGINS = [
     for origin in os.getenv("CORS_ALLOWED_ORIGINS", "").split(",")
     if origin.strip()
 ]
+
+if not DEBUG and not TESTING and not CORS_ALLOWED_ORIGINS:
+    from django.core.exceptions import ImproperlyConfigured
+    raise ImproperlyConfigured("CORS_ALLOWED_ORIGINS must not be empty in production.")
+
 CORS_ALLOW_CREDENTIALS = True
-CORS_ALLOW_ALL_ORIGINS = False
+# CORS_ALLOW_ALL_ORIGINS defaults to False; rely on CORS_ALLOWED_ORIGINS allowlist.
 
 INSTALLED_APPS = [
     "django_prometheus",

--- a/backend/tests/test_cors.py
+++ b/backend/tests/test_cors.py
@@ -20,3 +20,22 @@ def test_cors_headers():
     assert response.status_code == 200
     assert response["Access-Control-Allow-Origin"] == "http://localhost:5173"
     assert response["Access-Control-Allow-Credentials"] == "true"
+
+
+@pytest.mark.django_db
+@override_settings(
+    CORS_ALLOWED_ORIGINS=["http://localhost:5173"],
+    CORS_ALLOW_CREDENTIALS=True,
+)
+def test_cors_headers_rejected_origin():
+    client = APIClient()
+
+    response = client.options(
+        "/api/schema/",
+        HTTP_ORIGIN="http://malicious.com",
+        HTTP_ACCESS_CONTROL_REQUEST_METHOD="GET",
+    )
+
+    assert response.status_code == 200
+    assert "Access-Control-Allow-Origin" not in response
+


### PR DESCRIPTION

  ### Description
  Enforces origin restrictions for API calls. Previously, `CORS_ALLOW_ALL_ORIGINS = True` was hardcoded, which bypassed the config defined in the environment via `CORS_ALLOWED_ORIGINS`.
  
  ### Changes
  - Set `CORS_ALLOW_ALL_ORIGINS = False` in `backend/config/settings.py` so Django now respects the origins specified in the `CORS_ALLOWED_ORIGINS` environment variable.
Fixes #1266 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Tightened cross-origin access by disabling wildcard origin matching; the server now relies on an explicit allowed-origins allowlist.
  * Added production-time validation to prevent running with an empty allowed-origins configuration.
* **Tests**
  * Added a CORS regression test that verifies requests from unapproved origins do not include the `Access-Control-Allow-Origin` header.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->