### PR TITLE
fix(uploads): prevent path traversal and arbitrary file write in chunked uploads

### DIFF
--- a/backend/apps/uploads/tests.py
+++ b/backend/apps/uploads/tests.py
@@ -1,0 +1,69 @@
+import tempfile
+import pytest
+from django.contrib.auth.models import User
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from rest_framework import status
+from apps.uploads.models import UploadSession
+
+class ChunkedUploadTests(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="testuploader", password="password123")
+        self.client.force_authenticate(user=self.user)
+
+    def test_start_upload_sanitizes_path_traversal_filename(self):
+        url = reverse("uploads:start_upload")
+        data = {
+            "filename": "../../../../etc/cron.d/malicious_cron",
+            "total_size": 1000,
+            "total_chunks": 2
+        }
+        response = self.client.post(url, data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        session_id = response.data["session_id"]
+        
+        session = UploadSession.objects.get(session_id=session_id)
+        # Should sanitize to basename
+        self.assertEqual(session.filename, "malicious_cron")
+
+    def test_upload_flow_success(self):
+        # 1. Start Upload
+        start_url = reverse("uploads:start_upload")
+        start_data = {
+            "filename": "testfile.txt",
+            "total_size": 20,
+            "total_chunks": 2
+        }
+        response = self.client.post(start_url, start_data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        session_id = response.data["session_id"]
+
+        # 2. Upload Chunks
+        import os
+        chunk_url = reverse("uploads:upload_chunk", kwargs={"session_id": session_id})
+        
+        with tempfile.NamedTemporaryFile(delete=False) as f1:
+            f1.write(b"part1")
+            f1.seek(0)
+            f1.close()
+            with open(f1.name, "rb") as upload_f1:
+                res_c1 = self.client.post(chunk_url, {"chunk_index": 0, "chunk": upload_f1}, format="multipart")
+                self.assertEqual(res_c1.status_code, status.HTTP_200_OK)
+            os.unlink(f1.name)
+
+        with tempfile.NamedTemporaryFile(delete=False) as f2:
+            f2.write(b"part2")
+            f2.seek(0)
+            f2.close()
+            with open(f2.name, "rb") as upload_f2:
+                res_c2 = self.client.post(chunk_url, {"chunk_index": 1, "chunk": upload_f2}, format="multipart")
+                self.assertEqual(res_c2.status_code, status.HTTP_200_OK)
+            os.unlink(f2.name)
+
+        # 3. Complete Upload
+        complete_url = reverse("uploads:complete_upload", kwargs={"session_id": session_id})
+        res_complete = self.client.post(complete_url, format="json")
+        self.assertEqual(res_complete.status_code, status.HTTP_200_OK)
+        
+        session = UploadSession.objects.get(session_id=session_id)
+        self.assertEqual(session.status, UploadSession.Status.COMPLETED)

--- a/backend/apps/uploads/views.py
+++ b/backend/apps/uploads/views.py
@@ -23,9 +23,16 @@ class StartUploadView(views.APIView):
                 {"error": "Missing required fields"}, status=status.HTTP_400_BAD_REQUEST
             )
 
+        # Sanitize filename to prevent path traversal
+        sanitized_filename = os.path.basename(filename)
+        if not sanitized_filename:
+            return Response(
+                {"error": "Invalid filename"}, status=status.HTTP_400_BAD_REQUEST
+            )
+
         session = UploadSession.objects.create(
             user=request.user,
-            filename=filename,
+            filename=sanitized_filename,
             total_size=int(total_size),
             total_chunks=int(total_chunks),
             status=UploadSession.Status.PENDING,
@@ -102,7 +109,16 @@ class CompleteUploadView(views.APIView):
 
         temp_dir = session.get_temp_dir()
         final_filename = f"{session.session_id}_{session.filename}"
-        final_path = os.path.join(settings.MEDIA_ROOT, "uploads", final_filename)
+        
+        # Verify absolute path resides strictly within MEDIA_ROOT/uploads
+        allowed_prefix = os.path.abspath(os.path.join(settings.MEDIA_ROOT, "uploads"))
+        final_path = os.path.abspath(os.path.join(allowed_prefix, final_filename))
+        
+        if not final_path.startswith(allowed_prefix + os.sep) and final_path != allowed_prefix:
+            return Response(
+                {"error": "Invalid file path"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
         os.makedirs(os.path.dirname(final_path), exist_ok=True)
 


### PR DESCRIPTION
Fixes #1514

### Description
This PR resolves the Path Traversal and Arbitrary File Write vulnerability in the chunked uploads service (Issue #1514):
1. **Filename Sanitization:** In `StartUploadView` (in `backend/apps/uploads/views.py`), the user-supplied filename is now sanitized using `os.path.basename` to strip any parent/relative path characters before creating the `UploadSession` in the database.
2. **Path Scope Integrity Verification:** In `CompleteUploadView`, the target file's absolute path is resolved using `os.path.abspath` and validated to ensure it starts with the absolute directory prefix of the media uploads folder (`settings.MEDIA_ROOT/uploads`). Any validation failures are rejected with a `400 Bad Request` error.
3. **Added Upload Flow Tests:** Added `ChunkedUploadTests` inside `backend/apps/uploads/tests.py` to cover successful chunked uploads and path traversal sanitization checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved upload security by sanitizing filenames and preventing path traversal.
  * Added validation to reject invalid or unsafe upload file paths.
  * Preserved successful multi-part upload and completion workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->