### PR TITLE
fix(backend): remove duplicate apps.cache entries from settings.py

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -156,13 +156,11 @@ INSTALLED_APPS = [
     "apps.webhooks",
     "apps.notes",
     "apps.recommendations",
-    "apps.cache",
     "apps.rbac",
     "apps.uploads",
     "graphene_django",
     "apps.feature_flags",
     "apps.issues",
-"apps.cache",
 "apps.moderation",
     "django_q",
 ]


### PR DESCRIPTION
## Description
Resolves a critical backend crash caused by duplicate entries for `"apps.cache"` in `INSTALLED_APPS` within `settings.py`.
Fixes #1349
## Issue
Django's app registry performs a strict uniqueness check when initializing the server (`AppConfig.ready()`). The multiple `"apps.cache"` entries caused an `ImproperlyConfigured` exception to be thrown immediately, preventing the API and test suite from starting.

## Changes
- Removed the duplicate occurrences of `"apps.cache"` in `backend/config/settings.py`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the app loading order in the settings so all expected modules are registered properly.
  * Removed an accidental duplicate app entry to prevent configuration issues during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->