### PR TITLE
fix(cache): add logging for cache invalidation exceptions

### DIFF
--- a/backend/apps/cache/services/cache_manager.py
+++ b/backend/apps/cache/services/cache_manager.py
@@ -202,8 +202,10 @@ class CacheManager:
                         parent = getattr(target, field.name)
                         if parent:
                             self.invalidate_dependencies(parent)
-                    except:
-                        pass
+                    except Exception:
+                        logger.exception(
+                            "Failed to invalidate parent cache dependency."
+                        )
 
     def warm_cache(self, model_name: str):
         """
@@ -392,10 +394,12 @@ if (
 try:
     manager = CacheManager()
     manager.invalidate_dependencies(instance)
-except Exception:
-    # Silently ignore errors during migrations/cache invalidation
-    pass
-        pass
+except Exception as e:
+    logger.warning(
+        "Cache invalidation failed after saving %s: %s",
+        instance,
+        e,
+    )
 
 
 @receiver(post_delete)
@@ -423,10 +427,12 @@ if sender._meta.app_label in [
 try:
     manager = CacheManager()
     manager.invalidate_dependencies(instance)
-except Exception:
-    # Silently ignore cache invalidation errors
-    pass
-        pass
+except Exception as e:
+    logger.warning(
+        "Cache invalidation failed after deleting %s: %s",
+        instance,
+        e,
+    )
 
 
 @receiver(m2m_changed)
@@ -440,8 +446,12 @@ def invalidate_cache_on_m2m_change(
         manager = CacheManager()
         try:
             manager.invalidate_dependencies(instance)
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning(
+                "Cache invalidation failed for M2M change on %s: %s",
+                instance,
+                e,
+            )
 
         # Also invalidate for related objects
         for pk in pk_set:
@@ -449,7 +459,11 @@ def invalidate_cache_on_m2m_change(
                 related = model.objects.get(pk=pk)
                 try:
                     manager.invalidate_dependencies(related)
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.warning(
+                        "Cache invalidation failed for related object with pk=%s: %s",
+                        pk,
+                        e,
+                    )
             except model.DoesNotExist:
                 pass


### PR DESCRIPTION
## Summary

This PR improves cache error observability by replacing silent exception handlers in `backend/apps/cache/services/cache_manager.py` with appropriate logging.

## Changes Made

* Replaced empty `except: pass` blocks with meaningful logging statements.
* Added `logger.warning()` for recoverable cache invalidation failures.
* Added `logger.exception()` where a full traceback is useful for debugging unexpected failures.
* Logged exception details to improve troubleshooting while preserving the existing cache invalidation behavior.
* Removed silent exception handling that could hide cache-related failures during runtime.

## Why

Previously, several exception handlers silently ignored cache-related errors. This made it difficult to detect and diagnose issues such as cache invalidation failures or unexpected runtime exceptions.

With these changes, cache failures are now recorded in the application logs without changing the existing application flow, making debugging and monitoring significantly easier.

## Testing

* Reviewed all modified exception handlers to ensure silent failures were replaced with logging.
* Verified that the changes preserve the existing cache invalidation behavior while improving observability.

Closes #1325


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cache invalidation errors are now logged instead of being silently ignored.
  * Dependency and related-record invalidation will continue processing while recording any failures, improving visibility into cache update issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->