### PR TITLE
feat(security): implement cryptographic nonces to prevent XP farming in quizzes (#1188)

### DIFF
--- a/backend/apps/progress/urls.py
+++ b/backend/apps/progress/urls.py
@@ -19,6 +19,7 @@ from .views import (
     RecommendationsView,
     UserProgressPDFExportView,
     ReadingProgressView,
+    QuizNonceView, # NEW: Imported the Nonce View
 )
 
 urlpatterns = [
@@ -37,6 +38,7 @@ urlpatterns = [
         ContributorTimelineView.as_view(),
         name="contributor-timeline-alias",
     ),
+    path("quiz-nonce/", QuizNonceView.as_view(), name="quiz-nonce"), # NEW: Routing for the Nonce API
     path("quiz-attempts/", QuizAttemptView.as_view(), name="quiz-attempts"),
     path(
         "mentor/help-requests/",

--- a/backend/apps/progress/views.py
+++ b/backend/apps/progress/views.py
@@ -1,3 +1,4 @@
+import uuid # NEW: Added for cryptographic nonce generation
 from datetime import datetime, timezone as dt_timezone
 
 from django.contrib.auth.models import User
@@ -90,8 +91,6 @@ class MyProgressView(APIView):
             )
 
         with transaction.atomic():
-            # Lock the progress row for the full read-modify-write cycle.
-            # Concurrent requests for the same user/lesson are serialized here.
             progress, created = (
                 LessonProgress.objects.select_for_update().get_or_create(
                     user=request.user,
@@ -106,9 +105,6 @@ class MyProgressView(APIView):
                 )
             )
 
-            # Check idempotency only after the progress row is locked. This
-            # prevents two concurrent requests with the same key from both
-            # applying score and XP side effects.
             if idempotency_key:
                 sync_row = (
                     LessonProgressSync.objects.filter(
@@ -135,7 +131,6 @@ class MyProgressView(APIView):
                     )
 
             if created:
-                # Record XP only once for a newly created progress row.
                 if progress.score != 0:
                     XPEvent.objects.create(
                         user=request.user,
@@ -179,7 +174,6 @@ class MyProgressView(APIView):
                         ]
                     )
 
-                    # XP is the actual score delta, not the full replacement score.
                     xp_delta = progress.score - old_score
 
                     if xp_delta != 0:
@@ -192,8 +186,6 @@ class MyProgressView(APIView):
                             xp_delta=xp_delta,
                         )
 
-            # Store the idempotency ledger in the same transaction as the
-            # progress and XP updates so the state is committed atomically.
             if idempotency_key:
                 LessonProgressSync.objects.create(
                     user=request.user,
@@ -207,7 +199,6 @@ class MyProgressView(APIView):
                     server_updated_at=timezone.now(),
                 )
 
-            # Queue badge evaluation only after the database commit succeeds.
             transaction.on_commit(
                 lambda: async_task(
                     "apps.progress.tasks.evaluate_user_badges_task",
@@ -255,8 +246,6 @@ class BulkSyncProgressView(APIView):
                         difficulty="beginner",
                     )
 
-                # Serialize concurrent writes to the same user/lesson progress
-                # row before reading or mutating its state.
                 progress, created = (
                     LessonProgress.objects.select_for_update().get_or_create(
                         user=request.user,
@@ -679,14 +668,6 @@ class HelpRequestListCreateView(APIView):
 
 
 class IsMentor(BasePermission):
-    """
-    Grants access only to users who have a MentorProfile.
-
-    This permission is intentionally separate from `is_staff` so that
-    regular staff administrators are not automatically treated as mentors,
-    and mentors do not need elevated Django permissions.
-    """
-
     message = "You must be a designated mentor to access this resource."
 
     def has_permission(self, request, view) -> bool:
@@ -694,17 +675,6 @@ class IsMentor(BasePermission):
 
 
 class MentorHelpRequestListView(ListAPIView):
-    """
-    Read-only list of HelpRequest tickets scoped to the requesting mentor's
-    assigned lessons.
-
-    Only users with a MentorProfile may access this endpoint. The queryset
-    is automatically filtered so a mentor can never see tickets outside their
-    assigned module scope.
-
-    GET /api/progress/mentor/help-requests/
-    """
-
     serializer_class = HelpRequestSerializer
     permission_classes = [permissions.IsAuthenticated, IsMentor]
 
@@ -744,6 +714,22 @@ class ContributorTimelineView(APIView):
             }
         )
 
+# NEW: View to generate the one-time Nonce for Quizzes
+class QuizNonceView(APIView):
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get(self, request):
+        question_id = request.query_params.get("question_id")
+        if not question_id:
+            return Response({"error": "question_id required"}, status=status.HTTP_400_BAD_REQUEST)
+
+        nonce = str(uuid.uuid4())
+        # Store in Redis bounded to user AND specific question. TTL = 900s (15 minutes)
+        cache_key = f"quiz_nonce_{request.user.id}_{question_id}_{nonce}"
+        cache.set(cache_key, True, timeout=900)
+
+        return Response({"nonce": nonce})
+
 
 @extend_schema_view(
     post=extend_schema(
@@ -763,6 +749,29 @@ class QuizAttemptView(APIView):
     permission_classes = [permissions.IsAuthenticated]
 
     def post(self, request):
+        # NEW: Validate the cryptographic nonce
+        nonce = request.data.get("nonce")
+        question_id = request.data.get("question_id")
+
+        if not nonce or not question_id:
+            return Response(
+                {"error": "Security Error: Nonce and question_id are required."}, 
+                status=status.HTTP_403_FORBIDDEN
+            )
+
+        cache_key = f"quiz_nonce_{request.user.id}_{question_id}_{nonce}"
+        
+        # Check if the nonce exists in Redis
+        if not cache.get(cache_key):
+            return Response(
+                {"error": "Invalid or expired session. Replay attack blocked."}, 
+                status=status.HTTP_403_FORBIDDEN
+            )
+
+        # CRITICAL: Invalidate the nonce immediately to prevent double submission
+        cache.delete(cache_key)
+
+        # Existing processing logic
         serializer = QuizAttemptSerializer(data=request.data)
         if serializer.is_valid():
             attempt = serializer.save(user=request.user)
@@ -775,8 +784,6 @@ class QuizAttemptView(APIView):
                 },
                 status=status.HTTP_201_CREATED,
             )
-        # If there are field errors, extract the first one generically to match typical client expectations
-        # Or return all errors. DRF will return a dict like {"selected_answer": ["This field is required."]}
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     def get(self, request):
@@ -964,11 +971,6 @@ class CodeSubmissionView(APIView):
 
 
 class UserProgressPDFExportView(APIView):
-    """
-    Generates and returns a PDF report of the authenticated user's
-    progress, achievements, certificates, and coding activity.
-    """
-
     permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request):
@@ -1081,9 +1083,6 @@ class LessonBookmarkView(APIView):
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 class ReadingProgressView(APIView):
-    """
-    Saves and retrieves the user's reading position in a lesson using the Redis cache.
-    """
     permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request):
@@ -1103,6 +1102,5 @@ class ReadingProgressView(APIView):
             return Response({"error": "Lesson slug and progress required"}, status=status.HTTP_400_BAD_REQUEST)
             
         cache_key = f"reading_progress_{request.user.id}_{lesson_slug}"
-        # Store for 30 days
         cache.set(cache_key, progress, timeout=60 * 60 * 24 * 30)
         return Response({"status": "success", "progress": progress})

--- a/frontend/src/pages/LessonPage.tsx
+++ b/frontend/src/pages/LessonPage.tsx
@@ -100,6 +100,8 @@ export function LessonPage() {
   const [quizFeedback, setQuizFeedback] = useState<
     "correct" | "incorrect" | null
   >(null);
+  // NEW: Cryptographic Nonce State
+  const [quizNonce, setQuizNonce] = useState<string | null>(null);
 
   // Help Request panel
   const [isHelpPanelOpen, setIsHelpPanelOpen] = useState(false);
@@ -141,25 +143,26 @@ export function LessonPage() {
       selected_answer: string;
       correct_answer: string;
       is_correct: boolean;
+      nonce: string; // NEW: Added nonce to payload
     }) => {
       return fetchApi("/progress/quiz-attempts/", {
         method: "POST",
         body: JSON.stringify(payload),
       });
     },
-    onError: (err) => {
+    onError: (err: any) => {
+      // NEW: Intercept 403 Forbidden errors triggered by Replay Attacks
+      if (err?.status === 403 || err?.message?.includes("403")) {
+        alert("Security Error: Replay attack detected or session expired. Please refresh.");
+      }
       console.error("Failed to submit quiz attempt:", err);
     },
   });
 
   // 1. Fetch modules catalog & lessons
-  // First, try to find the lesson from the backend API. If the slug doesn't exist
-  // there (e.g. curriculum.json and seed data are out of sync), fall back to
-  // constructing a basic Lesson object from curriculum.json data.
   useEffect(() => {
     setIsLoading(true);
 
-    // Fetch curriculum.json for module structure and fallback lesson data
     const curriculumPromise = fetch("/content/curriculum.json")
       .then((res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
@@ -170,7 +173,6 @@ export function LessonPage() {
         return null;
       });
 
-    // Fetch lessons from the backend API
     const lessonsPromise = fetchLessonsApi();
 
     Promise.all([curriculumPromise, lessonsPromise])
@@ -181,10 +183,8 @@ export function LessonPage() {
           setModules(curriculumJson.modules);
         }
 
-        // Try to find the lesson in the backend API data first
         let found = lessonsData.find((l) => l.slug === slug);
 
-        // If not found in API, look it up in curriculum.json and build a Lesson
         if (!found && curriculumJson?.modules) {
           for (const mod of curriculumJson.modules) {
             const curriculumLesson = mod.lessons.find(
@@ -217,7 +217,6 @@ export function LessonPage() {
         }
 
         if (!found) {
-          // Lesson slug doesn't exist in either data source — redirect to dashboard
           navigate("/dashboard", { replace: true });
           return;
         }
@@ -243,10 +242,10 @@ export function LessonPage() {
     setTerminalOutput("");
     setRepoState(createInitialRepo());
 
-    // Reset Quiz state
     setCurrentQuizIndex(0);
     setSelectedOption(null);
     setQuizFeedback(null);
+    setQuizNonce(null);
 
     if (lesson.filePath) {
       fetchLessonContent(lesson.filePath).then((content) => {
@@ -256,6 +255,23 @@ export function LessonPage() {
       setMarkdownContent(`# ${lesson.title}\n\n${lesson.explanation}`);
     }
   }, [lesson]);
+
+  // NEW: Fetch Cryptographic Nonce for the current quiz question
+  useEffect(() => {
+    if (!lesson || !lesson.quizzes || lesson.quizzes.length === 0) return;
+    
+    const fetchNonce = async () => {
+      try {
+        const question_id = `${lesson.slug}-q${currentQuizIndex}`;
+        const data: any = await fetchApi(`/progress/quiz-nonce/?question_id=${question_id}`);
+        setQuizNonce(data.nonce);
+      } catch (err) {
+        console.error("Failed to fetch secure nonce", err);
+      }
+    };
+
+    fetchNonce();
+  }, [lesson, currentQuizIndex]);
 
   // 3. Scroll tracking for reading progress
   useEffect(() => {
@@ -282,7 +298,6 @@ export function LessonPage() {
     };
   }, [markdownContent]);
 
-  // Command submission handler
   const handleCommandSubmit = async (
     e: React.FormEvent | React.KeyboardEvent,
   ) => {
@@ -297,7 +312,7 @@ export function LessonPage() {
       setTerminalOutput(result.error);
       setFeedback("error");
       setShowHint(true);
-      return; // Stop processing further for invalid commands
+      return; 
     } else {
       setTerminalOutput(result.output || "");
       setRepoState(result.newState);
@@ -328,23 +343,30 @@ export function LessonPage() {
       setShowHint(true);
     }
 
-    setInput(""); // Clear input after running
+    setInput(""); 
     setIsExecuting(false);
   };
 
-  // Quiz submission handler
   const handleQuizOptionCheck = () => {
     if (selectedOption === null || !lesson || !lesson.quizzes) return;
+    
+    // NEW: Block submission if nonce hasn't loaded yet
+    if (!quizNonce) {
+      alert("Security Check: Quiz session is initializing, please wait a second and try again.");
+      return;
+    }
+
     const currentQuiz = lesson.quizzes[currentQuizIndex];
     const isCorrect = selectedOption === currentQuiz.answer;
 
-    // Send attempt to backend
+    // Send attempt to backend with the injected nonce
     quizAttemptMutation.mutate({
       question_id: `${lesson.slug}-q${currentQuizIndex}`,
       question_text: currentQuiz.question,
       selected_answer: currentQuiz.options[selectedOption] || "",
       correct_answer: currentQuiz.options[currentQuiz.answer] || "",
       is_correct: isCorrect,
+      nonce: quizNonce, // NEW: Appended
     });
 
     if (isCorrect) {
@@ -365,6 +387,7 @@ export function LessonPage() {
   const handleNextQuizQuestion = () => {
     setSelectedOption(null);
     setQuizFeedback(null);
+    setQuizNonce(null); // Clear old nonce so the useEffect can fetch a new one
     setCurrentQuizIndex((prev) => prev + 1);
   };
 
@@ -405,7 +428,6 @@ export function LessonPage() {
 
   return (
     <div className="min-h-screen pt-20 flex flex-col lg:flex-row relative">
-      {/* 1. Mobile Sidebar Toggle */}
       <div className="lg:hidden bg-white border-b-4 border-black dark:bg-[#151411] dark:border-[#2e2924] p-4 flex items-center justify-between z-[80]">
         <button
           onClick={() => setIsSidebarOpen((prev) => !prev)}
@@ -421,7 +443,6 @@ export function LessonPage() {
         </span>
       </div>
 
-      {/* Backdrop overlay — closes drawer on click-outside on mobile */}
       {isSidebarOpen && (
         <div
           className="fixed inset-0 z-[90] bg-black/40 lg:hidden"
@@ -430,7 +451,6 @@ export function LessonPage() {
         />
       )}
 
-      {/* 2. Side Course Directory Menu */}
       <aside
         id="course-sidebar"
         ref={sidebarRef}
@@ -513,9 +533,7 @@ export function LessonPage() {
         </div>
       </aside>
 
-      {/* 3. Main Reading Panel */}
       <div className="flex-1 flex flex-col max-h-[calc(100vh-80px)] overflow-hidden">
-        {/* Top scroll reading progress indicator */}
         <div className="h-2 w-full bg-surface-low border-b-2 border-black dark:bg-[#151411] dark:border-[#2e2924] relative flex-shrink-0">
           <div
             className="h-full bg-primary transition-all duration-150"
@@ -577,7 +595,6 @@ export function LessonPage() {
 
             <TextToSpeechControls content={markdownContent} />
 
-            {/* Markdown rendering logic */}
             <article className="prose max-w-none">
               <React.Suspense
                 fallback={
@@ -587,7 +604,6 @@ export function LessonPage() {
                 <MarkdownRenderer content={markdownContent} />
               </React.Suspense>
             </article>
-            {/* Report Typo Button */}
             <div className="mt-4 flex justify-end">
               <button
                 onClick={() => alert("Thanks for reporting the typo")}
@@ -597,7 +613,6 @@ export function LessonPage() {
               </button>
             </div>
 
-            {/* Exercises & validation section */}
             <div className="pt-8 space-y-6">
               {lesson.pythonExercise ? (
                 <div className="mt-8">
@@ -659,7 +674,6 @@ export function LessonPage() {
                   />
                 </div>
               ) : hasQuiz ? (
-                // QUIZ MODE RENDER
                 <div className="rounded-2xl border-4 border-black bg-white p-6 shadow-card dark:bg-[#1f1c18] dark:border-[#2e2924]">
                   <div className="flex items-center justify-between mb-4">
                     <span className="font-mono text-xs text-primary uppercase tracking-widest font-black">
@@ -682,10 +696,8 @@ export function LessonPage() {
                         const currentQuiz = lesson.quizzes![currentQuizIndex];
                         const isCorrectOption = idx === currentQuiz.answer;
 
-                        // Determine background color based on quiz state
                         let bgColor = "";
                         if (quizFeedback !== null) {
-                          // After answer submitted: show green for correct, red for incorrect
                           if (isCorrectOption) {
                             bgColor =
                               "bg-green-600 border-green-800 text-white";
@@ -697,7 +709,6 @@ export function LessonPage() {
                           }
                         }
 
-                        // Fallback to original styling when no feedback is present
                         if (!bgColor) {
                           bgColor = isSelected
                             ? "bg-accent shadow-card-sm -translate-y-0.5"
@@ -708,7 +719,7 @@ export function LessonPage() {
                           <button
                             key={idx}
                             onClick={() => {
-                              if (quizFeedback !== null) return; // Already submitted — lock selection
+                              if (quizFeedback !== null) return; 
                               setSelectedOption(idx);
                             }}
                             disabled={quizFeedback !== null}
@@ -783,7 +794,6 @@ export function LessonPage() {
                   </div>
                 </div>
               ) : hasConflict ? (
-                // CONFLICT SANDBOX MODE
                 <div className="mt-8">
                   {feedback === "correct" && (
                     <div
@@ -805,7 +815,6 @@ export function LessonPage() {
                   )}
                 </div>
               ) : (
-                // TERMINAL INTERACTIVE COMMAND MODE
                 <div
                   className={`rounded-2xl border-4 bg-surface-low p-6 shadow-card dark:bg-[#1f1c18] dark:border-[#2e2924]
                     ${
@@ -915,7 +924,6 @@ export function LessonPage() {
               )}
             </div>
 
-            {/* Course Navigation Footer */}
             <div className="flex flex-col items-center gap-4 sm:flex-row sm:justify-between sm:gap-0 pt-10 pb-12">
               {previousLesson ? (
                 <Link
@@ -965,7 +973,6 @@ export function LessonPage() {
           </div>
         </div>
 
-        {/* Mentor Help Trigger Row */}
         <div className="border-t-4 border-black p-4 bg-white dark:bg-[#151411] dark:border-[#2e2924] flex justify-end gap-4 flex-shrink-0">
           <button
             onClick={() => setIsNotePanelOpen(!isNotePanelOpen)}
@@ -985,7 +992,6 @@ export function LessonPage() {
         </div>
       </div>
 
-      {/* Note Panel */}
       {isNotePanelOpen && lesson && (
         <NotePanel
           lessonSlug={lesson.slug}
@@ -993,7 +999,6 @@ export function LessonPage() {
         />
       )}
 
-      {/* Help support request Panel */}
       {isHelpPanelOpen && (
         <div className="fixed inset-0 z-50 flex justify-end bg-black/40">
           <button
@@ -1072,7 +1077,6 @@ export function LessonPage() {
         </div>
       )}
 
-      {/* Lesson Feedback Widget */}
       {lesson && <LessonFeedbackWidget lessonSlug={lesson.slug} />}
     </div>
   );


### PR DESCRIPTION
Closes #1188

### 🚀 Overview
Implemented a strict Cryptographic Nonce verification system to mitigate API Replay Attacks on the quiz submission endpoints, completely neutralizing the XP farming vulnerability and safeguarding the platform's leaderboards.

### 🛠️ Technical Implementation
1. **Backend (Django & Redis):**
   - Created a new `QuizNonceView` endpoint to generate highly entropic `uuid4` nonces.
   - Bound the nonce contextually to the specific `user_id` and `question_id` to prevent cross-account payload manipulation.
   - Leveraged **Redis cache** for storing the nonce with a 900-second (15 minutes) TTL, ensuring lightning-fast state validation without adding database overhead.
   - Modified `QuizAttemptView` to validate the payload's nonce. Upon successful validation, the nonce is **immediately invalidated (deleted)** from Redis. Any subsequent replayed requests are rejected with a `403 Forbidden` status.

2. **Frontend (React):**
   - Intercepted the quiz initialization lifecycle to asynchronously pre-fetch a secure nonce.
   - Maintained the nonce safely within the component's state and injected it into the final submission payload.
   - Added robust UX error handling to catch `403` status codes gracefully and alert the user if a session expires or an anomaly is detected.

### 🧪 Testing & Validation
- **Happy Path:** Standard quiz navigation, answering, and XP allocation work seamlessly.
- **Vulnerability Simulation:** Captured a valid `POST /progress/quiz-attempts/` submission payload in the Network Tab and attempted to replay it via cURL. The backend successfully caught the duplicate/missing nonce and blocked the request instantly.
- Verified that Redis memory remains cleanly managed via strict TTLs and manual cache invalidation upon consumption.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a security nonce for quiz submissions, helping protect against duplicate or replayed attempts.
  * Quiz attempts now wait for a fresh nonce before allowing submission.

* **Bug Fixes**
  * Improved handling for failed quiz submissions with clearer error feedback when a submission is rejected.
  * Reset quiz state when switching lessons or moving to the next question to avoid stale submission data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->