### PR TITLE
security(channels): Implement Redis Rate Limiting on Websocket handshakes

### DIFF
--- a/backend/apps/core/middleware.py
+++ b/backend/apps/core/middleware.py
@@ -1,0 +1,62 @@
+import time
+from asgiref.sync import sync_to_async
+from django.core.cache import cache
+
+class WebSocketRateLimitMiddleware:
+    """
+    ASGI middleware that rate-limits WebSocket handshakes.
+    Uses Django's cache framework (which is backed by Redis in production).
+    Limits clients to 60 connections per minute by IP.
+    """
+
+    def __init__(self, inner):
+        self.inner = inner
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] == "websocket":
+            client_ip = self.get_client_ip(scope)
+            if client_ip:
+                is_allowed = await self.check_rate_limit(client_ip)
+                if not is_allowed:
+                    # Reject connection with a custom close code for rate limiting
+                    await send({"type": "websocket.close", "code": 4429})
+                    return
+
+        return await self.inner(scope, receive, send)
+
+    def get_client_ip(self, scope):
+        headers = dict(scope.get("headers", []))
+        if b"x-forwarded-for" in headers:
+            return headers[b"x-forwarded-for"].decode().split(",")[0].strip()
+        client = scope.get("client")
+        if client:
+            return client[0]
+        return None
+
+    @sync_to_async
+    def check_rate_limit(self, client_ip):
+        # 60 handshake attempts per 60 seconds
+        RATE_LIMIT = 60
+        WINDOW = 60
+        
+        cache_key = f"ws_ratelimit_{client_ip}"
+        
+        try:
+            current = cache.get(cache_key, 0)
+            
+            if current >= RATE_LIMIT:
+                return False
+                
+            if current == 0:
+                cache.set(cache_key, 1, WINDOW)
+            else:
+                try:
+                    cache.incr(cache_key)
+                except ValueError:
+                    # In case the key expired between get and incr, or is not an integer
+                    cache.set(cache_key, 1, WINDOW)
+                    
+            return True
+        except Exception:
+            # Fail open if cache is unreachable
+            return True

--- a/backend/config/asgi.py
+++ b/backend/config/asgi.py
@@ -25,12 +25,16 @@ from apps.sandbox.routing import websocket_urlpatterns as sandbox_ws  # noqa: E4
 # Including dashboard_ws which handles real-time metric distributions
 combined_websocket_urlpatterns = notifications_ws + dashboard_ws + chat_ws + sandbox_ws
 
+from apps.core.middleware import WebSocketRateLimitMiddleware
+
 application = ProtocolTypeRouter(
     {
         "http": django_asgi_app,
         "websocket": AllowedHostsOriginValidator(
-            JWTAuthMiddleware(
-                URLRouter(combined_websocket_urlpatterns)
+            WebSocketRateLimitMiddleware(
+                JWTAuthMiddleware(
+                    URLRouter(combined_websocket_urlpatterns)
+                )
             )
         ),
     }


### PR DESCRIPTION
## Description

This PR introduces robust rate-limiting for all WebSocket connections at the ASGI entry point to protect our Channels layer from abuse and connection flooding. It utilizes our Redis-backed cache to track handshake attempts by IP address.

Fixes #1399

## Type of Change
- [x] 🔒 Security (fixes a potential DDoS/abuse vector by limiting connection rate)

## Proposed Changes
- Added a new ASGI middleware `WebSocketRateLimitMiddleware` inside `backend/apps/core/middleware.py`.
- The middleware enforces a strict 60 handshakes/minute limit per IP address using Django's core caching mechanism (Redis).
- Connections exceeding the limit are instantly rejected with a `4429` WebSocket close code, preventing them from reaching the `JWTAuthMiddleware` or creating heavy channel layers.
- Modified `backend/config/asgi.py` to wrap the master `URLRouter` in this new security middleware.

## How Has This Been Tested?
### Manual Verification
- [x] Verified that legitimate WebSocket traffic proceeds normally through the ASGI stack.
- [x] Inspected the backend server output to ensure the middleware does not crash if the cache goes temporarily unavailable (fails open gracefully).

## Pre-Push Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or console errors
- [x] I have run `git diff` locally and verified my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added protection against excessive WebSocket connection attempts by limiting repeated handshakes from the same IP address.
  * WebSocket connections now use a safer connection flow that can reject suspicious bursts with a standard close response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->