### PR TITLE
fix(auth): remove dead login and profile view stubs, preserve swaggerschema

### DIFF
--- a/backend/apps/accounts/views.py
+++ b/backend/apps/accounts/views.py
@@ -108,37 +108,17 @@ class SignupView(generics.CreateAPIView):
     throttle_classes = [SignupThrottle]
 
 
-@extend_schema(
-    summary="Login user",
-    description="Authenticate user and return JWT token",
-    request=UserLoginSchema,
-    responses={
-        200: OpenApiResponse(
-            description="Login successful", response=UserResponseSchema
-        ),
-        401: OpenApiResponse(description="Invalid credentials"),
-    },
-)
-def login(request):
-    pass
-
-
-@extend_schema(
-    summary="Get user profile",
-    description="Returns current user profile information",
-    responses={
-        200: UserResponseSchema,
-        401: OpenApiResponse(description="Unauthorized"),
-    },
-)
-def get_profile(request):
-    pass
-
-
 class MeView(APIView):
     permission_classes = [IsAuthenticated]  # check jwt authentication
 
-    @extend_schema(responses=UserListSerializer)
+    @extend_schema(
+        summary="Get user profile",
+        description="Returns current user profile information",
+        responses={
+            200: UserResponseSchema,
+            401: OpenApiResponse(description="Unauthorized"),
+        },
+    )
     def get(self, request):
         serializer = UserListSerializer(request.user, context={"request": request})
         return Response(serializer.data)
@@ -217,6 +197,19 @@ class UserStatisticsView(APIView):
         )
 
 
+@extend_schema_view(
+    post=extend_schema(
+        summary="Login user",
+        description="Authenticate user and return JWT token",
+        request=UserLoginSchema,
+        responses={
+            200: OpenApiResponse(
+                description="Login successful", response=UserResponseSchema
+            ),
+            401: OpenApiResponse(description="Invalid credentials"),
+        },
+    )
+)
 class LoginView(TokenObtainPairView):
     permission_classes = [permissions.AllowAny]
     serializer_class = EmailOrUsernameTokenObtainPairSerializer

--- a/backend/apps/accounts/views.py
+++ b/backend/apps/accounts/views.py
@@ -30,6 +30,7 @@ from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
+from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
 from rest_framework_simplejwt.tokens import RefreshToken
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
@@ -204,7 +205,7 @@ class UserStatisticsView(APIView):
         request=UserLoginSchema,
         responses={
             200: OpenApiResponse(
-                description="Login successful", response=UserResponseSchema
+                description="Login successful", response=TokenObtainPairSerializer
             ),
             401: OpenApiResponse(description="Invalid credentials"),
         },


### PR DESCRIPTION
## Description
This PR cleans up the `accounts` app by removing dead authentication stubs that were causing confusion, while ensuring that our OpenAPI/Swagger documentation remains fully intact and accurate.
closes #1496 
### Changes Made:
- **Removed Dead Code**: Deleted the inert `login(request)` and `get_profile(request)` function stubs in `backend/apps/accounts/views.py`. These were dead code since auth is handled by the `LoginView` (SimpleJWT) and `MeView` class-based views.
- **Preserved Swagger Schemas**: 
  - Migrated the `@extend_schema` definitions from the dead functions to the actual active CBVs. 
  - Attached the `UserLoginSchema` and responses to `LoginView` using `@extend_schema_view`.
  - Upgraded the documentation on `MeView.get` to use the comprehensive `UserResponseSchema`.

### Testing Instructions
1. Run `pytest backend/apps/accounts/` and ensure no existing authentication tests are broken.
2. Spin up the server and navigate to `/api/docs/` (Swagger UI). Verify that the `POST /api/auth/login/` and `GET /api/auth/me/` endpoints still display their proper schemas and descriptions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved API documentation for the authenticated profile (“me/profile”) endpoint.
  * Updated OpenAPI schema placement so it’s documented directly alongside the profile handler.
  * Enhanced login endpoint API docs, including clearer operation descriptions and documented success (token) and unauthorized (401) responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->