### PR TITLE
fix(security): remove wildcard appends from ALLOWED_HOSTS

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -43,6 +43,10 @@ ALLOWED_HOSTS = [
     if host.strip()
 ]
 
+if not DEBUG and not ALLOWED_HOSTS:
+    from django.core.exceptions import ImproperlyConfigured
+    raise ImproperlyConfigured("ALLOWED_HOSTS must not be empty in production.")
+
 CORS_ALLOWED_ORIGINS = [
     origin.strip()
     for origin in os.getenv("CORS_ALLOWED_ORIGINS", "").split(",")

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -42,8 +42,7 @@ ALLOWED_HOSTS = [
     for host in os.getenv("ALLOWED_HOSTS", "localhost,127.0.0.1").split(",")
     if host.strip()
 ]
-ALLOWED_HOSTS.append(".vercel.app")
-ALLOWED_HOSTS.append(".hf.space")
+
 CORS_ALLOWED_ORIGINS = [
     origin.strip()
     for origin in os.getenv("CORS_ALLOWED_ORIGINS", "").split(",")


### PR DESCRIPTION
### Description
  Fixes a potential Host Header Injection vulnerability where subdomains on `.vercel.app` and `.hf.space` were unconditionally appended to `ALLOWED_HOSTS`.
  
  ### Changes
  - Removed `.append(".vercel.app")` and `.append(".hf.space")` from `backend/config/settings.py`.
  - The application now strictly validates the `Host` header against the hosts defined via the `ALLOWED_HOSTS` environment variable (defaulting to `localhost,127.0.0.1`).
  Fixes #1267 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated host validation so the app no longer automatically permits extra deployment-domain suffixes.
  * In production mode, the site now requires `ALLOWED_HOSTS` to be configured; if it’s empty, startup will fail with a clear configuration error.
  * This makes allowed-domain behavior more predictable and helps prevent unintended access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->