### PR TITLE
feat: add --format json flag to seed_lessons command (#1329)

### DIFF
--- a/backend/apps/content/management/commands/seed_lessons.py
+++ b/backend/apps/content/management/commands/seed_lessons.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any, Dict, List
 
 from django.core.management.base import BaseCommand
@@ -292,50 +293,104 @@ LESSONS: List[Dict[str, Any]] = [
 class Command(BaseCommand):
     help = "Seed the database with example lessons and exercises. Safe to run multiple times."
 
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--format",
+            type=str,
+            default="json",
+            choices=["json", "text"],
+            help="Output format: 'json' for structured data, 'text' for human-readable",
+        )
+
     def handle(self, *args, **options):
+        output_format = options["format"]
+
+        seeded = []
+        skipped = []
+        errors = []
+
         previous_lesson = None
         for l in LESSONS:
-            lesson_obj, _ = Lesson.objects.update_or_create(
-                slug=l["slug"],
-                defaults={
-                    "difficulty": l.get("difficulty", "beginner"),
-                    "title": l["title"],
-                    "summary": l["summary"],
-                    "content": l["content"],
-                    "learning_objectives": l.get("learning_objectives", []),
-                    "tips": l.get("tips", []),
-                    "category": l.get("category", "general"),
-                    "order": l.get("order", 0),
-                    "estimated_minutes": l.get("estimated_minutes", 15),
-                },
-            )
+            try:
+                lesson_obj, created = Lesson.objects.update_or_create(
+                    slug=l["slug"],
+                    defaults={
+                        "difficulty": l.get("difficulty", "beginner"),
+                        "title": l["title"],
+                        "summary": l["summary"],
+                        "content": l["content"],
+                        "learning_objectives": l.get("learning_objectives", []),
+                        "tips": l.get("tips", []),
+                        "category": l.get("category", "general"),
+                        "order": l.get("order", 0),
+                        "estimated_minutes": l.get("estimated_minutes", 15),
+                    },
+                )
 
-            if previous_lesson:
-                lesson_obj.prerequisites.add(previous_lesson)
-            previous_lesson = lesson_obj
+                if previous_lesson:
+                    lesson_obj.prerequisites.add(previous_lesson)
+                previous_lesson = lesson_obj
 
-            self.stdout.write(
-                self.style.SUCCESS(f"Created/updated lesson: {lesson_obj.slug}")
-            )
-
-            exercises = l.get("exercises", [])
-            if isinstance(exercises, list):
-                for ex in exercises:
-                    ex_obj, _ = Exercise.objects.update_or_create(
-                        lesson=lesson_obj,
-                        title=ex["title"],
-                        defaults={
-                            "prompt": ex["prompt"],
-                            "expected_command": ex.get("expected_command", ""),
-                            "explanation": ex.get("explanation", ""),
-                            "points": ex.get("points", 10),
-                        },
-                    )
-
-                    self.stdout.write(
-                        self.style.SUCCESS(
-                            f"  Created/updated exercise: {ex_obj.title}"
+                if created:
+                    seeded.append(lesson_obj.slug)
+                    if output_format == "text":
+                        self.stdout.write(
+                            self.style.SUCCESS(f"✓ Created lesson: {lesson_obj.slug}")
                         )
-                    )
+                else:
+                    skipped.append(lesson_obj.slug)
+                    if output_format == "text":
+                        self.stdout.write(
+                            self.style.WARNING(f"~ Skipped lesson: {lesson_obj.slug}")
+                        )
 
-        self.stdout.write(self.style.SUCCESS("Seeding complete."))
+                exercises = l.get("exercises", [])
+                if isinstance(exercises, list):
+                    for ex in exercises:
+                        ex_obj, ex_created = Exercise.objects.update_or_create(
+                            lesson=lesson_obj,
+                            title=ex["title"],
+                            defaults={
+                                "prompt": ex["prompt"],
+                                "expected_command": ex.get("expected_command", ""),
+                                "explanation": ex.get("explanation", ""),
+                                "points": ex.get("points", 10),
+                            },
+                        )
+
+                        if output_format == "text":
+                            if ex_created:
+                                self.stdout.write(
+                                    self.style.SUCCESS(
+                                        f"  ✓ Created exercise: {ex_obj.title}"
+                                    )
+                                )
+                            else:
+                                self.stdout.write(
+                                    self.style.WARNING(
+                                        f"  ~ Skipped exercise: {ex_obj.title}"
+                                    )
+                                )
+            except Exception as e:
+                error_msg = f"Error seeding lesson {l.get('slug', 'unknown')}: {str(e)}"
+                errors.append(error_msg)
+                if output_format == "text":
+                    self.stdout.write(self.style.ERROR(error_msg))
+
+        result = {
+            "seeded": seeded,
+            "skipped": skipped,
+            "errors": errors,
+            "total": len(seeded) + len(skipped),
+        }
+
+        if output_format == "json":
+            self.stdout.write(json.dumps(result, indent=2))
+        else:
+            self.stdout.write(self.style.SUCCESS("\nSeeding complete."))
+            self.stdout.write(
+                self.style.WARNING(
+                    f"Summary: {len(seeded)} lessons seeded, {len(skipped)} skipped, "
+                    f"{len(errors)} errors. Total: {result['total']}"
+                )
+            )

--- a/backend/apps/content/management/commands/seed_lessons.py
+++ b/backend/apps/content/management/commands/seed_lessons.py
@@ -1,9 +1,13 @@
 import json
+import logging
 from typing import Any, Dict, List
 
 from django.core.management.base import BaseCommand
+from django.db import transaction
 
 from apps.content.models import Exercise, Lesson
+
+logger = logging.getLogger(__name__)
 
 LESSONS: List[Dict[str, Any]] = [
     {
@@ -297,7 +301,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "--format",
             type=str,
-            default="json",
+            default="text",
             choices=["json", "text"],
             help="Output format: 'json' for structured data, 'text' for human-readable",
         )
@@ -307,79 +311,101 @@ class Command(BaseCommand):
 
         seeded = []
         skipped = []
+        exercises_seeded = []
+        exercises_skipped = []
         errors = []
 
         previous_lesson = None
-        for l in LESSONS:
+        for lesson_data in LESSONS:
             try:
-                lesson_obj, created = Lesson.objects.update_or_create(
-                    slug=l["slug"],
-                    defaults={
-                        "difficulty": l.get("difficulty", "beginner"),
-                        "title": l["title"],
-                        "summary": l["summary"],
-                        "content": l["content"],
-                        "learning_objectives": l.get("learning_objectives", []),
-                        "tips": l.get("tips", []),
-                        "category": l.get("category", "general"),
-                        "order": l.get("order", 0),
-                        "estimated_minutes": l.get("estimated_minutes", 15),
-                    },
-                )
+                with transaction.atomic():
+                    lesson_obj, created = Lesson.objects.update_or_create(
+                        slug=lesson_data["slug"],
+                        defaults={
+                            "difficulty": lesson_data.get("difficulty", "beginner"),
+                            "title": lesson_data["title"],
+                            "summary": lesson_data["summary"],
+                            "content": lesson_data["content"],
+                            "learning_objectives": lesson_data.get(
+                                "learning_objectives", []
+                            ),
+                            "tips": lesson_data.get("tips", []),
+                            "category": lesson_data.get("category", "general"),
+                            "order": lesson_data.get("order", 0),
+                            "estimated_minutes": lesson_data.get(
+                                "estimated_minutes", 15
+                            ),
+                        },
+                    )
 
-                if previous_lesson:
-                    lesson_obj.prerequisites.add(previous_lesson)
-                previous_lesson = lesson_obj
+                    if previous_lesson:
+                        lesson_obj.prerequisites.add(previous_lesson)
+                    previous_lesson = lesson_obj
 
-                if created:
-                    seeded.append(lesson_obj.slug)
-                    if output_format == "text":
-                        self.stdout.write(
-                            self.style.SUCCESS(f"✓ Created lesson: {lesson_obj.slug}")
-                        )
-                else:
-                    skipped.append(lesson_obj.slug)
-                    if output_format == "text":
-                        self.stdout.write(
-                            self.style.WARNING(f"~ Skipped lesson: {lesson_obj.slug}")
-                        )
+                    exercises = lesson_data.get("exercises", [])
+                    if isinstance(exercises, list):
+                        for ex in exercises:
+                            ex_obj, ex_created = Exercise.objects.update_or_create(
+                                lesson=lesson_obj,
+                                title=ex["title"],
+                                defaults={
+                                    "prompt": ex["prompt"],
+                                    "expected_command": ex.get("expected_command", ""),
+                                    "explanation": ex.get("explanation", ""),
+                                    "points": ex.get("points", 10),
+                                },
+                            )
 
-                exercises = l.get("exercises", [])
-                if isinstance(exercises, list):
-                    for ex in exercises:
-                        ex_obj, ex_created = Exercise.objects.update_or_create(
-                            lesson=lesson_obj,
-                            title=ex["title"],
-                            defaults={
-                                "prompt": ex["prompt"],
-                                "expected_command": ex.get("expected_command", ""),
-                                "explanation": ex.get("explanation", ""),
-                                "points": ex.get("points", 10),
-                            },
-                        )
-
-                        if output_format == "text":
                             if ex_created:
-                                self.stdout.write(
-                                    self.style.SUCCESS(
-                                        f"  ✓ Created exercise: {ex_obj.title}"
-                                    )
-                                )
+                                exercises_seeded.append(ex_obj.title)
                             else:
-                                self.stdout.write(
-                                    self.style.WARNING(
-                                        f"  ~ Skipped exercise: {ex_obj.title}"
+                                exercises_skipped.append(ex_obj.title)
+
+                            if output_format == "text":
+                                if ex_created:
+                                    self.stdout.write(
+                                        self.style.SUCCESS(
+                                            f"  ✓ Created exercise: {ex_obj.title}"
+                                        )
                                     )
+                                else:
+                                    self.stdout.write(
+                                        self.style.WARNING(
+                                            f"  ~ Skipped exercise: {ex_obj.title}"
+                                        )
+                                    )
+
+                    # Only mark as seeded/skipped after all exercises succeed
+                    if created:
+                        seeded.append(lesson_obj.slug)
+                        if output_format == "text":
+                            self.stdout.write(
+                                self.style.SUCCESS(
+                                    f"✓ Created lesson: {lesson_obj.slug}"
                                 )
-            except Exception as e:
-                error_msg = f"Error seeding lesson {l.get('slug', 'unknown')}: {str(e)}"
+                            )
+                    else:
+                        skipped.append(lesson_obj.slug)
+                        if output_format == "text":
+                            self.stdout.write(
+                                self.style.WARNING(
+                                    f"~ Skipped lesson: {lesson_obj.slug}"
+                                )
+                            )
+            except (KeyError, ValueError) as e:
+                error_msg = (
+                    f"Error seeding lesson {lesson_data.get('slug', 'unknown')}: {e}"
+                )
                 errors.append(error_msg)
+                logger.exception("Failed to seed lesson", exc_info=True)
                 if output_format == "text":
                     self.stdout.write(self.style.ERROR(error_msg))
 
         result = {
             "seeded": seeded,
             "skipped": skipped,
+            "exercises_seeded": len(exercises_seeded),
+            "exercises_skipped": len(exercises_skipped),
             "errors": errors,
             "total": len(seeded) + len(skipped),
         }

--- a/backend/apps/content/tests.py
+++ b/backend/apps/content/tests.py
@@ -575,3 +575,62 @@ def test_semantic_search_view_anonymous_user():
     if response.status_code == 200:
         assert response.data == {"query": "React", "results": []}
 
+
+@pytest.mark.django_db
+def test_seed_lessons_json_output_format():
+    """Test that seed_lessons command outputs valid JSON with required fields."""
+    import json
+    from io import StringIO
+    from django.core.management import call_command
+
+    out = StringIO()
+    call_command("seed_lessons", "--format", "json", stdout=out)
+    output = out.getvalue()
+
+    # Parse JSON output
+    result = json.loads(output)
+
+    # Validate structure
+    assert "seeded" in result
+    assert "skipped" in result
+    assert "errors" in result
+    assert "total" in result
+
+    # Validate types
+    assert isinstance(result["seeded"], list)
+    assert isinstance(result["skipped"], list)
+    assert isinstance(result["errors"], list)
+    assert isinstance(result["total"], int)
+
+    # Validate totals
+    assert result["total"] == len(result["seeded"]) + len(result["skipped"])
+
+    # On first run, should seed all lessons
+    assert len(result["seeded"]) > 0
+    assert len(result["skipped"]) == 0
+    assert len(result["errors"]) == 0
+
+
+@pytest.mark.django_db
+def test_seed_lessons_idempotent_with_skip_detection():
+    """Test that running seed_lessons twice produces skipped on second run."""
+    import json
+    from io import StringIO
+    from django.core.management import call_command
+
+    # First run
+    out1 = StringIO()
+    call_command("seed_lessons", "--format", "json", stdout=out1)
+    result1 = json.loads(out1.getvalue())
+
+    first_seeded = set(result1["seeded"])
+    assert len(first_seeded) > 0
+
+    # Second run should skip all
+    out2 = StringIO()
+    call_command("seed_lessons", "--format", "json", stdout=out2)
+    result2 = json.loads(out2.getvalue())
+
+    second_skipped = set(result2["skipped"])
+    assert first_seeded == second_skipped
+    assert len(result2["seeded"]) == 0

--- a/backend/apps/content/tests.py
+++ b/backend/apps/content/tests.py
@@ -652,13 +652,10 @@ def test_seed_lessons_default_format_is_text():
     call_command("seed_lessons", stdout=out)
     output = out.getvalue()
 
-    # Should not be JSON (would fail to parse or raise)
-    try:
-        import json
+    import json
 
+    # Should not be JSON (would fail to parse)
+    with pytest.raises(json.JSONDecodeError):
         json.loads(output)
-        # If it parses as JSON, it should at least have text markers
-        assert "✓" in output or "~" in output
-    except json.JSONDecodeError:
-        # Expected: output is human-readable text, not JSON
-        assert "✓" in output or "Seeding complete" in output
+    # Should contain text markers
+    assert "✓" in output or "~" in output or "Seeding complete" in output

--- a/backend/apps/content/tests.py
+++ b/backend/apps/content/tests.py
@@ -593,21 +593,27 @@ def test_seed_lessons_json_output_format():
     # Validate structure
     assert "seeded" in result
     assert "skipped" in result
+    assert "exercises_seeded" in result
+    assert "exercises_skipped" in result
     assert "errors" in result
     assert "total" in result
 
     # Validate types
     assert isinstance(result["seeded"], list)
     assert isinstance(result["skipped"], list)
+    assert isinstance(result["exercises_seeded"], int)
+    assert isinstance(result["exercises_skipped"], int)
     assert isinstance(result["errors"], list)
     assert isinstance(result["total"], int)
 
     # Validate totals
     assert result["total"] == len(result["seeded"]) + len(result["skipped"])
 
-    # On first run, should seed all lessons
+    # On first run, should seed all lessons and exercises
     assert len(result["seeded"]) > 0
     assert len(result["skipped"]) == 0
+    assert result["exercises_seeded"] > 0
+    assert result["exercises_skipped"] == 0
     assert len(result["errors"]) == 0
 
 
@@ -634,3 +640,25 @@ def test_seed_lessons_idempotent_with_skip_detection():
     second_skipped = set(result2["skipped"])
     assert first_seeded == second_skipped
     assert len(result2["seeded"]) == 0
+
+
+@pytest.mark.django_db
+def test_seed_lessons_default_format_is_text():
+    """Test that default format is human-readable text (backward compatibility)."""
+    from io import StringIO
+    from django.core.management import call_command
+
+    out = StringIO()
+    call_command("seed_lessons", stdout=out)
+    output = out.getvalue()
+
+    # Should not be JSON (would fail to parse or raise)
+    try:
+        import json
+
+        json.loads(output)
+        # If it parses as JSON, it should at least have text markers
+        assert "✓" in output or "~" in output
+    except json.JSONDecodeError:
+        # Expected: output is human-readable text, not JSON
+        assert "✓" in output or "Seeding complete" in output


### PR DESCRIPTION
Closes: #1329

## Description

<!-- Provide a clear and concise summary of your changes -->

Fixes #1329 

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update (no code changes)
- [ ] ⚙️ CI/CD or build pipeline change
- [ ] ⚡ Performance optimization
- [ ] 🛠️ Refactoring (no functional changes)

## How Has This Been Tested?

<!-- Describe the tests that you ran to verify your changes -->

### Automated Tests
- [ ] Backend tests pass: `cd backend && pytest`
- [ ] Frontend tests pass: `cd frontend && npm run test`
- [ ] Frontend builds successfully: `cd frontend && npm run build`

### Manual Verification
<!-- Describe any manual testing performed (e.g. user flow verification, edge case testing) -->

## Pre-Push Checklist

> [!IMPORTANT]
> **All items below must be checked before requesting a review.** Our CI bot will automatically run the frontend build and backend tests on your PR. If CI fails, you will receive a comment explaining what went wrong.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or console errors
- [ ] I have run `npm run build` in `frontend/` and it completes with **0 errors**
- [ ] I have run `pytest` in `backend/` and all tests pass
- [ ] I have run `git diff` locally and verified my changes

## Deployment Notes

> [!NOTE]
> This project is deployed on **Vercel** (Frontend) and **Hugging Face** (Backend). The CI workflow simulates both deployment environments. If your PR passes CI, it is safe to merge.

<!-- Add any notes about deployment considerations, environment variables, or migration steps needed -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--format` option to the lesson seeding command to support `json` output (default remains human-readable text).
  * Produces detailed per-run reporting, including seeded vs skipped lessons/exercises and overall totals.

* **Bug Fixes**
  * Improved resilience by recording per-lesson errors and continuing the run rather than stopping at the first failure.
  * More accurate “created vs skipped” console messaging for both lessons and exercises.

* **Tests**
  * Added/extended coverage for JSON output structure, counters, totals, and zero-error behavior on first run.
  * Added idempotency tests to verify repeat runs skip previously seeded items.
  * Confirmed default output remains non-JSON text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->