### PR TITLE
feat: session-based 'Recently Viewed Lessons' sidebar widget

### DIFF
--- a/frontend/src/components/ui/RecentlyViewedLessonsWidget.tsx
+++ b/frontend/src/components/ui/RecentlyViewedLessonsWidget.tsx
@@ -1,0 +1,82 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+
+type RecentlyViewedLesson = {
+  slug: string;
+  title: string;
+};
+
+const SESSION_KEY = "recentlyViewedLessonsV1";
+const MAX_ITEMS = 3;
+
+function safeParseSessionValue(raw: string | null): RecentlyViewedLesson[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .filter(
+        (x): x is RecentlyViewedLesson =>
+          !!x &&
+          typeof x === "object" &&
+          typeof (x as { slug?: unknown }).slug === "string" &&
+          typeof (x as { title?: unknown }).title === "string",
+      )
+      .map((x) => ({ slug: x.slug, title: x.title }))
+      .slice(0, MAX_ITEMS);
+
+  } catch {
+    return [];
+  }
+}
+
+export function RecentlyViewedLessonsWidget() {
+  const [items, setItems] = useState<RecentlyViewedLesson[]>([]);
+
+  useEffect(() => {
+    setItems(
+      safeParseSessionValue(
+        window.sessionStorage?.getItem(SESSION_KEY) ?? null,
+      ).slice(0, MAX_ITEMS),
+    );
+  }, []);
+
+  const hasItems = items.length > 0;
+
+  const content = useMemo(() => {
+    if (!hasItems) {
+      return (
+        <div className="text-xs text-muted dark:text-[#c4bbae]">
+          No recent lessons
+        </div>
+      );
+    }
+
+    return (
+      <div className="space-y-1">
+        {items.map((l) => (
+          <Link
+            key={l.slug}
+            to={`/lessons/${l.slug}`}
+            className="w-full block p-2 rounded-lg border-2 border-transparent hover:border-black/20 hover:bg-surface-lowest dark:hover:bg-[#151411] text-xs font-bold truncate"
+            title={l.title}
+          >
+            {l.title}
+          </Link>
+        ))}
+      </div>
+    );
+  }, [hasItems, items]);
+
+  return (
+    <section aria-label="Recently viewed lessons" className="space-y-2">
+      <h3 className="font-mono text-[10px] uppercase tracking-wider font-bold px-2 py-1.5 rounded-lg border-2 border-black bg-accent text-black">
+        Recently Viewed
+      </h3>
+      {content}
+    </section>
+  );
+}
+
+export default RecentlyViewedLessonsWidget;
+

--- a/frontend/src/pages/LessonPage.tsx
+++ b/frontend/src/pages/LessonPage.tsx
@@ -18,7 +18,33 @@ import { useUserProgress } from "../hooks/useUserProgress";
 import { useBookmarks } from "../hooks/useBookmarks";
 import { fetchApi } from "../lib/api";
 import { Lesson, fetchLessonsApi, fetchLessonContent } from "../lib/lessons";
+import { RecentlyViewedLessonsWidget } from "../components/ui/RecentlyViewedLessonsWidget";
+
+const SESSION_KEY_RECENT = "recentlyViewedLessonsV1";
+const MAX_RECENT_ITEMS = 3;
+
+function safeParseRecentlyViewedLessons(raw: string | null): { slug: string; title: string }[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .filter(
+        (x) =>
+          x &&
+          typeof x === "object" &&
+          typeof (x as any).slug === "string" &&
+          typeof (x as any).title === "string",
+      )
+      .map((x) => ({ slug: (x as any).slug, title: (x as any).title }))
+      .slice(0, MAX_RECENT_ITEMS);
+  } catch {
+    return [];
+  }
+}
+
 const RichTextEditor = React.lazy(() =>
+
   import("../components/ui/RichTextEditor").then((mod) => ({
     default: mod.RichTextEditor,
   })),
@@ -252,11 +278,29 @@ export function LessonPage() {
   useEffect(() => {
     if (!lesson) return;
 
+    // Update session-based "Recently Viewed Lessons".
+    try {
+      const nextItem = { slug: lesson.slug, title: lesson.title };
+      const raw = window.sessionStorage.getItem(SESSION_KEY_RECENT);
+      const current = safeParseRecentlyViewedLessons(raw);
+
+      const deduped = current.filter((x) => x.slug !== nextItem.slug);
+      const updated = [nextItem, ...deduped].slice(0, MAX_RECENT_ITEMS);
+
+      window.sessionStorage.setItem(
+        SESSION_KEY_RECENT,
+        JSON.stringify(updated),
+      );
+    } catch {
+      // Ignore storage errors (private mode / quota / unsupported browsers)
+    }
+
     setFeedback("");
     setInput("");
     setShowHint(false);
     setTerminalOutput("");
     setRepoState(createInitialRepo());
+
 
     setCurrentQuizIndex(0);
     setSelectedOption(null);
@@ -495,8 +539,13 @@ export function LessonPage() {
         </div>
 
         <div className="space-y-6">
+          <div className="pt-2">
+            <RecentlyViewedLessonsWidget />
+          </div>
+
           {modules.map((mod, modIdx) => (
             <div key={mod.id} className="space-y-2">
+
               <h3
                 className={`font-mono text-[10px] uppercase tracking-wider font-bold px-2 py-1.5 rounded-lg border-2 transition-all
                          ${


### PR DESCRIPTION
Implemented session-based “Recently Viewed Lessons” sidebar widget.

Changes:

Added frontend/src/components/ui/RecentlyViewedLessonsWidget.tsx which reads sessionStorage key recentlyViewedLessonsV1 and renders up to the last 3 lesson links.
Updated frontend/src/pages/LessonPage.tsx to write the current lesson (deduped by slug) into sessionStorage on lesson load and to render the widget at the top of the existing left sidebar.
Behavior:

Navigating between /lessons/:slug pages in the same browser session updates the widget.
Refreshing keeps the same session history; opening a new session/tab resets when the browser session ends.


closes #1481

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Recently Viewed Lessons” widget to the lesson sidebar.
  * Displays up to three recently viewed lessons with links to revisit them.
  * Prevents duplicate entries and safely handles unavailable or invalid saved data.
  * Shows a “No recent lessons” message when no viewing history is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->