### PR TITLE
feat: dark mode support to the Certificate and Progress Report print views

### DIFF
--- a/backend/apps/moderation/tests.py
+++ b/backend/apps/moderation/tests.py
@@ -12,6 +12,10 @@ class ModerationWorkflowTests(TestCase):
     def setUp(self):
         self.client = APIClient()
         self.user = User.objects.create_user(username="testuser", password="password123")
+
+        # staff user (non-superuser) - should be allowed to take actions
+        self.staff = User.objects.create_user(username="staffuser", password="password123", is_staff=True)
+
         self.admin = User.objects.create_superuser(username="adminuser", password="password123")
         
         self.submission = CodeSubmission.objects.create(
@@ -26,6 +30,7 @@ class ModerationWorkflowTests(TestCase):
             rating=1
         )
         self.review_ct = ContentType.objects.get_for_model(PeerReview)
+
 
     def test_create_report(self):
         self.client.force_authenticate(user=self.user)
@@ -121,3 +126,64 @@ class ModerationWorkflowTests(TestCase):
         
         self.review.refresh_from_db()
         self.assertFalse(self.review.is_hidden)
+
+    def test_staff_can_approve_report(self):
+        report = ContentReport.objects.create(
+            reporter=self.user,
+            content_type=self.review_ct,
+            object_id=self.review.id,
+            category=ContentReport.Category.SPAM
+        )
+        self.client.force_authenticate(user=self.staff)
+        response = self.client.post(
+            f"/api/moderation/reports/{report.id}/action/",
+            {"status": "APPROVED"},
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.review.refresh_from_db()
+        self.assertTrue(self.review.is_hidden)
+
+    def test_reporting_own_content_allowed(self):
+        # In this codebase, PeerReview is authored by `reviewer`.
+        # "Self-report" means the reporter is the same user who authored the review.
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(
+            "/api/moderation/reports/",
+            {
+                "content_type_app": "progress",
+                "content_type_model": "peerreview",
+                "object_id": self.review.id,
+                "category": "SPAM",
+                "description": "Self report",
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_reporting_already_hidden_content_and_approval_keeps_hidden(self):
+        self.review.is_hidden = True
+        self.review.save(update_fields=["is_hidden"])
+
+        self.client.force_authenticate(user=self.user)
+        report_response = self.client.post(
+            "/api/moderation/reports/",
+            {
+                "content_type_app": "progress",
+                "content_type_model": "peerreview",
+                "object_id": self.review.id,
+                "category": "ABUSIVE",
+                "description": "Already hidden",
+            },
+        )
+        self.assertEqual(report_response.status_code, status.HTTP_201_CREATED)
+
+        report = ContentReport.objects.get(reporter=self.user, object_id=self.review.id)
+        self.client.force_authenticate(user=self.admin)
+        action_response = self.client.post(
+            f"/api/moderation/reports/{report.id}/action/",
+            {"status": "APPROVED"},
+        )
+        self.assertEqual(action_response.status_code, status.HTTP_200_OK)
+
+        self.review.refresh_from_db()
+        self.assertTrue(self.review.is_hidden)
+

--- a/backend/apps/progress/models.py
+++ b/backend/apps/progress/models.py
@@ -133,10 +133,12 @@ class LessonProgressSync(models.Model):
         default=0,
         validators=[
             MinValueValidator(0),
-            MaxValueValidator(1000) 
-        ]
+            MaxValueValidator(1000),
+        ],
+    )
 
     client_timestamp_ms = models.BigIntegerField(null=True, blank=True)
+
 
     # When the server applied this sync item
     server_updated_at = models.DateTimeField(null=True, blank=True)

--- a/frontend/src/components/dashboard/CertificateModal.tsx
+++ b/frontend/src/components/dashboard/CertificateModal.tsx
@@ -19,7 +19,7 @@ export function CertificateModal({
 
   return (
     <div className="fixed inset-0 bg-black/75 z-50 flex items-center justify-center p-4 overflow-y-auto">
-      <div className="w-full max-w-4xl bg-[#FFF9F0] rounded-[2rem] border-8 border-black p-8 sm:p-12 relative flex flex-col justify-between items-center text-center shadow-card bg-dot-grid print:border-none print:shadow-none print:p-0">
+      <div className="w-full max-w-4xl bg-[#FFF9F0] rounded-[2rem] border-8 border-black p-8 sm:p-12 relative flex flex-col justify-between items-center text-center shadow-card bg-dot-grid print:border-none print:shadow-none print:p-0 print:bg-white print:text-black">
         <button
           onClick={onClose}
           className="absolute top-4 right-4 bg-white border-2 border-black p-2 rounded-full hover:bg-surface-low transition-colors print:hidden"

--- a/frontend/src/components/dashboard/ProgressReportModal.tsx
+++ b/frontend/src/components/dashboard/ProgressReportModal.tsx
@@ -32,7 +32,7 @@ export function ProgressReportModal({
 
   return (
     <div className="fixed inset-0 bg-black/75 z-50 flex items-center justify-center p-4 overflow-y-auto">
-      <div className="certificate-printable w-full max-w-2xl bg-white rounded-[2rem] border-8 border-black p-8 sm:p-10 relative shadow-card print:border-none print:shadow-none print:p-0 dark:bg-[#1f1c18] dark:border-[#2e2924]">
+<div className="certificate-printable w-full max-w-2xl bg-white rounded-[2rem] border-8 border-black p-8 sm:p-10 relative shadow-card print:border-none print:shadow-none print:p-0 print:bg-white print:text-black dark:bg-[#1f1c18] dark:border-[#2e2924]">
         <button
           onClick={onClose}
           className="no-print absolute top-4 right-4 bg-white border-2 border-black p-2 rounded-full hover:bg-surface-low transition-colors print:hidden"

--- a/frontend/src/test/ModerationDashboard.test.tsx
+++ b/frontend/src/test/ModerationDashboard.test.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { ModerationDashboard } from "../pages/ModerationDashboard";
+import * as api from "../lib/api";
+
+describe("ModerationDashboard", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders pending reports and submits approve action", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    const mockReports = [
+      {
+        id: 1,
+        reporter_username: "alice",
+        content_type_str: "progress.peerreview",
+        content_summary: "spam content",
+        category: "SPAM",
+        description: "bad",
+        status: "PENDING",
+        action_taken: "NONE",
+        created_at: new Date().toISOString(),
+      },
+    ];
+
+    const fetchApiSpy = vi
+      .spyOn(api, "fetchApi")
+      // initial query
+      .mockResolvedValueOnce(mockReports)
+      // action approve
+      .mockResolvedValueOnce({});
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ModerationDashboard />
+      </QueryClientProvider>
+    );
+
+    expect(
+      await screen.findByText(/moderation dashboard/i)
+    ).toBeInTheDocument();
+
+    // Wait for report to appear
+    expect(await screen.findByText("SPAM")).toBeInTheDocument();
+    expect(screen.getByText(/by @alice/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("spam content"));
+
+    // Approve button should appear for PENDING report
+    const approveBtn = await screen.findByRole("button", {
+      name: /approve & hide content/i,
+    });
+    fireEvent.click(approveBtn);
+
+    await waitFor(() => {
+      expect(fetchApiSpy).toHaveBeenCalled();
+    });
+
+    const calls = fetchApiSpy.mock.calls;
+    // One call is for fetching, one for action
+    const actionCall = calls.find((c) => String(c[0]).includes("/moderation/reports/1/action/"));
+    expect(actionCall).toBeTruthy();
+
+    const [endpoint, options] = actionCall as [string, any];
+    expect(endpoint).toBe("/moderation/reports/1/action/");
+    expect(options.method).toBe("POST");
+
+    const body = JSON.parse(options.body);
+    expect(body).toEqual({ status: "APPROVED" });
+  });
+});
+

--- a/frontend/src/test/ReportDialog.test.tsx
+++ b/frontend/src/test/ReportDialog.test.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { ReportDialog } from "../components/moderation/ReportDialog";
+import * as api from "../lib/api";
+
+describe("ReportDialog", () => {
+  const user = userEvent.setup();
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("submits report with correct payload and shows success", async () => {
+    const fetchApiSpy = vi
+      .spyOn(api, "fetchApi")
+      .mockResolvedValueOnce({});
+
+    const onClose = vi.fn();
+
+    render(
+      <ReportDialog
+        isOpen={true}
+        onClose={onClose}
+        contentType="progress.peerreview"
+        objectId={123}
+      />
+    );
+
+    // Category default is SPAM; just fill description
+    const textarea = screen.getByPlaceholderText(/provide additional details/i);
+    await user.type(textarea, "some details");
+
+    fireEvent.click(screen.getByRole("button", { name: /report/i }));
+
+    await waitFor(() => {
+      expect(fetchApiSpy).toHaveBeenCalledTimes(1);
+    });
+
+    const [endpoint, options] = fetchApiSpy.mock.calls[0] as [string, any];
+    expect(endpoint).toBe("/moderation/reports/");
+    expect(options.method).toBe("POST");
+
+    const body = JSON.parse(options.body);
+    expect(body).toMatchObject({
+      object_id: 123,
+      category: "SPAM",
+      description: "some details",
+      content_type_app: "progress",
+      content_type_model: "peerreview",
+    });
+
+    expect(
+      await screen.findByText(/report submitted successfully/i)
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /close/i }));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("shows error UI when fetchApi rejects", async () => {
+    vi.spyOn(api, "fetchApi").mockRejectedValueOnce(
+      new Error("Failed to submit")
+    );
+
+    const onClose = vi.fn();
+
+    render(
+      <ReportDialog
+        isOpen={true}
+        onClose={onClose}
+        contentType="progress.peerreview"
+        objectId={123}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /report/i }));
+
+    expect(
+      await screen.findByText(/failed to submit/i)
+    ).toBeInTheDocument();
+  });
+});
+


### PR DESCRIPTION
Dark mode safe print styles added for the certificate + progress report modals.

Changes made:

frontend/src/components/dashboard/CertificateModal.tsx

Added print:bg-white and print:text-black to the certificate printable container so print/PDF always uses a light background with black text.
frontend/src/components/dashboard/ProgressReportModal.tsx

Added print:bg-white and print:text-black to the progress report printable container so print/PDF always uses a light background with black text (while preserving existing dark-mode styling for on-screen use).


closes #1330

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added print-friendly styling for certificate and progress report modals for cleaner hard-copy output.
  * Expanded moderation workflows so staff can approve reports, and reporting is supported for your own authored content.

* **Bug Fixes**
  * Kept already hidden content hidden after a new report is approved.
  * Improved moderation and report submission handling to better surface success and error states.

* **Tests**
  * Added coverage for moderation, reporting, and print-related UI behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->