### PR TITLE
fix(search): add missing time and timezone imports to prevent fatal crashes

### DIFF
--- a/backend/apps/advanced_search/services/search_engine.py
+++ b/backend/apps/advanced_search/services/search_engine.py
@@ -4,12 +4,14 @@ Advanced search engine with relevance scoring and semantic understanding.
 
 import logging
 import re
+import time
 import numpy as np
 from typing import Dict, Any, List, Optional, Tuple
 from django.db.models import Q, F, Value
 from django.contrib.postgres.search import SearchQuery, SearchRank, SearchVector
 from django.core.cache import cache
 from django.conf import settings
+from django.utils import timezone
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics.pairwise import cosine_similarity
 from apps.advanced_search.models import SearchEmbedding, UserSearchProfile


### PR DESCRIPTION
Fixes #1351 & #1352
## Description
Fixes two fatal `NameError` exceptions that completely broke the `AdvancedSearchEngine` module.

## Issue
The `search()` method attempted to use `time.time()` and `timezone.now()` for performance tracking and freshness scoring, respectively. However, neither `time` nor `django.utils.timezone` were imported, causing the endpoint to crash and rendering the search functionality unusable.

## Changes
- Added `import time` to `backend/apps/advanced_search/services/search_engine.py`.
- Added `from django.utils import timezone` to the same file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search reliability by adding support for time-based measurements and date-aware scoring.
  * Kept search behavior aligned with current system time for more accurate freshness results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->