### PR TITLE
fix(security): sanitize export paths to prevent zip slip vulnerability

### DIFF
--- a/backend/apps/sandbox/tests_projects.py
+++ b/backend/apps/sandbox/tests_projects.py
@@ -127,3 +127,29 @@ class ProjectExportTests(APITestCase):
         self.client.force_authenticate(user=self.user)
         response = self.client.get(f"/api/sandbox/projects/{other_project.id}/export_zip/")
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_export_zip_sanitizes_paths(self):
+        # Legitimate file that should be included
+        ProjectFile.objects.create(project=self.project, path="..env", content="valid")
+        # Malicious traversal files
+        ProjectFile.objects.create(project=self.project, path="../evil.txt", content="evil")
+        ProjectFile.objects.create(project=self.project, path="..\\evil.txt", content="evil")
+        ProjectFile.objects.create(project=self.project, path="C:\\Windows\\win.ini", content="evil")
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(self.export_url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        import io
+        import zipfile
+        buffer = io.BytesIO(response.content)
+        with zipfile.ZipFile(buffer, "r") as zf:
+            names = zf.namelist()
+            # The valid file must be included
+            self.assertIn("..env", names)
+            # The malicious files must be excluded
+            self.assertNotIn("../evil.txt", names)
+            self.assertNotIn("..\\evil.txt", names)
+            self.assertNotIn("C:\\Windows\\win.ini", names)
+            self.assertNotIn("C:/Windows/win.ini", names)

--- a/backend/apps/sandbox/views.py
+++ b/backend/apps/sandbox/views.py
@@ -140,13 +140,17 @@ class ProjectViewSet(viewsets.ModelViewSet):
         project = self.get_object()
         files = ProjectFile.objects.filter(project=project)
 
+        import os
+
         # Create ZIP in memory
         buffer = io.BytesIO()
         with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as zip_file:
             for file in files:
-                # Normalize path to avoid issues
-                file_path = file.path.lstrip("/")
-                zip_file.writestr(file_path, file.content)
+                # Sanitize path to prevent Zip Slip (Directory Traversal)
+                clean_path = os.path.normpath(file.path.lstrip("/"))
+                if clean_path.startswith("..") or os.path.isabs(clean_path):
+                    continue  # Skip malicious paths attempting to escape the directory
+                zip_file.writestr(clean_path, file.content)
 
             # Add a README file
             readme_content = f"""# {project.name}

--- a/backend/apps/sandbox/views.py
+++ b/backend/apps/sandbox/views.py
@@ -147,9 +147,10 @@ class ProjectViewSet(viewsets.ModelViewSet):
         with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as zip_file:
             for file in files:
                 # Sanitize path to prevent Zip Slip (Directory Traversal)
-                clean_path = os.path.normpath(file.path.lstrip("/"))
-                if clean_path.startswith("..") or os.path.isabs(clean_path):
-                    continue  # Skip malicious paths attempting to escape the directory
+                raw_path = (file.path or "").replace("\\", "/").lstrip("/")
+                clean_path = os.path.normpath(raw_path).replace("\\", "/")
+                if clean_path in ("", ".", "..") or clean_path.startswith("../") or ":" in clean_path.split("/", 1)[0]:
+                    continue  # Skip paths that could escape the archive root
                 zip_file.writestr(clean_path, file.content)
 
             # Add a README file


### PR DESCRIPTION
## Description
Mitigates a High-severity Arbitrary File Write (Zip Slip) vulnerability in the sandbox project export functionality.
Fixes #1350
## Issue
The `export_zip` method in `backend/apps/sandbox/views.py` sanitized file paths using only `.lstrip("/")` before writing them into a ZIP archive. This failed to prevent directory traversal sequences (e.g., `../`). A malicious user could craft project files with traversal paths, causing the resulting ZIP to overwrite arbitrary system files when extracted by a victim.

## Changes
- Introduced `os.path.normpath` to resolve paths safely.
- Added strict checks to skip any paths starting with `..` or attempting to escape the directory root.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ZIP export safety by sanitizing each exported file path and excluding unsafe normalized entries (including traversal and absolute Windows-style paths).
  * Added coverage to ensure legitimate filenames are still included while malicious traversal/absolute variants are omitted from the downloaded archive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->