### PR TITLE
feat(organizations): implement OrganizationViewSet and routing

### DIFF
--- a/backend/apps/organizations/serializers.py
+++ b/backend/apps/organizations/serializers.py
@@ -1,0 +1,7 @@
+from rest_framework import serializers
+from .models import Organization
+
+class OrganizationSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Organization
+        fields = ["id", "name", "description"]

--- a/backend/apps/organizations/tests.py
+++ b/backend/apps/organizations/tests.py
@@ -1,3 +1,32 @@
-from django.test import TestCase
+from rest_framework.test import APITestCase
+from rest_framework import status
+from django.contrib.auth.models import User
+from .models import Organization
 
-# Create your tests here.
+class OrganizationViewSetTests(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="testuser", password="password123")
+        self.org = Organization.objects.create(name="Test Org", description="Test Desc")
+        self.url = "/api/organizations/"
+
+    def test_list_organizations_unauthenticated(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_list_organizations_authenticated(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        # Using pagination might change the response shape, but ViewSet defaults to list if no pagination is configured for the view
+        # We can safely test for results array if pagination is on, otherwise it's just a list
+        if "results" in response.data:
+            self.assertEqual(len(response.data["results"]), 1)
+        else:
+            self.assertEqual(len(response.data), 1)
+
+    def test_create_organization(self):
+        self.client.force_authenticate(user=self.user)
+        data = {"name": "New Org", "description": "New Desc"}
+        response = self.client.post(self.url, data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(Organization.objects.count(), 2)

--- a/backend/apps/organizations/urls.py
+++ b/backend/apps/organizations/urls.py
@@ -1,3 +1,10 @@
-from django.urls import path
+from django.urls import path, include
+from rest_framework.routers import DefaultRouter
+from .views import OrganizationViewSet
 
-urlpatterns = []
+router = DefaultRouter()
+router.register(r"", OrganizationViewSet, basename="organization")
+
+urlpatterns = [
+    path("", include(router.urls)),
+]

--- a/backend/apps/organizations/views.py
+++ b/backend/apps/organizations/views.py
@@ -1,3 +1,9 @@
-from django.shortcuts import render
+from rest_framework import viewsets
+from rest_framework.permissions import IsAuthenticated
+from .models import Organization
+from .serializers import OrganizationSerializer
 
-# Create your views here.
+class OrganizationViewSet(viewsets.ModelViewSet):
+    queryset = Organization.objects.all()
+    serializer_class = OrganizationSerializer
+    permission_classes = [IsAuthenticated]

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -35,6 +35,7 @@ urlpatterns = [
     path("api/recommendations/", include("apps.recommendations.urls")),
     path("api/moderation/", include("apps.moderation.urls")),
     path("api/portfolio/", include("apps.portfolio.urls")),
+    path("api/organizations/", include("apps.organizations.urls")),
     # ============================================================
     # WEBHOOKS & UPLOADS
     # ============================================================
@@ -79,7 +80,6 @@ if settings.DEBUG:
     from apps.feature_flags.debug_view import feature_flags_debug_view
 
     urlpatterns += [
-        path("api/organizations/", include("apps.organizations.urls")),
         path("api/feature-flags/", feature_flags_debug_view, name="feature-flags-debug"),
         path("api/schema/", SpectacularAPIView.as_view(), name="schema"),
         path(


### PR DESCRIPTION
## Description
This PR implements the missing API views and routing for the newly scaffolded `organizations` app, making it fully functional.

### Changes Made:
- **`serializers.py`**: Added `OrganizationSerializer` for the `Organization` model.
- **`views.py`**: Replaced the empty template with an `OrganizationViewSet` using standard DRF `ModelViewSet` and secured it with `IsAuthenticated`.
- **`urls.py`**: Registered the `OrganizationViewSet` using a `DefaultRouter`.
- **`config/urls.py`**: Fixed a bug where `/api/organizations/` was trapped inside a `DEBUG` block. It is now properly routed in production and testing environments.
- **`tests.py`**: Added `APITestCase` unit tests to ensure that unauthenticated requests are rejected and authenticated requests can list/create organizations successfully.

### Testing Instructions
1. Run `pytest backend/apps/organizations/tests.py` and verify all tests pass.
2. Spin up the server and navigate to `/api/organizations/` to interact with the DRF browsable API.
Closes #1495

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an authenticated organizations API.
  * Organizations can now be listed and created through standard API endpoints.
  * Responses include each organization’s ID, name, and description.

* **Bug Fixes**
  * Made the organizations endpoint available in all environments, not only during development.

* **Tests**
  * Added coverage for authentication, listing organizations, and creating organizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->