### PR TITLE
feat(ui): Add Dark Mode Optimization for Recharts Graphs on Dashboard

### DIFF
--- a/frontend/src/components/dashboard/AdminDashboard.tsx
+++ b/frontend/src/components/dashboard/AdminDashboard.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { fetchApi } from "../../lib/api";
+import { useTheme } from "../../hooks/useTheme";
 import SkeletonAdminDashboard from "../ui/skeletons/SkeletonAdminDashboard";
 import {
   Bar,
@@ -17,6 +18,7 @@ import {
 import type { AdminDashboardData, LeaderboardResponse } from "./types";
 
 export function AdminDashboard() {
+  const { theme } = useTheme();
   const {
     data: adminData,
     isLoading: isAdminLoading,
@@ -155,18 +157,19 @@ return (
           ) : leaderboardResults.length > 0 ? (
             <ResponsiveContainer width="100%" height="100%">
               <BarChart data={leaderboardResults}>
-                <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
+                <CartesianGrid strokeDasharray="3 3" stroke={theme === "dark" ? "#2e2924" : "#e0e0e0"} />
                 <XAxis
                   dataKey="username"
-                  tick={{ fontStyle: "bold", fill: "#6b5a49" }}
+                  tick={{ fontStyle: "bold", fill: theme === "dark" ? "#c4bbae" : "#6b5a49" }}
                 />
-                <YAxis tick={{ fontStyle: "bold", fill: "#6b5a49" }} />
+                <YAxis tick={{ fontStyle: "bold", fill: theme === "dark" ? "#c4bbae" : "#6b5a49" }} />
                 <Tooltip
                   contentStyle={{
-                    backgroundColor: "#ffffff",
-                    border: "4px solid #000000",
+                    backgroundColor: theme === "dark" ? "#1f1c18" : "#ffffff",
+                    border: theme === "dark" ? "4px solid #2e2924" : "4px solid #000000",
                     borderRadius: "12px",
                     fontWeight: "bold",
+                    color: theme === "dark" ? "#f0ebe2" : "#000",
                   }}
                 />
                 <Legend wrapperStyle={{ fontWeight: "bold" }} />
@@ -174,14 +177,14 @@ return (
                   dataKey="xp"
                   name="XP Points"
                   fill="#ff9500"
-                  stroke="#000000"
+                  stroke={theme === "dark" ? "#1f1c18" : "#000000"}
                   strokeWidth={2}
                 />
                 <Bar
                   dataKey="prs_merged"
                   name="Merged PRs"
                   fill="#ff3b30"
-                  stroke="#000000"
+                  stroke={theme === "dark" ? "#1f1c18" : "#000000"}
                   strokeWidth={2}
                 />
               </BarChart>
@@ -218,17 +221,18 @@ return (
                       <Cell
                         key={`cell-${index}`}
                         fill={COLORS[index % COLORS.length]}
-                        stroke="#000"
+                        stroke={theme === "dark" ? "#1f1c18" : "#000"}
                         strokeWidth={2}
                       />
                     ))}
                   </Pie>
                   <Tooltip
                     contentStyle={{
-                      backgroundColor: "#ffffff",
-                      border: "4px solid #000000",
+                      backgroundColor: theme === "dark" ? "#1f1c18" : "#ffffff",
+                      border: theme === "dark" ? "4px solid #2e2924" : "4px solid #000000",
                       borderRadius: "12px",
                       fontWeight: "bold",
+                      color: theme === "dark" ? "#f0ebe2" : "#000",
                     }}
                   />
                 </PieChart>

--- a/frontend/src/components/dashboard/ContributorDashboard.tsx
+++ b/frontend/src/components/dashboard/ContributorDashboard.tsx
@@ -18,6 +18,7 @@ import {
 } from "recharts";
 
 import { useAuth } from "../../features/auth/AuthContext";
+import { useTheme } from "../../hooks/useTheme";
 import { useBookmarks } from "../../hooks/useBookmarks";
 import { useUserProgress } from "../../hooks/useUserProgress";
 import { fetchApi } from "../../lib/api";
@@ -58,6 +59,7 @@ interface ContributorsCache {
 
 export function ContributorDashboard() {
   const { user } = useAuth();
+  const { theme } = useTheme();
   const { isLessonCompleted } = useUserProgress();
   const { bookmarks, toggleBookmark } = useBookmarks();
 
@@ -540,8 +542,16 @@ return (
               paddingAngle={3}
               dataKey="value"
             >
-              <Cell fill="#ff3b30" stroke="#000" strokeWidth={2} />
-              <Cell fill="#FFEBC2" stroke="#000" strokeWidth={2} />
+              <Cell 
+                fill={theme === "dark" ? "#ff665c" : "#ff3b30"} 
+                stroke={theme === "dark" ? "#1f1c18" : "#000"} 
+                strokeWidth={2} 
+              />
+              <Cell 
+                fill={theme === "dark" ? "#3d2b14" : "#FFEBC2"} 
+                stroke={theme === "dark" ? "#1f1c18" : "#000"} 
+                strokeWidth={2} 
+              />
             </Pie>
           </PieChart>
         </ResponsiveContainer>

--- a/frontend/src/pages/AnalyticsDashboardPage.tsx
+++ b/frontend/src/pages/AnalyticsDashboardPage.tsx
@@ -17,6 +17,7 @@ import {
   Cell,
 } from "recharts";
 import { Activity, Users, BookOpen, Code, AlertTriangle } from "lucide-react";
+import { useTheme } from "../context/ThemeContext";
 
 interface AnalyticsData {
   registrations: { date: string; count: number }[];
@@ -28,6 +29,7 @@ interface AnalyticsData {
 const COLORS = ["#0088FE", "#00C49F", "#FFBB28", "#FF8042"];
 
 export default function AnalyticsDashboardPage() {
+  const { theme } = useTheme();
   const { data, isLoading, isError } = useQuery<AnalyticsData>({
     queryKey: ["moderator_analytics"],
     queryFn: () => fetchApi("/dashboard/analytics/"),
@@ -111,13 +113,15 @@ export default function AnalyticsDashboardPage() {
                 <CartesianGrid
                   strokeDasharray="3 3"
                   vertical={false}
-                  stroke="#e0e0e0"
+                  stroke={theme === "dark" ? "#2e2924" : "#e0e0e0"}
                 />
                 <Tooltip
                   contentStyle={{
                     borderRadius: "8px",
-                    border: "2px solid black",
+                    border: theme === "dark" ? "2px solid #2e2924" : "2px solid black",
                     fontWeight: "bold",
+                    backgroundColor: theme === "dark" ? "#1f1c18" : "#fff",
+                    color: theme === "dark" ? "#f0ebe2" : "#000",
                   }}
                 />
                 <Area
@@ -164,8 +168,10 @@ export default function AnalyticsDashboardPage() {
                 <Tooltip
                   contentStyle={{
                     borderRadius: "8px",
-                    border: "2px solid black",
+                    border: theme === "dark" ? "2px solid #2e2924" : "2px solid black",
                     fontWeight: "bold",
+                    backgroundColor: theme === "dark" ? "#1f1c18" : "#fff",
+                    color: theme === "dark" ? "#f0ebe2" : "#000",
                   }}
                 />
                 <Legend
@@ -215,7 +221,7 @@ export default function AnalyticsDashboardPage() {
                       <Cell
                         key={`cell-${index}`}
                         fill={COLORS[index % COLORS.length]}
-                        stroke="black"
+                        stroke={theme === "dark" ? "#1f1c18" : "black"}
                         strokeWidth={2}
                       />
                     ))}
@@ -223,8 +229,10 @@ export default function AnalyticsDashboardPage() {
                   <Tooltip
                     contentStyle={{
                       borderRadius: "8px",
-                      border: "2px solid black",
+                      border: theme === "dark" ? "2px solid #2e2924" : "2px solid black",
                       fontWeight: "bold",
+                      backgroundColor: theme === "dark" ? "#1f1c18" : "#fff",
+                      color: theme === "dark" ? "#f0ebe2" : "#000",
                     }}
                   />
                   <Legend
@@ -263,7 +271,7 @@ export default function AnalyticsDashboardPage() {
                       <Cell
                         key={`cell-${index}`}
                         fill={COLORS[(index + 2) % COLORS.length]}
-                        stroke="black"
+                        stroke={theme === "dark" ? "#1f1c18" : "black"}
                         strokeWidth={2}
                       />
                     ))}
@@ -271,8 +279,10 @@ export default function AnalyticsDashboardPage() {
                   <Tooltip
                     contentStyle={{
                       borderRadius: "8px",
-                      border: "2px solid black",
+                      border: theme === "dark" ? "2px solid #2e2924" : "2px solid black",
                       fontWeight: "bold",
+                      backgroundColor: theme === "dark" ? "#1f1c18" : "#fff",
+                      color: theme === "dark" ? "#f0ebe2" : "#000",
                     }}
                   />
                   <Legend


### PR DESCRIPTION
## Description

This PR implements dynamic theme support for the Recharts graphs across the dashboard pages. Previously, the charts used hardcoded stroke, grid, and tooltip colors that were difficult to read when the application was in dark mode.

Fixes #1383

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## Proposed Changes
- Imported `useTheme` context in `AnalyticsDashboardPage`, `ContributorDashboard`, and `AdminDashboard`.
- Dynamically updated colors for Recharts components (`CartesianGrid`, `Tooltip`, `XAxis`, `YAxis`, `Cell`, `Bar`) to swap strokes, borders, and text fills based on `theme === "dark"`.

## How Has This Been Tested?

### Automated Tests
- [x] Frontend tests pass: `cd frontend && npm run test`

## Pre-Push Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or console errors
- [x] I have run `git diff` locally and verified my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard charts now adapt their colors and tooltips to the selected light or dark theme.
  * Pie and bar charts across analytics and contributor views now use theme-aware styling for better readability.
* **Bug Fixes**
  * Improved chart contrast in dark mode by updating grid lines, axis labels, borders, and slice outlines.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->