### PR TITLE
fix(github): handle missing GITHUB_TOKEN gracefully to prevent rate limit DoS

### DIFF
--- a/backend/apps/recommendations/services/github_analyzer.py
+++ b/backend/apps/recommendations/services/github_analyzer.py
@@ -20,11 +20,14 @@ class GitHubAnalyzer:
     GITHUB_API_URL = "https://api.github.com"
     
     def __init__(self, github_token: Optional[str] = None):
-        self.github_token = github_token or settings.GITHUB_TOKEN
+        self.github_token = github_token or getattr(settings, 'GITHUB_TOKEN', None)
         self.headers = {
-            "Authorization": f"token {self.github_token}",
             "Accept": "application/vnd.github.v3+json"
         }
+        if self.github_token:
+            self.headers["Authorization"] = f"token {self.github_token}"
+        else:
+            logger.warning("GITHUB_TOKEN is missing. Requests will be unauthenticated and subject to strict rate limits.")
     
     def analyze_user(self, username: str) -> Dict[str, Any]:
         """

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -264,6 +264,7 @@ GITHUB_APP={
     'WEBHOOK_SECRET': os.getenv('GITHUB_WEBHOOK_SECRET'),
 }
 GITHUB_INSTALLATION_ID = os.getenv("GITHUB_INSTALLATION_ID")
+GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
 
 # ── Discord Integration ────────────────────────────────────────────────────────
 # Discord webhook URL for achievement announcements


### PR DESCRIPTION
## Description
Resolves a service denial condition where unauthenticated GitHub API requests exhaust the public rate limit.
Fixes #1353
## Issue
The `GitHubAnalyzer` attempted to use `settings.GITHUB_TOKEN`, but the variable was not defined in `settings.py`. This caused an `AttributeError`, and even if caught, the analyzer would fall back to unauthenticated requests. GitHub strictly limits unauthenticated requests to 60 per hour per IP. Once exhausted, all requests failed with a `403 Forbidden`, breaking the recommendation engine.

## Changes
- Defined `GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")` securely in `backend/config/settings.py`.
- Updated `GitHubAnalyzer.__init__` to gracefully check `getattr(settings, 'GITHUB_TOKEN', None)`. If missing, it now omits the `Authorization` header instead of crashing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub API requests now support an optional access token from environment configuration, improving reliability when available.
* **Bug Fixes**
  * Made GitHub request setup more resilient when a token is missing, preventing failures from absent configuration.
  * Added a clear warning when requests run without authentication, helping explain potential rate-limit issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->