### PR TITLE
fix(chat): add missing public_key action to WebSocket ChatConsumer

### DIFF
--- a/backend/apps/chat/consumers.py
+++ b/backend/apps/chat/consumers.py
@@ -122,6 +122,20 @@ class ChatConsumer(AsyncWebsocketConsumer):
                 },
             )
 
+        elif action == "public_key":
+            public_key = data.get("public_key")
+            if public_key:
+                await self.channel_layer.group_send(
+                    self.group_name,
+                    {
+                        "type": "public_key_broadcast",
+                        "username": self.user.username,
+                        "user_id": self.user.id,
+                        "public_key": public_key,
+                        "sender_channel": self.channel_name,
+                    },
+                )
+
         elif action == "send_message":
             content = data.get("message", "")
             if content:

--- a/backend/apps/chat/tests/test_consumers.py
+++ b/backend/apps/chat/tests/test_consumers.py
@@ -137,3 +137,39 @@ class TestChatConsumer:
 
         await comm1.disconnect()
         await comm2.disconnect()
+
+    async def test_public_key_exchange(self, auth_user, token):
+        user2 = await create_user("testuser2")
+        token2 = str(AccessToken.for_user(user2))
+        headers = [(b"origin", b"http://localhost")]
+
+        # Connect User 1
+        comm1 = WebsocketCommunicator(
+            application, f"/ws/chat/room1/?token={token}", headers=headers
+        )
+        await comm1.connect()
+        await comm1.receive_json_from()
+
+        # Connect User 2
+        comm2 = WebsocketCommunicator(
+            application, f"/ws/chat/room1/?token={token2}", headers=headers
+        )
+        await comm2.connect()
+        await comm2.receive_json_from()
+
+        # User 1 sends their public key
+        mock_public_key = "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAv..."
+        await comm1.send_json_to(
+            {"action": "public_key", "public_key": mock_public_key}
+        )
+
+        # User 2 should receive the broadcasted public key
+        response = await comm2.receive_json_from()
+        assert response["type"] == "public_key"
+        assert response["username"] == auth_user.username
+        assert response["user_id"] == auth_user.id
+        assert response["public_key"] == mock_public_key
+
+        await comm1.disconnect()
+        await comm2.disconnect()
+


### PR DESCRIPTION
Fixes #1450

### Description
This PR resolves issue #1450 where end-to-end encrypted messaging is broken in the real-time community chat due to a missing WebSocket key exchange handler in the backend:
1. **Broadcast Key Action:** Implemented the `public_key` action handler inside the `ChatConsumer.receive()` method to catch the E2EE public keys broadcasted by connecting clients.
2. **Group Communication:** Forwards the public key event to the Channels room group via a `public_key_broadcast` type event, allowing other room participants to import the key and derive the required ECDH shared keys.
3. **Unit Testing:** Added a comprehensive async test `test_public_key_exchange` inside `apps/chat/tests/test_consumers.py` to verify key propagation and message routing among multiple connected WebSocket clients.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added public key exchange in chat rooms, allowing participants to share public keys with other connected members.

* **Bug Fixes**
  * Ensured public key messages are delivered to other participants without echoing back to the sender.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->