### PR TITLE
fix: prevent race conditions in progress updates

### DIFF
--- a/backend/apps/progress/tests/test_progress_concurrency.py
+++ b/backend/apps/progress/tests/test_progress_concurrency.py
@@ -1,0 +1,177 @@
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import patch
+
+from django.contrib.auth.models import User
+from django.db import close_old_connections
+from django.test import TransactionTestCase, skipUnlessDBFeature
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from apps.content.models import Lesson
+from apps.progress.models import (
+    LessonProgress,
+    LessonProgressSync,
+    XPEvent,
+)
+from apps.progress.views import MyProgressView
+
+
+class ProgressConcurrencyTests(TransactionTestCase):
+    reset_sequences = True
+
+    def setUp(self):
+        self.factory = APIRequestFactory()
+
+        self.user = User.objects.create_user(
+            username="concurrent-user",
+            password="test-password",
+        )
+
+        self.lesson = Lesson.objects.create(
+            title="Concurrency Lesson",
+            slug="concurrency-lesson",
+            summary="Test lesson",
+            content="Test content",
+            difficulty="beginner",
+            organization=getattr(
+                self.user,
+                "organization",
+                None,
+            ),
+        )
+
+        # Create the row before concurrent requests.
+        #
+        # select_for_update() protects an existing progress row,
+        # allowing concurrent updates to be serialized.
+        self.progress = LessonProgress.objects.create(
+            user=self.user,
+            lesson=self.lesson,
+            organization=getattr(
+                self.user,
+                "organization",
+                None,
+            ),
+            completed=False,
+            base_score=0,
+            multiplier_applied=1.0,
+            score=0,
+        )
+
+    def _post_progress(
+        self,
+        score,
+        idempotency_key,
+    ):
+        close_old_connections()
+
+        try:
+            user = User.objects.get(pk=self.user.pk)
+
+            request = self.factory.post(
+                "/api/progress/my-progress/",
+                {
+                    "lesson_slug": self.lesson.slug,
+                    "score": score,
+                    "completed": True,
+                    "idempotency_key": idempotency_key,
+                },
+                format="json",
+            )
+
+            force_authenticate(
+                request,
+                user=user,
+            )
+
+            response = MyProgressView.as_view()(request)
+
+            return response.status_code
+
+        finally:
+            close_old_connections()
+
+    @skipUnlessDBFeature("has_select_for_update")
+    @patch("django_q.tasks.async_task")
+    def test_concurrent_duplicate_idempotency_key_is_applied_once(
+        self,
+        mocked_task,
+    ):
+        """
+        Concurrent requests using the same idempotency key must
+        serialize progress mutation and apply XP only once.
+
+        This test requires a database backend supporting
+        SELECT ... FOR UPDATE, such as PostgreSQL.
+        """
+        idempotency_key = "same-concurrent-key"
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            futures = [
+                executor.submit(
+                    self._post_progress,
+                    100,
+                    idempotency_key,
+                ),
+                executor.submit(
+                    self._post_progress,
+                    100,
+                    idempotency_key,
+                ),
+            ]
+
+            statuses = [
+                future.result()
+                for future in futures
+            ]
+
+        self.assertTrue(
+            all(
+                response_status in (200, 201)
+                for response_status in statuses
+            )
+        )
+
+        self.assertEqual(
+            LessonProgress.objects.filter(
+                user=self.user,
+                lesson=self.lesson,
+            ).count(),
+            1,
+        )
+
+        progress = LessonProgress.objects.get(
+            user=self.user,
+            lesson=self.lesson,
+        )
+
+        self.assertEqual(
+            progress.base_score,
+            100,
+        )
+
+        self.assertEqual(
+            progress.score,
+            100,
+        )
+
+        self.assertTrue(
+            progress.completed,
+        )
+
+        self.assertEqual(
+            LessonProgressSync.objects.filter(
+                user=self.user,
+                lesson=self.lesson,
+                idempotency_key=idempotency_key,
+            ).count(),
+            1,
+        )
+
+        self.assertEqual(
+            XPEvent.objects.filter(
+                user=self.user,
+                source_type="lesson",
+                source_id=self.lesson.id,
+            ).count(),
+            1,
+        )

--- a/backend/apps/progress/views.py
+++ b/backend/apps/progress/views.py
@@ -1,11 +1,11 @@
-from datetime import datetime
+from datetime import datetime, timezone as dt_timezone
 
 from django.contrib.auth.models import User
 from django.db import transaction
+from django.utils import timezone
 from django.db.models import Count, Min, Sum
 from apps.progress.constants import XP_PER_LEVEL
 from apps.progress.models import XPEvent
-from apps.progress.constants import XP_PER_LEVEL
 from django.shortcuts import get_object_or_404
 from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_view
 from rest_framework import permissions, status
@@ -66,21 +66,21 @@ class MyProgressView(APIView):
         return Response(serializer.data)
 
     def post(self, request):
+        from apps.progress.models import LessonProgressSync, XPMultiplierEvent
+        from django_q.tasks import async_task
+
         lesson_slug = request.data.get("lesson_slug")
-        from apps.progress.models import XPMultiplierEvent, LessonProgressSync
-
         idempotency_key = request.data.get("idempotency_key")
-
         client_timestamp_ms = request.data.get("client_timestamp")
 
         multiplier = XPMultiplierEvent.get_active_multiplier()
-
         base_score = request.data.get("score", 100)
         completed = request.data.get("completed", True)
 
         try:
             lesson = Lesson.objects.get(
-                slug=lesson_slug, organization=request.user.organization
+                slug=lesson_slug,
+                organization=request.user.organization,
             )
         except Lesson.DoesNotExist:
             return Response(
@@ -88,73 +88,99 @@ class MyProgressView(APIView):
                 status=status.HTTP_404_NOT_FOUND,
             )
 
-        client_timestamp_ms = request.data.get("client_timestamp")
-
         with transaction.atomic():
-            # Idempotency: if this (user, lesson, key) was already processed,
-            # return existing progress state without re-applying multiplier.
+            # Lock the progress row for the full read-modify-write cycle.
+            # Concurrent requests for the same user/lesson are serialized here.
+            progress, created = (
+                LessonProgress.objects.select_for_update().get_or_create(
+                    user=request.user,
+                    lesson=lesson,
+                    defaults={
+                        "organization": request.user.organization,
+                        "completed": completed,
+                        "base_score": base_score,
+                        "multiplier_applied": multiplier,
+                        "score": int(base_score * multiplier),
+                    },
+                )
+            )
+
+            # Check idempotency only after the progress row is locked. This
+            # prevents two concurrent requests with the same key from both
+            # applying score and XP side effects.
             if idempotency_key:
                 sync_row = (
-                    LessonProgressSync.objects.select_related("lesson")
-                    .filter(
+                    LessonProgressSync.objects.filter(
                         user=request.user,
                         lesson=lesson,
                         idempotency_key=idempotency_key,
                     )
                     .first()
                 )
+
                 if sync_row is not None:
-                    progress, _ = LessonProgress.objects.get_or_create(
-                        user=request.user,
-                        lesson=lesson,
-                        defaults={
-                            "organization": request.user.organization,
-                            "completed": sync_row.completed,
-                            "base_score": sync_row.base_score,
-                            "multiplier_applied": sync_row.multiplier_applied,
-                            "score": sync_row.score,
-                        },
-                    )
                     serializer = LessonProgressSerializer(progress)
-                    async_task = __import__(
-                        "django_q.tasks", fromlist=["async_task"]
-                    ).async_task
-                    async_task(
-                        "apps.progress.tasks.evaluate_user_badges_task",
-                        request.user.id,
+
+                    transaction.on_commit(
+                        lambda: async_task(
+                            "apps.progress.tasks.evaluate_user_badges_task",
+                            request.user.id,
+                        )
                     )
+
                     return Response(
                         serializer.data,
                         status=status.HTTP_200_OK,
                     )
 
-            try:
-                progress = LessonProgress.objects.get(user=request.user, lesson=lesson)
-                created = False
-
-                skip_update = False
-                if client_timestamp_ms:
-                    import datetime
-
-                    client_dt = datetime.datetime.fromtimestamp(
-                        client_timestamp_ms / 1000.0, tz=datetime.timezone.utc
+            if created:
+                # Record XP only once for a newly created progress row.
+                if progress.score != 0:
+                    XPEvent.objects.create(
+                        user=request.user,
+                        source_type="lesson",
+                        source_id=lesson.id,
+                        base_points=base_score,
+                        multiplier=multiplier,
+                        xp_delta=progress.score,
                     )
+            else:
+                skip_update = False
+
+                if client_timestamp_ms:
+                    client_dt = datetime.fromtimestamp(
+                        client_timestamp_ms / 1000.0,
+                        tz=dt_timezone.utc,
+                    )
+
                     if progress.updated_at > client_dt:
                         skip_update = True
 
                 if not skip_update and (
-                    progress.base_score != base_score or progress.completed != completed
+                    progress.base_score != base_score
+                    or progress.completed != completed
                 ):
                     old_score = progress.score
+
                     progress.completed = completed
                     progress.base_score = base_score
                     progress.multiplier_applied = multiplier
                     progress.score = int(base_score * multiplier)
                     progress.organization = request.user.organization
-                    progress.save()
+                    progress.save(
+                        update_fields=[
+                            "completed",
+                            "base_score",
+                            "multiplier_applied",
+                            "score",
+                            "organization",
+                            "updated_at",
+                        ]
+                    )
 
-                    # XP side-effect only when we actually applied.
+                    # XP is the actual score delta, not the full replacement score.
                     xp_delta = progress.score - old_score
+
                     if xp_delta != 0:
                         XPEvent.objects.create(
                             user=request.user,
@@ -165,28 +191,8 @@ class MyProgressView(APIView):
                             xp_delta=xp_delta,
                         )
 
-            except LessonProgress.DoesNotExist:
-                created = True
-                progress = LessonProgress.objects.create(
-                    user=request.user,
-                    lesson=lesson,
-                    completed=completed,
-                    base_score=base_score,
-                    multiplier_applied=multiplier,
-                    score=int(base_score * multiplier),
-                    organization=request.user.organization,
-                )
-                # Record XP event for new progress
-                XPEvent.objects.create(
-                    user=request.user,
-                    source_type="lesson",
-                    source_id=lesson.id,
-                    base_points=base_score,
-                    multiplier=multiplier,
-                    xp_delta=progress.score,
-                )
-
-            # Write idempotency ledger AFTER progress state is committed.
+            # Store the idempotency ledger in the same transaction as the
+            # progress and XP updates so the state is committed atomically.
             if idempotency_key:
                 LessonProgressSync.objects.create(
                     user=request.user,
@@ -200,7 +206,13 @@ class MyProgressView(APIView):
                     server_updated_at=timezone.now(),
                 )
 
-        async_task("apps.progress.tasks.evaluate_user_badges_task", request.user.id)
+            # Queue badge evaluation only after the database commit succeeds.
+            transaction.on_commit(
+                lambda: async_task(
+                    "apps.progress.tasks.evaluate_user_badges_task",
+                    request.user.id,
+                )
+            )
 
         serializer = LessonProgressSerializer(progress)
 
@@ -220,15 +232,16 @@ class BulkSyncProgressView(APIView):
         synced = []
 
         from apps.progress.models import XPMultiplierEvent
+        from django_q.tasks import async_task
 
         multiplier = XPMultiplierEvent.get_active_multiplier()
 
         with transaction.atomic():
             for item in serializer.validated_data["lessons"]:
-
                 lesson_slug = item["lesson_slug"]
                 base_score = item.get("score", 100)
                 completed = item.get("completed", True)
+                client_timestamp_ms = item.get("client_timestamp")
 
                 try:
                     lesson = Lesson.objects.get(slug=lesson_slug)
@@ -241,18 +254,31 @@ class BulkSyncProgressView(APIView):
                         difficulty="beginner",
                     )
 
-                try:
-                    progress = LessonProgress.objects.get(
-                        user=request.user, lesson=lesson
+                # Serialize concurrent writes to the same user/lesson progress
+                # row before reading or mutating its state.
+                progress, created = (
+                    LessonProgress.objects.select_for_update().get_or_create(
+                        user=request.user,
+                        lesson=lesson,
+                        defaults={
+                            "completed": completed,
+                            "base_score": base_score,
+                            "multiplier_applied": multiplier,
+                            "score": int(base_score * multiplier),
+                            "organization": request.user.organization,
+                        },
                     )
-                    client_timestamp_ms = item.get("client_timestamp")
-                    skip_update = False
-                    if client_timestamp_ms:
-                        import datetime
+                )
 
-                        client_dt = datetime.datetime.fromtimestamp(
-                            client_timestamp_ms / 1000.0, tz=datetime.timezone.utc
+                if not created:
+                    skip_update = False
+
+                    if client_timestamp_ms:
+                        client_dt = datetime.fromtimestamp(
+                            client_timestamp_ms / 1000.0,
+                            tz=dt_timezone.utc,
                         )
+
                         if progress.updated_at > client_dt:
                             skip_update = True
 
@@ -260,35 +286,44 @@ class BulkSyncProgressView(APIView):
                         progress.base_score != base_score
                         or progress.completed != completed
                     ):
+                        old_score = progress.score
+
                         progress.completed = completed
                         progress.base_score = base_score
                         progress.multiplier_applied = multiplier
                         progress.score = int(base_score * multiplier)
-                        progress.save()
-                        # Record XP event for bulk sync update
-                        XPEvent.objects.create(
-                            user=request.user,
-                            source_type="lesson",
-                            source_id=lesson.id,
-                            base_points=base_score,
-                            multiplier=multiplier,
-                            xp_delta=progress.score,
+                        progress.organization = request.user.organization
+                        progress.save(
+                            update_fields=[
+                                "completed",
+                                "base_score",
+                                "multiplier_applied",
+                                "score",
+                                "organization",
+                                "updated_at",
+                            ]
                         )
-                except LessonProgress.DoesNotExist:
-                    progress = LessonProgress.objects.create(
-                        user=request.user,
-                        lesson=lesson,
-                        completed=completed,
-                        base_score=base_score,
-                        multiplier_applied=multiplier,
-                        score=int(base_score * multiplier),
-                    )
+
+                        xp_delta = progress.score - old_score
+
+                        if xp_delta != 0:
+                            XPEvent.objects.create(
+                                user=request.user,
+                                source_type="lesson",
+                                source_id=lesson.id,
+                                base_points=base_score,
+                                multiplier=multiplier,
+                                xp_delta=xp_delta,
+                            )
 
                 synced.append(progress.id)
 
-            from django_q.tasks import async_task
-
-            async_task("apps.progress.tasks.evaluate_user_badges_task", request.user.id)
+            transaction.on_commit(
+                lambda: async_task(
+                    "apps.progress.tasks.evaluate_user_badges_task",
+                    request.user.id,
+                )
+            )
 
         return Response(
             {"synced_count": len(synced), "progress_ids": synced},


### PR DESCRIPTION
## Description

Fixes #1168

This PR fixes race conditions in user progress tracking by adding database-level locking around progress update flows.

### Changes made

* Added `select_for_update()` row locking for lesson progress updates.
* Kept progress updates, XP event creation, and idempotency ledger creation inside the same atomic transaction.
* Moved idempotency handling into the locked transaction path to prevent duplicate concurrent updates.
* Updated bulk progress sync logic to lock existing progress rows before mutation.
* Added a concurrency regression test for duplicate idempotent progress submissions.
* Deferred badge evaluation task scheduling until after the transaction commits.

## Type of Change

* [x] 🐛 Bug fix (non-breaking change which fixes an issue)
* [ ] ✨ New feature (non-breaking change which adds functionality)
* [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] 📝 Documentation update (no code changes)
* [ ] ⚙️ CI/CD or build pipeline change
* [ ] ⚡ Performance optimization
* [ ] 🛠️ Refactoring (no functional changes)

## Screenshots / Recordings

Not applicable. This PR only changes backend progress tracking logic and tests.

## How Has This Been Tested?

### Automated Tests

* [ ] Backend tests pass: `cd backend && pytest`
* [ ] Frontend tests pass: `cd frontend && npm run test`
* [ ] Frontend builds successfully: `cd frontend && npm run build`

### Manual Verification

* Ran targeted progress tests:

  * `python -m pytest apps/progress/tests -v`
* Ran concurrency regression test:

  * `python -m pytest apps/progress/tests/test_progress_concurrency.py -v`
* Verified that the concurrency test is skipped on SQLite because row-level `SELECT FOR UPDATE` locking requires a supported database backend such as PostgreSQL.
* Ran full backend test command:

  * `python -m pytest`

Full backend test collection currently stops due to unrelated existing repository issues:

* `apps/cache/tests.py` fails because cache models are not registered in `INSTALLED_APPS`.
* `tests/test_github_auth.py` fails because the `services` module cannot be imported.

These failures occur during collection and are outside the scope of this PR.

## Pre-Push Checklist

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings or console errors related to this change
* [ ] I have run `npm run build` in `frontend/` and it completes with **0 errors**
* [ ] I have run `pytest` in `backend/` and all tests pass
* [x] I have run `git diff` locally and verified my changes

## Deployment Notes

No deployment changes, migrations, or environment variable updates are required.

This change only updates backend transaction handling for progress tracking. The row-locking behavior is intended for database backends that support `SELECT FOR UPDATE`, such as PostgreSQL.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved progress updates so duplicate submissions are handled safely, reducing the chance of double-counting XP or progress changes.
  * Made progress syncing more reliable when multiple updates happen at the same time.
  * Badge updates now happen after changes are saved, helping keep progress and rewards consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->