### PR TITLE
Feat/search dropdown

### DIFF
--- a/backend/apps/content/permissions.py
+++ b/backend/apps/content/permissions.py
@@ -1,0 +1,37 @@
+from rest_framework.permissions import BasePermission
+from .models import Lesson, UserProgress
+
+class IsLessonUnlocked(BasePermission):
+    """
+    Check if user has completed prerequisites for a lesson.
+    """
+    def has_permission(self, request, view):
+        # Get lesson slug from URL
+        lesson_slug = view.kwargs.get('slug')
+        user = request.user
+        
+        if not user or not user.is_authenticated:
+            return False
+            
+        try:
+            lesson = Lesson.objects.get(slug=lesson_slug)
+        except Lesson.DoesNotExist:
+            return False
+            
+        # If no prerequisites, lesson is accessible
+        if not hasattr(lesson, 'prerequisites') or not lesson.prerequisites.exists():
+            return True
+            
+        # Get user's completed lessons
+        completed_lessons = UserProgress.objects.filter(
+            user=user,
+            lesson__in=lesson.prerequisites.all(),
+            completed=True
+        ).values_list('lesson_id', flat=True)
+        
+        # Check if ALL prerequisites are completed
+        for prereq in lesson.prerequisites.all():
+            if prereq.id not in completed_lessons:
+                return False
+                
+        return True

--- a/backend/apps/content/views.py
+++ b/backend/apps/content/views.py
@@ -290,6 +290,18 @@ class LessonPDFView(views.APIView):
 
         return response_obj
 
+class LessonAccessCheckView(APIView):
+    """
+    Check if user can access a lesson.
+    """
+    permission_classes = [IsLessonUnlocked]
+    
+    def get(self, request, slug):
+        return Response({
+            "has_access": True,
+            "message": "You have access to this lesson"
+        })
+
 
 import json
 import os

--- a/frontend/src/hooks/SearchHistoryDropdown.css
+++ b/frontend/src/hooks/SearchHistoryDropdown.css
@@ -1,0 +1,62 @@
+.search-history-dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  background: white;
+  border: 2px solid black;
+  border-radius: 8px;
+  padding: 8px;
+  z-index: 100;
+  box-shadow: 4px 4px 0 rgba(0,0,0,0.1);
+}
+
+.dropdown-header {
+  display: flex;
+  justify-content: space-between;
+  padding: 4px 8px;
+  border-bottom: 1px solid #eee;
+}
+
+.dropdown-header button {
+  background: none;
+  border: none;
+  color: red;
+  cursor: pointer;
+}
+
+ul {
+  list-style: none;
+  padding: 0;
+  margin: 4px 0 0;
+}
+
+li {
+  display: flex;
+  justify-content: space-between;
+  padding: 6px 8px;
+  border-radius: 4px;
+}
+
+li:hover {
+  background: #f5f5f5;
+}
+
+li button:first-child {
+  background: none;
+  border: none;
+  cursor: pointer;
+  flex: 1;
+  text-align: left;
+}
+
+li button:last-child {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: #999;
+}
+
+li button:last-child:hover {
+  color: red;
+}

--- a/frontend/src/hooks/SearchHistoryDropdown.tsx
+++ b/frontend/src/hooks/SearchHistoryDropdown.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import './SearchHistoryDropdown.css';
+
+export function SearchHistoryDropdown({ history, onSelect, onRemove, onClear, isOpen }) {
+  if (!isOpen || history.length === 0) return null;
+
+  return (
+    <div className="search-history-dropdown">
+      <div className="dropdown-header">
+        <span>Recent Searches</span>
+        <button onClick={onClear}>Clear All</button>
+      </div>
+      <ul>
+        {history.map((query, i) => (
+          <li key={i}>
+            <button onClick={() => onSelect(query)}>🔍 {query}</button>
+            <button onClick={() => onRemove(query)}>✕</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useSearchHistory.ts
+++ b/frontend/src/hooks/useSearchHistory.ts
@@ -1,0 +1,51 @@
+import { useState, useEffect } from 'react';
+
+const STORAGE_KEY = 'search_history';
+const MAX_HISTORY = 5;
+
+export function useSearchHistory() {
+  const [history, setHistory] = useState<string[]>([]);
+
+  // Load from localStorage on mount
+  useEffect(() => {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (saved) {
+      try {
+        setHistory(JSON.parse(saved));
+      } catch {
+        setHistory([]);
+      }
+    }
+  }, []);
+
+  // Add new search
+  const addSearch = (query: string) => {
+    if (!query || !query.trim()) return;
+    
+    setHistory(prev => {
+      // Remove duplicate if exists
+      const filtered = prev.filter(item => item !== query);
+      // Add to front, limit to MAX_HISTORY
+      const newHistory = [query, ...filtered].slice(0, MAX_HISTORY);
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(newHistory));
+      return newHistory;
+    });
+  };
+
+  // Clear all history
+  const clearHistory = () => {
+    setHistory([]);
+    localStorage.removeItem(STORAGE_KEY);
+  };
+
+  // Remove single item
+  const removeItem = (query: string) => {
+    setHistory(prev => {
+      const newHistory = prev.filter(item => item !== query);
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(newHistory));
+      return newHistory;
+    });
+  };
+
+  return { history, addSearch, clearHistory, removeItem };
+}


### PR DESCRIPTION
## Description

Adds search history dropdown showing last 5 searches saved in LocalStorage. Users can click history items to repeat searches and clear all history with one click.

Fixes #1409 


## Features
- Last 5 searches saved in LocalStorage
- Dropdown appears on input focus
- Click history item to search
- Clear All button
- Individual remove buttons




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a recent-searches dropdown, including selecting, removing, and clearing past searches.
  * Search history now persists between visits and keeps the most recent entries available.
  * Added lesson access checks so locked lessons are only available after required lessons are completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->