### PR TITLE
feat(tour): Add a Guided Interactive Tour on the Git Sandbox page

### DIFF
--- a/frontend/src/components/ui/OnboardingTour.tsx
+++ b/frontend/src/components/ui/OnboardingTour.tsx
@@ -12,6 +12,7 @@ import { X, ChevronRight, ChevronLeft, Sparkles } from "lucide-react";
 interface OnboardingTourProps {
   run: boolean;
   onFinish: () => void;
+  steps?: Step[];
 }
 
 function CustomTooltip({
@@ -110,8 +111,8 @@ function CustomTooltip({
   );
 }
 
-export function OnboardingTour({ run, onFinish }: OnboardingTourProps) {
-  const steps: Step[] = [
+export function OnboardingTour({ run, onFinish, steps: providedSteps }: OnboardingTourProps) {
+  const defaultSteps: Step[] = [
     {
       target: "#tour-welcome",
       title: "Welcome to the Atelier! 🎉",
@@ -165,7 +166,7 @@ export function OnboardingTour({ run, onFinish }: OnboardingTourProps) {
       continuous
       run={run}
       scrollToFirstStep
-      steps={steps}
+      steps={providedSteps || defaultSteps}
       tooltipComponent={CustomTooltip}
       options={{
         zIndex: 10000,

--- a/frontend/src/components/ui/ProjectWorkspace.tsx
+++ b/frontend/src/components/ui/ProjectWorkspace.tsx
@@ -150,14 +150,16 @@ export function ProjectWorkspace() {
 
   return (
     <div className="flex h-full border border-gray-200 dark:border-gray-800 rounded-lg overflow-hidden bg-white dark:bg-[#1a1a1a]">
-      <ProjectExplorer
-        files={files}
-        activeFileId={activeFileId}
-        onSelectFile={setActiveFileId}
-        onCreateFile={handleCreateFile}
-        onDeleteFile={handleDeleteFile}
-      />
-      <div className="w-[300px] border-r border-gray-800">
+      <div id="tour-sandbox-explorer" className="h-full border-r border-gray-800">
+        <ProjectExplorer
+          files={files}
+          activeFileId={activeFileId}
+          onSelectFile={setActiveFileId}
+          onCreateFile={handleCreateFile}
+          onDeleteFile={handleDeleteFile}
+        />
+      </div>
+      <div id="tour-sandbox-search" className="w-[300px] border-r border-gray-800">
         <SearchPanel 
           project={project} 
           onMatchClick={(fileId) => {
@@ -173,7 +175,7 @@ export function ProjectWorkspace() {
               <span className="text-sm text-gray-300 font-mono">
                 {activeFile.path}
               </span>
-              <div className="flex items-center gap-2">
+              <div id="tour-sandbox-tools" className="flex items-center gap-2">
                 <button
                   onClick={async () => {
                     if (project) {
@@ -202,7 +204,7 @@ export function ProjectWorkspace() {
                 </button>
               </div>
             </div>
-            <div className="flex-1 overflow-auto bg-[#151411]">
+            <div id="tour-sandbox-editor" className="flex-1 overflow-auto bg-[#151411]">
               <CodeEditor
                 code={activeFile.content}
                 onChange={handleCodeChange}
@@ -216,7 +218,7 @@ export function ProjectWorkspace() {
             Select a file to edit
           </div>
         )}
-        <div className="h-1/3 min-h-[250px] max-h-[50%] flex flex-col border-t border-gray-800">
+        <div id="tour-sandbox-terminal" className="h-1/3 min-h-[250px] max-h-[50%] flex flex-col border-t border-gray-800">
           <TerminalWorkspace projectId={project?.id} />
         </div>
       </div>

--- a/frontend/src/pages/SandboxPage.tsx
+++ b/frontend/src/pages/SandboxPage.tsx
@@ -1,20 +1,73 @@
-import React from "react";
+import React, { useState } from "react";
 import { ProjectWorkspace } from "../components/ui/ProjectWorkspace";
+import { OnboardingTour } from "../components/ui/OnboardingTour";
+import { Map } from "lucide-react";
 
 export function SandboxPage() {
+  const [runTour, setRunTour] = useState(false);
+
+  const sandboxSteps = [
+    {
+      target: "#tour-sandbox-explorer",
+      title: "Project Explorer 📁",
+      content: "Create, rename, and organize your files and folders here. Navigate through your project seamlessly.",
+      placement: "right",
+      skipBeacon: true,
+    },
+    {
+      target: "#tour-sandbox-search",
+      title: "Search Panel 🔍",
+      content: "Quickly search for keywords and find exactly what you need across all your files.",
+      placement: "right",
+    },
+    {
+      target: "#tour-sandbox-editor",
+      title: "Code Editor ✍️",
+      content: "Write your code with full syntax highlighting, error checking, and auto-completion built right in.",
+      placement: "left",
+    },
+    {
+      target: "#tour-sandbox-tools",
+      title: "Workspace Tools 🛠️",
+      content: "Export your project, save snippets for later, or manage snapshots to revert changes easily.",
+      placement: "bottom",
+    },
+    {
+      target: "#tour-sandbox-terminal",
+      title: "Interactive Terminal 💻",
+      content: "Run bash commands, compile code, test applications, or interact with Git right from the browser.",
+      placement: "top",
+    },
+  ];
+
   return (
     <div className="p-6 max-w-7xl mx-auto space-y-6 flex flex-col h-[calc(100vh-64px)]">
-      <div>
-        <h1 className="text-3xl font-black text-text dark:text-[#f0ebe2]">
-          Interactive Workspace
-        </h1>
-        <p className="mt-2 text-muted dark:text-[#c4bbae]">
-          Write and organize multi-file projects safely in the browser.
-        </p>
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-black text-text dark:text-[#f0ebe2]">
+            Interactive Workspace
+          </h1>
+          <p className="mt-2 text-muted dark:text-[#c4bbae]">
+            Write and organize multi-file projects safely in the browser.
+          </p>
+        </div>
+        <button
+          onClick={() => setRunTour(true)}
+          className="flex items-center gap-2 px-4 py-2 font-bold text-sm bg-surface dark:bg-[#1a1a1a] border-2 border-black dark:border-[#2e2924] rounded-xl shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] hover:shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] hover:-translate-y-0.5 transition-all"
+        >
+          <Map className="w-4 h-4 text-primary" />
+          Take a Tour
+        </button>
       </div>
       <div className="flex-1 min-h-[500px]">
         <ProjectWorkspace />
       </div>
+
+      <OnboardingTour
+        run={runTour}
+        onFinish={() => setRunTour(false)}
+        steps={sandboxSteps}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Description

This PR introduces an interactive guided tour to the Sandbox page to help users navigate and utilize the workspace tools effectively. It reuses the existing `react-joyride` implementation from the dashboard to maintain a consistent UI and onboarding experience.

Fixes #1398

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)

## Proposed Changes
- Refactored `frontend/src/components/ui/OnboardingTour.tsx` to accept custom `steps` as a prop while falling back to default dashboard steps.
- Embedded specific DOM `id` attributes across `ProjectWorkspace.tsx` (Explorer, Search, Editor, Tools, Terminal) to act as tour anchor targets.
- Added a "Take a Tour" button and custom Sandbox tour steps directly into `SandboxPage.tsx`.

## How Has This Been Tested?
### Manual Verification
- [x] Verified that clicking "Take a Tour" on the Sandbox page launches the Joyride tooltip flow correctly across all 5 workspace zones.
- [x] Checked that the Dashboard tour fallback still functions as expected without breaking.
- [x] Front-end lint passed.

## Pre-Push Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or console errors
- [x] I have run `git diff` locally and verified my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a guided onboarding tour to the sandbox page.
  * Users can now start the tour from a new “Take a Tour” button.
  * The tour highlights key workspace areas, including the explorer, search, editor, tools, and terminal.

* **Bug Fixes**
  * Improved tour targeting by adding stable anchors to major workspace sections, making the walkthrough more reliable.

* **Refactor**
  * Updated the onboarding flow to support custom tour steps while keeping the existing default experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->