### PR TITLE
bug: Fix horizontal layout overflow of Neobrutalist cards on 320px viewports

### DIFF
--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -19,6 +19,7 @@ body {
   margin: 0;
   min-width: 320px;
   min-height: 100vh;
+  overflow-x: hidden;
   font-family: "Outfit", "Inter", sans-serif;
   color: #000000;
   background-color: #fdfbf7;
@@ -62,6 +63,10 @@ html.dark {
   --dark-primary: #ff665c;
   --dark-cyan: #22d3ee;
   --dark-green: #4ade80;
+}
+
+html {
+  overflow-x: hidden;
 }
 
 /*


### PR DESCRIPTION
## Description

This PR fixes a layout bug where viewing the application on small mobile screens (e.g., 320px width) would result in an unintended horizontal scrollbar. 

The overflow was caused by the `.shadow-card` CSS utility. When applied to `w-full` elements, the hard 4px box-shadow offset extended past the device's viewport width.

Fixes #1387

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Proposed Changes
- Added `overflow-x: hidden;` to the global `html` and `body` rules in `frontend/src/styles.css` to globally prevent decorative box-shadow offsets and rotated elements from triggering X-axis scrolling.

## How Has This Been Tested?
### Automated Tests
- [x] Frontend tests pass: `cd frontend && npm run test`

## Pre-Push Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or console errors
- [x] I have run `git diff` locally and verified my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented horizontal scrolling on the site by tightening global overflow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->