### PR TITLE
feat: a 'Streak Flame Animation' to the Profile Stats Card

### DIFF
--- a/frontend/src/components/dashboard/StatsCards.tsx
+++ b/frontend/src/components/dashboard/StatsCards.tsx
@@ -1,5 +1,8 @@
-import { CheckCircle2, Code, Flame, Trophy } from "lucide-react";
+import { CheckCircle2, Code, Trophy } from "lucide-react";
 import type { PersonalStats } from "./types";
+import { StreakFlame } from "./StreakFlame";
+import "./streakFlame.css";
+
 
 interface StatsCardsProps {
   personalStats: PersonalStats;
@@ -13,10 +16,17 @@ export function StatsCards({
   return (
     <div id="tour-stats" className="grid grid-cols-2 gap-4">
       <div className="relative rounded-[2rem] border-4 border-black bg-white p-6 shadow-card flex flex-col justify-center items-center text-center dark:bg-[#1f1c18] dark:border-[#2e2924] dark:shadow-none hover:-translate-y-0.5 transition-transform">
-        <Flame className="w-12 h-12 text-primary animate-pulse mb-2" />
+        <div className="relative w-12 h-12 mb-2" style={{ color: "#ff7a18" }}>
+          <StreakFlame
+            animate={personalStats.streak_days >= 3}
+            className="absolute inset-0 m-auto"
+          />
+        </div>
+
         <span className="text-4xl font-black text-primary drop-shadow-[2px_2px_0_#000] dark:drop-shadow-none">
           {personalStats.streak_days}
         </span>
+
         <span className="font-black text-black uppercase tracking-widest text-[9px] mt-1 dark:text-[#c4bbae]">
           Streak Days
         </span>

--- a/frontend/src/components/dashboard/StreakFlame.tsx
+++ b/frontend/src/components/dashboard/StreakFlame.tsx
@@ -1,0 +1,74 @@
+import React from "react";
+
+interface StreakFlameProps {
+  animate?: boolean;
+  className?: string;
+}
+
+export function StreakFlame({ animate = false, className = "" }: StreakFlameProps) {
+  return (
+    <div
+      className={[
+        "relative inline-flex items-center justify-center",
+        className,
+      ].join(" ")}
+      aria-hidden="true"
+    >
+      {/* Glow layer (kept small + uses opacity/transform only) */}
+      <div
+        className={
+          animate
+            ? "streak-flame-glow"
+            : "streak-flame-glow streak-flame-glow--static"
+        }
+      />
+
+      {/* SVG flame */}
+      <svg
+        width="54"
+        height="54"
+        viewBox="0 0 64 64"
+        className={animate ? "streak-flame streak-flame--anim" : "streak-flame"}
+        role="img"
+        focusable="false"
+        style={{ color: "var(--flame-fg, #ff7a18)" }}
+      >
+        <defs>
+          <linearGradient id="streakFlameGrad" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor="currentColor" stopOpacity="1" />
+            <stop offset="45%" stopColor="#ffcc33" stopOpacity="1" />
+            <stop offset="100%" stopColor="#ff3b30" stopOpacity="1" />
+          </linearGradient>
+
+          {/* Subtle inner highlight gradient */}
+          <linearGradient id="streakFlameHi" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0%" stopColor="#fff2c2" stopOpacity="0.9" />
+            <stop offset="100%" stopColor="#ffffff" stopOpacity="0" />
+          </linearGradient>
+        </defs>
+
+        {/* Flame shape */}
+        <path
+          d="M32 6c1.6 10.3-4.2 14.8-8.2 19.6C19.7 31.4 19 37.2 21.2 42.4c2.2 5.2 7.2 10.6 10.8 15.6 0.7 1 1.4 1 2.1 0 3.6-5 8.6-10.4 10.8-15.6 2.2-5.2 1.5-11-2.6-16.8C36.2 20.8 30.4 16.3 32 6z"
+          fill="url(#streakFlameGrad)"
+          stroke="rgba(0,0,0,0.35)"
+          strokeWidth="1"
+          strokeLinejoin="round"
+        />
+
+        {/* Inner highlight */}
+        <path
+          d="M32.2 12.5c1.1 7.4-3.3 10.8-6.3 14.5-3.1 3.8-3.6 8.2-1.9 12.1 1.7 3.9 5.4 7.8 8.2 11.9 0.4 0.6 0.9 0.6 1.3 0 2.8-4.1 6.5-8 8.2-11.9 1.7-3.9 1.2-8.3-1.9-12.1-3-3.7-7.4-7.1-6.6-14.5z"
+          fill="url(#streakFlameHi)"
+          opacity="0.75"
+        />
+
+        {/* Outer ember specks (tiny, low cost) */}
+        <circle cx="22" cy="39" r="1.3" fill="#ffd45a" opacity="0.9" />
+        <circle cx="42" cy="34" r="1.1" fill="#ffd45a" opacity="0.8" />
+        <circle cx="31" cy="46" r="1.0" fill="#ffd45a" opacity="0.7" />
+      </svg>
+    </div>
+  );
+}
+

--- a/frontend/src/components/dashboard/streakFlame.css
+++ b/frontend/src/components/dashboard/streakFlame.css
@@ -1,0 +1,46 @@
+.streak-flame-glow{
+  position:absolute;
+  inset:0;
+  width:54px;
+  height:54px;
+  border-radius:9999px;
+  transform:translateZ(0);
+  background:
+    radial-gradient(circle at 50% 50%, rgba(255, 204, 51, 0.65) 0%, rgba(255, 122, 24, 0.35) 35%, rgba(255, 59, 48, 0) 70%);
+  opacity:0.25;
+  pointer-events:none;
+}
+
+.streak-flame-glow--static{
+  opacity:0.18;
+}
+
+.streak-flame-glow.streak-flame-glow--anim{
+  opacity:0.35;
+  animation:streakFlameGlow 1.25s ease-in-out infinite;
+}
+
+.streak-flame{width:54px;height:54px;display:block;transform-origin:50% 70%;}
+
+.streak-flame--anim{
+  animation:streakFlameScale 1.25s ease-in-out infinite;
+}
+
+@keyframes streakFlameScale{
+  0%{transform:scale(0.98) rotate(-1deg);filter:brightness(1);opacity:0.95;}
+  35%{transform:scale(1.06) rotate(1deg);filter:brightness(1.08);opacity:1;}
+  70%{transform:scale(1.02) rotate(-0.5deg);filter:brightness(1.02);opacity:0.98;}
+  100%{transform:scale(0.98) rotate(-1deg);filter:brightness(1);opacity:0.95;}
+}
+
+@keyframes streakFlameGlow{
+  0%{transform:scale(0.95);opacity:0.28;}
+  35%{transform:scale(1.08);opacity:0.42;}
+  70%{transform:scale(1.02);opacity:0.32;}
+  100%{transform:scale(0.95);opacity:0.28;}
+}
+
+@media (prefers-reduced-motion: reduce){
+  .streak-flame--anim,.streak-flame-glow--anim{animation:none !important;}
+}
+


### PR DESCRIPTION
Added a premium, SVG-based “Streak Flame Animation” to the dashboard Profile Stats card.

What changed:

frontend/src/components/dashboard/StatsCards.tsx
Replaced the lucide icon with the new component.
Animation is triggered when personalStats.streak_days >= 3.
frontend/src/components/dashboard/StreakFlame.tsx (new)
Lightweight SVG flame with gradient fills and ember specks.
frontend/src/components/dashboard/streakFlame.css (new)
CSS keyframe animations (transform/opacity + small glow) for continuous, alive feel.
Includes prefers-reduced-motion support.


closes #1400

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the dashboard’s streak display with a custom flame visual and glow effect.
  * The flame animates when a streak reaches three or more days.
  * Respects reduced-motion preferences by disabling animations when requested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->