### PR TITLE
fix(progress): calculate daily streak based on consecutive days rather than total days

### DIFF
--- a/backend/apps/progress/badge_evaluator.py
+++ b/backend/apps/progress/badge_evaluator.py
@@ -152,15 +152,30 @@ class BadgeEvaluator:
             user=user, status=PullRequest.Status.MERGED
         ).count()
 
-        # Calculate streak based on deterministic daily activity ledger
+        # Calculate longest consecutive daily streak based on deterministic activity ledger
         from apps.progress.models import DailyActivity
 
-        streak_days = (
-            DailyActivity.objects.filter(user=user)
-            .values_list("date", flat=True)
-            .distinct()
-            .count()
+        dates = sorted(
+            list(
+                DailyActivity.objects.filter(user=user)
+                .values_list("date", flat=True)
+                .distinct()
+            )
         )
+        longest_streak = 0
+        current_streak = 0
+        prev_date = None
+        for date in dates:
+            if prev_date is None:
+                current_streak = 1
+            elif (date - prev_date).days == 1:
+                current_streak += 1
+            elif (date - prev_date).days > 1:
+                longest_streak = max(longest_streak, current_streak)
+                current_streak = 1
+            prev_date = date
+        longest_streak = max(longest_streak, current_streak)
+        streak_days = longest_streak
 
         # Fetch user's already earned badge slugs
 

--- a/backend/apps/progress/tests.py
+++ b/backend/apps/progress/tests.py
@@ -624,3 +624,59 @@ class PeerReviewTests(APITestCase):
         response = self.client.post(url, data)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("Cannot review your own", response.data["error"])
+
+
+class BadgeEvaluatorTests(APITestCase):
+    """Tests for BadgeEvaluator daily streak badge logic."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="badgelearner", password="password123"
+        )
+
+    def test_streak_badge_not_awarded_for_non_consecutive_days(self):
+        from apps.progress.models import DailyActivity, UserBadge
+        from apps.progress.badge_evaluator import BadgeEvaluator
+        import datetime
+
+        # Create 7 non-consecutive login days (each 2 days apart)
+        base_date = datetime.date(2026, 7, 1)
+        for i in range(7):
+            DailyActivity.objects.create(
+                user=self.user,
+                date=base_date + datetime.timedelta(days=i * 2),
+                activity_type="login",
+            )
+
+        # Evaluate badges
+        BadgeEvaluator.evaluate(self.user)
+
+        # User should not have the 'streak-7' badge
+        has_streak_badge = UserBadge.objects.filter(
+            user=self.user, badge__slug="streak-7"
+        ).exists()
+        self.assertFalse(has_streak_badge)
+
+    def test_streak_badge_awarded_for_consecutive_days(self):
+        from apps.progress.models import DailyActivity, UserBadge
+        from apps.progress.badge_evaluator import BadgeEvaluator
+        import datetime
+
+        # Create 7 consecutive login days
+        base_date = datetime.date(2026, 7, 1)
+        for i in range(7):
+            DailyActivity.objects.create(
+                user=self.user,
+                date=base_date + datetime.timedelta(days=i),
+                activity_type="login",
+            )
+
+        # Evaluate badges
+        BadgeEvaluator.evaluate(self.user)
+
+        # User should have the 'streak-7' badge
+        has_streak_badge = UserBadge.objects.filter(
+            user=self.user, badge__slug="streak-7"
+        ).exists()
+        self.assertTrue(has_streak_badge)
+


### PR DESCRIPTION
Fixes #1452

### Description
This PR resolves issue #1452 where user badges are awarded using incorrect daily streak calculations:
1. **Consecutive Days Logic:** Modified the `BadgeEvaluator.evaluate()` method in `backend/apps/progress/badge_evaluator.py` to calculate the longest consecutive daily login/activity streak instead of counting total unique login days from the `DailyActivity` ledger. This prevents users from getting streak-based badges (such as 'streak-7') unless their active dates are truly consecutive (exactly 1 day apart).
2. **Added Unit Tests:** Added two new test cases `test_streak_badge_not_awarded_for_non_consecutive_days` and `test_streak_badge_awarded_for_consecutive_days` in `backend/apps/progress/tests.py` to cover this logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Streak-based badges now require consecutive active days, rather than simply counting total active days.
  * Prevents users from earning streak badges when activity days are spread out.

* **Tests**
  * Added coverage confirming seven consecutive days earn the seven-day streak badge.
  * Added coverage confirming non-consecutive activity does not qualify.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->