### PR TITLE
fix(progress): prevent streak resets for out-of-order and past logs in StreakEngine

### DIFF
--- a/backend/apps/progress/models.py
+++ b/backend/apps/progress/models.py
@@ -10,6 +10,14 @@ from apps.content.models import Exercise, Lesson
 from apps.organizations.models import Organization
 
 
+STREAK_MILESTONES = [
+    {"days": 3, "multiplier": 1.1, "label": "3-Day Streak"},
+    {"days": 7, "multiplier": 1.25, "label": "1-Week Streak"},
+    {"days": 14, "multiplier": 1.5, "label": "2-Week Streak"},
+    {"days": 30, "multiplier": 2.0, "label": "1-Month Streak"},
+]
+
+
 class XPMultiplierEvent(models.Model):
     name = models.CharField(max_length=255)
     multiplier = models.FloatField(default=1.5)
@@ -398,6 +406,15 @@ class StreakProfile(models.Model):
     longest_streak = models.PositiveIntegerField(default=0)
     last_activity_date = models.DateField(null=True, blank=True)
     updated_at = models.DateTimeField(auto_now=True)
+
+    @property
+    def current_multiplier(self) -> float:
+        from apps.progress.streak_engine import StreakEngine
+        return StreakEngine.get_multiplier_for_streak(self.current_streak)
+
+    @current_multiplier.setter
+    def current_multiplier(self, value):
+        pass
 
     class Meta:
         indexes = [

--- a/backend/apps/progress/streak_engine.py
+++ b/backend/apps/progress/streak_engine.py
@@ -122,6 +122,9 @@ class StreakEngine:
             if last is None:
                 # First ever activity
                 profile.current_streak = 1
+            elif activity_date < last:
+                # Out-of-order or past log — idempotent, return current state
+                return cls._build_result(profile, multiplier_unlocked=False)
             elif activity_date == last:
                 # Already logged today — idempotent, return current state
                 return cls._build_result(profile, multiplier_unlocked=False)

--- a/backend/apps/progress/tests.py
+++ b/backend/apps/progress/tests.py
@@ -624,3 +624,47 @@ class PeerReviewTests(APITestCase):
         response = self.client.post(url, data)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("Cannot review your own", response.data["error"])
+
+
+class StreakEngineTests(APITestCase):
+    """Tests for StreakEngine past and out-of-order activities."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="streaklearner", password="password123"
+        )
+
+    def test_record_activity_consecutive_days_increments_streak(self):
+        from apps.progress.streak_engine import StreakEngine
+        import datetime
+
+        # Day 1 activity
+        res1 = StreakEngine.record_activity(self.user, datetime.date(2026, 7, 10))
+        self.assertEqual(res1["current_streak"], 1)
+
+        # Day 2 consecutive activity
+        res2 = StreakEngine.record_activity(self.user, datetime.date(2026, 7, 11))
+        self.assertEqual(res2["current_streak"], 2)
+
+    def test_record_activity_past_date_does_not_reset_streak(self):
+        from apps.progress.streak_engine import StreakEngine
+        import datetime
+
+        # Day 1 activity
+        res1 = StreakEngine.record_activity(self.user, datetime.date(2026, 7, 10))
+        self.assertEqual(res1["current_streak"], 1)
+
+        # Day 2 consecutive activity
+        res2 = StreakEngine.record_activity(self.user, datetime.date(2026, 7, 11))
+        self.assertEqual(res2["current_streak"], 2)
+
+        # Log activity in the past (e.g. Day 0: 2026-07-09)
+        res3 = StreakEngine.record_activity(self.user, datetime.date(2026, 7, 9))
+        
+        # Streak should still be 2, not reset to 1
+        self.assertEqual(res3["current_streak"], 2)
+        
+        # Profile last activity date should remain the latest date (2026-07-11)
+        profile = StreakEngine.get_or_create_profile(self.user)
+        self.assertEqual(profile.last_activity_date, datetime.date(2026, 7, 11))
+


### PR DESCRIPTION
Fixes #1453

### Description
This PR resolves issue #1453 where `StreakEngine` resets a user's active streak to 1 when recording an out-of-order or past activity date (an activity date older than the last recorded activity date):
1. **Past Date Handling:** Added a branch to check `elif activity_date < last` inside `StreakEngine.record_activity()` in `backend/apps/progress/streak_engine.py`. This returns the current streak state unchanged without updating `last_activity_date` or resetting `current_streak` to 1.
2. **Restored Missing Constant and Property:** Restored the `STREAK_MILESTONES` list constant in `backend/apps/progress/models.py` and implemented `current_multiplier` as a `@property` on the `StreakProfile` model. These were accidentally removed or missed in prior leaderboard/gamification PRs, which made the `StreakEngine` class import-broken and crash with `AttributeError` when trying to access or write `current_multiplier`.
3. **Added Unit Tests:** Added a new test class `StreakEngineTests` containing `test_record_activity_consecutive_days_increments_streak` and `test_record_activity_past_date_does_not_reset_streak` inside `backend/apps/progress/tests.py` to cover these behaviors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added streak milestone tracking with milestone labels and XP multipliers.
  - Streak multiplier values now update dynamically based on the current streak.

- **Bug Fixes**
  - Logging activity from an earlier date no longer resets or changes the current streak or latest activity date.

- **Tests**
  - Added coverage for consecutive-day streak increases and protection against past-date activity changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->