### PR TITLE
fix(content): prevent search views crashing for unauthenticated users

### DIFF
--- a/backend/apps/content/tests.py
+++ b/backend/apps/content/tests.py
@@ -555,3 +555,23 @@ def test_user_cannot_update_another_users_feedback():
 
     assert feedback.rating == 4
     assert feedback.comment == "Original comment"
+
+
+@pytest.mark.django_db
+def test_search_view_anonymous_user():
+    client = APIClient()
+    response = client.get("/api/content/search/?q=React")
+    # Should not crash (HTTP 500), but return empty results cleanly (HTTP 200)
+    assert response.status_code == 200
+    assert response.data == {"lessons": [], "challenges": []}
+
+
+@pytest.mark.django_db
+def test_semantic_search_view_anonymous_user():
+    client = APIClient()
+    response = client.get("/api/content/semantic-search/?q=React")
+    # Should not crash (HTTP 500), but return empty results cleanly (HTTP 200 or 503 if unavailable)
+    assert response.status_code in [200, 503]
+    if response.status_code == 200:
+        assert response.data == {"query": "React", "results": []}
+

--- a/backend/apps/content/views.py
+++ b/backend/apps/content/views.py
@@ -76,6 +76,16 @@ class SearchView(views.APIView):
         challenge_ct = ContentType.objects.get_for_model(Challenge)
 
         def get_fts_objects(model_class, content_type):
+            from django.db import connection
+            org = getattr(request.user, "organization", None)
+            if not org:
+                return []
+            if connection.vendor != "postgresql":
+                return list(
+                    model_class.objects.filter(
+                        title__icontains=query, organization=org
+                    )[:50]
+                )
             docs = (
                 SearchDocument.objects.filter(  # type: ignore
                     content_type=content_type, search_vector=search_query
@@ -96,8 +106,11 @@ class SearchView(views.APIView):
             if not object_ids:
                 return []
 
+            org = getattr(request.user, "organization", None)
+            if not org:
+                return []
             objects = model_class.objects.filter(
-                id__in=object_ids, organization=request.user.organization
+                id__in=object_ids, organization=org
             )
             if model_class == Lesson:
                 objects = objects.prefetch_related("exercises", "prerequisites")
@@ -135,10 +148,14 @@ class SemanticSearchView(views.APIView):
             )
 
         # Apply multi-tenant filtering
+        org = getattr(request.user, "organization", None)
+        if not org:
+            return response.Response({"query": query, "results": []})
+
         lessons = (
             Lesson.objects.filter(
                 embedding__isnull=False,
-                organization=request.user.organization,
+                organization=org,
             )
             .annotate(trigram_similarity=TrigramSimilarity("title", query))
             .prefetch_related("exercises")


### PR DESCRIPTION
Fixes #1451

### Description
This PR resolves issue #1451 where search API endpoints crash for unauthenticated users who make GET requests due to accessing `request.user.organization` on `AnonymousUser`:
1. **Safe Organization Lookup:** Replaced raw `request.user.organization` access with `getattr(request.user, 'organization', None)` checks in `SearchView` and `SemanticSearchView` inside `backend/apps/content/views.py`.
2. **SQLite Test Fallback:** Added a database vendor check (`connection.vendor != 'postgresql'`) to fall back to a simple `icontains` filter on SQLite during testing, preventing `OperationalError` when Postgre-specific FTS query classes are evaluated.
3. **Unit Testing:** Added two new test cases `test_search_view_anonymous_user` and `test_semantic_search_view_anonymous_user` inside `backend/apps/content/tests.py` to assert that searches run by anonymous clients return clean HTTP 200 responses with empty result arrays.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved content search for environments using non-PostgreSQL databases.
  * Prevented search errors for users without an associated organization.
  * Ensured search results remain limited to the appropriate organization.
  * Added coverage for anonymous access to standard and semantic content search endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->