### PR TITLE
fix: Replace broad except Exception with specific token exceptions

### DIFF
--- a/backend/config/services/token_service.py
+++ b/backend/config/services/token_service.py
@@ -1,6 +1,7 @@
 from rest_framework_simplejwt.tokens import RefreshToken
 from django.contrib.auth import get_user_model
 from django.core.cache import cache
+from rest_framework_simplejwt.exceptions import InvalidToken, TokenError
 import hashlib
 import json
 
@@ -27,8 +28,10 @@ class TokenService:
                 'access': str(token.access_token),
                 'refresh': str(token),
             }
-        except Exception as e:
-            return {'error': str(e)}
+        except InvalidToken as e:
+        return {'error': f'Invalid token: {str(e)}'}
+        except TokenError as e:
+        return {'error': f'Token error: {str(e)}'}
 
     @staticmethod
     def blacklist_token(refresh_token):


### PR DESCRIPTION
## What does this PR do?
Replaced broad except Exception blocks in token_service.py with specific exceptions.

## Related issue
Closes #1324

## Type
- [x] Bug fix

## Checklist
- [x] Specific exceptions used
- [x] Ready to merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token refresh error handling with clearer, more specific messages when a refresh token is invalid or otherwise cannot be processed.
  * Removed broad error handling in favor of targeted responses for token-related failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->