### PR TITLE
fix(github): prevent SSRF by validating endpoint as relative path

### DIFF
--- a/backend/github/service.py
+++ b/backend/github/service.py
@@ -27,6 +27,11 @@ class GithubService:
 
     def make_request(self, method: str, endpoint: str, **kwargs) -> Dict[str, Any]:
         """Make a GitHub API request"""
+        # Ensure endpoint is a relative path to prevent SSRF via URL injection
+        parsed_endpoint = urlparse(endpoint)
+        if parsed_endpoint.scheme or parsed_endpoint.netloc:
+            raise ValueError("Invalid endpoint: Must be a relative path")
+
         url = f"{self.base_url}/{endpoint.lstrip('/')}"
         
         parsed_url = urlparse(url)

--- a/backend/github/service.py
+++ b/backend/github/service.py
@@ -1,5 +1,6 @@
 import requests
 from typing import Dict, Any, Optional
+from urllib.parse import urlparse
 from .auth import get_github_token
 
 
@@ -27,6 +28,11 @@ class GithubService:
     def make_request(self, method: str, endpoint: str, **kwargs) -> Dict[str, Any]:
         """Make a GitHub API request"""
         url = f"{self.base_url}/{endpoint.lstrip('/')}"
+        
+        parsed_url = urlparse(url)
+        if parsed_url.netloc != "api.github.com" and not parsed_url.netloc.endswith(".github.com"):
+            raise ValueError("Invalid endpoint: Domain must be a github.com domain")
+
         headers = self._get_headers()
         headers.update(kwargs.pop("headers", {}))
 
@@ -76,4 +82,4 @@ class GithubService:
 
 
 # Singleton instance
-github_service = GitHubService()
+github_service = GithubService()


### PR DESCRIPTION
closes #1264 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request safety when connecting to GitHub by blocking non-relative URLs and ensuring requests only target approved GitHub domains.
  * Fixed the GitHub service instance initialization so the app uses the correct service class.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->