### PR TITLE
feat: personalized “Next Lesson” Recommendations

### DIFF
--- a/backend/apps/recommendations/next_lesson_service.py
+++ b/backend/apps/recommendations/next_lesson_service.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+
+from django.utils import timezone
+
+from apps.content.models import Lesson
+from apps.progress.models import LessonProgress
+
+
+@dataclass(frozen=True)
+class NextLessonCandidateScore:
+    lesson: Lesson
+    score: float
+    why: Dict[str, Any]
+
+
+class NextLessonRecommendationService:
+    """Scores lessons for a personalized "next lesson" pick.
+
+    Scoring is intentionally simple + explainable:
+    - prerequisite gap (mandatory): fewer missing prerequisites => higher score
+    - streak fit: keep streak alive + avoid overwhelming difficulty when streak is low
+    - XP/multiplier fit (best-effort): uses completed lesson scores as an XP proxy
+    - recency: prefer lessons never seen before / least recently updated
+
+    The response includes the breakdown so frontend can show a "why recommended" tooltip.
+    """
+
+    def __init__(self, user):
+        self.user = user
+
+    def get_next_lesson(self) -> Optional[Tuple[Lesson, Dict[str, Any]]]:
+        lessons = self._get_candidate_lessons()
+        if not lessons:
+            return None
+
+        # Include organization scoping via _get_candidate_lessons()
+        user_progress = LessonProgress.objects.filter(user=self.user).select_related(
+            "lesson"
+        )
+        progress_by_lesson_id: Dict[int, LessonProgress] = {p.lesson_id: p for p in user_progress}
+
+        candidates: List[NextLessonCandidateScore] = [
+            self._score_lesson(lesson, progress_by_lesson_id) for lesson in lessons
+        ]
+
+        best = sorted(candidates, key=lambda c: c.score, reverse=True)[0]
+        return best.lesson, best.why
+
+    def _get_candidate_lessons(self) -> List[Lesson]:
+        org = getattr(self.user, "organization", None)
+        qs = Lesson.objects.all().prefetch_related("prerequisites")
+        if org is not None:
+            qs = qs.filter(organization=org)
+
+        completed_lesson_ids = LessonProgress.objects.filter(
+            user=self.user, completed=True
+        ).values_list("lesson_id", flat=True)
+
+        qs = qs.exclude(id__in=list(completed_lesson_ids))
+        return list(qs.order_by("order"))
+
+    def _score_lesson(
+        self, lesson: Lesson, progress_by_lesson_id: Dict[int, LessonProgress]
+    ) -> NextLessonCandidateScore:
+        prereq_ids = list(lesson.prerequisites.values_list("id", flat=True))
+        completed_prereq_ids = [
+            pid
+            for pid in prereq_ids
+            if pid in progress_by_lesson_id
+            and progress_by_lesson_id[pid].completed
+        ]
+
+        total_prereqs = len(prereq_ids)
+        completed_prereqs = len(completed_prereq_ids)
+        prerequisite_gap = max(0, total_prereqs - completed_prereqs)
+
+        # 1) prerequisite score (primary)
+        if total_prereqs == 0:
+            prereq_score = 40.0
+            prereq_detail = "No prerequisites"
+        else:
+            prereq_score = 40.0 * (1.0 - (prerequisite_gap / total_prereqs))
+            prereq_detail = f"Missing {prerequisite_gap} of {total_prereqs} prerequisite(s)"
+
+        # 2) streak fit
+        streak_profile = getattr(self.user, "streak_profile", None)
+        current_streak = streak_profile.current_streak if streak_profile else 0
+        today = timezone.localdate()
+        did_activity_today = LessonProgress.objects.filter(
+            user=self.user,
+            completed=True,
+            updated_at__date=today,
+        ).exists()
+
+        if not did_activity_today:
+            streak_score = 25.0
+            streak_detail = "Keep your streak alive today"
+        else:
+            streak_score = 15.0 + min(20.0, current_streak * 1.2)
+            streak_detail = "Streak-based continuation"
+
+        # 3) XP/multiplier/difficulty fit (best-effort)
+        difficulty_map = {"beginner": 0, "intermediate": 1, "advanced": 2}
+        lesson_diff = difficulty_map.get((lesson.difficulty or "beginner").lower(), 0)
+
+        completed_scores = list(
+            LessonProgress.objects.filter(user=self.user, completed=True).values_list("score", flat=True)
+        )
+        avg_score = (sum(completed_scores) / len(completed_scores)) if completed_scores else 0
+
+        user_level_band = 0
+        if avg_score >= 60:
+            user_level_band = 1
+        if avg_score >= 85:
+            user_level_band = 2
+
+        if lesson_diff <= user_level_band:
+            xp_score = 20.0
+            xp_detail = "Difficulty matches your current XP/level"
+        else:
+            diff_gap = lesson_diff - user_level_band
+            xp_score = max(0.0, 20.0 - diff_gap * 8.0)
+            xp_detail = "Lesson is slightly above your current comfort level"
+
+        # 4) recency
+        progress = progress_by_lesson_id.get(lesson.id)
+        if progress is None:
+            recency_score = 10.0
+            recency_detail = "New to you"
+        else:
+            days_since_update = (
+                (timezone.now().date() - progress.updated_at.date()).days
+                if progress.updated_at
+                else 999
+            )
+            recency_score = max(0.0, 10.0 - min(10, days_since_update))
+            recency_detail = f"Last activity {days_since_update} day(s) ago"
+
+        total_score = prereq_score + streak_score + xp_score + recency_score
+
+        # missing prereq titles for explanation
+        missing_prereq_titles: List[str] = []
+        if prerequisite_gap > 0 and prereq_ids:
+            missing_ids = [pid for pid in prereq_ids if pid not in completed_prereq_ids]
+            missing_prereq_titles = list(
+                Lesson.objects.filter(id__in=missing_ids).values_list("title", flat=True)
+            )
+
+        why: Dict[str, Any] = {
+            "score": round(total_score, 2),
+            "score_breakdown": {
+                "prerequisites": round(prereq_score, 2),
+                "streak": round(streak_score, 2),
+                "xp_difficulty_fit": round(xp_score, 2),
+                "recency": round(recency_score, 2),
+            },
+            "prerequisites": {
+                "detail": prereq_detail,
+                "missing_titles": missing_prereq_titles[:3],
+                "missing_count": prerequisite_gap,
+                "total_prerequisites": total_prereqs,
+            },
+            "streak": {
+                "detail": streak_detail,
+                "current_streak_days": current_streak,
+                "activity_today": did_activity_today,
+            },
+            "xp_level": {
+                "detail": xp_detail,
+                "avg_completed_score": round(avg_score, 1) if completed_scores else 0,
+                "user_level_band": user_level_band,
+                "lesson_difficulty": lesson.difficulty,
+            },
+            "recency": {"detail": recency_detail},
+        }
+
+        return NextLessonCandidateScore(lesson=lesson, score=total_score, why=why)
+

--- a/backend/apps/recommendations/urls.py
+++ b/backend/apps/recommendations/urls.py
@@ -10,4 +10,10 @@ urlpatterns = [
     path(
         "<int:pk>/dismiss/", views.DismissRecommendationView.as_view(), name="dismiss"
     ),
+    path(
+        "next-lesson/",
+        views.NextLessonRecommendationView.as_view(),
+        name="next-lesson",
+    ),
 ]
+

--- a/backend/apps/recommendations/views.py
+++ b/backend/apps/recommendations/views.py
@@ -37,3 +37,30 @@ class DismissRecommendationView(APIView):
             return Response({"status": "dismissed"}, status=status.HTTP_200_OK)
         except Recommendation.DoesNotExist:
             return Response(status=status.HTTP_404_NOT_FOUND)
+
+
+class NextLessonRecommendationView(APIView):
+    """Return a single personalized "next lesson" recommendation plus explanation."""
+
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get(self, request):
+        from apps.recommendations.next_lesson_service import (
+            NextLessonRecommendationService,
+        )
+        from apps.content.serializers import LessonSerializer
+
+        service = NextLessonRecommendationService(request.user)
+        result = service.get_next_lesson()
+        if result is None:
+            return Response({"recommended": None, "why": {}}, status=200)
+
+        lesson, why = result
+        return Response(
+            {
+                "recommended": LessonSerializer(lesson).data,
+                "why": why,
+            },
+            status=status.HTTP_200_OK,
+        )
+

--- a/frontend/src/components/ui/NextLessonWidget.tsx
+++ b/frontend/src/components/ui/NextLessonWidget.tsx
@@ -1,0 +1,125 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { Sparkles, Info } from "lucide-react";
+
+import Tooltip from "./Tooltip";
+
+
+type WhyPayload = {
+  score_breakdown?: {
+    prerequisites?: number;
+    streak?: number;
+    xp_difficulty_fit?: number;
+    recency?: number;
+  };
+  prerequisites?: {
+    detail?: string;
+    missing_titles?: string[];
+    missing_count?: number;
+    total_prerequisites?: number;
+  };
+  streak?: {
+    detail?: string;
+    current_streak_days?: number;
+    activity_today?: boolean;
+  };
+  xp_level?: {
+    detail?: string;
+    avg_completed_score?: number;
+    user_level_band?: number;
+    lesson_difficulty?: string;
+  };
+  recency?: { detail?: string };
+};
+
+type LessonPayload = {
+  id?: number;
+  slug: string;
+  title: string;
+  difficulty?: string;
+  estimated_minutes?: number;
+  points?: number;
+};
+
+export function NextLessonWidget({
+  recommended,
+  why,
+  disabled,
+}: {
+  recommended: LessonPayload | null;
+  why: WhyPayload | null;
+  disabled?: boolean;
+}) {
+  if (!recommended) return null;
+
+  const difficulty = recommended.difficulty || "beginner";
+  const minutes = recommended.estimated_minutes ?? 10;
+  const points = recommended.points ?? undefined;
+
+  const missingTitles = why?.prerequisites?.missing_titles || [];
+  const prereqDetail = why?.prerequisites?.detail;
+  const streakDetail = why?.streak?.detail;
+  const xpDetail = why?.xp_level?.detail;
+  const recencyDetail = why?.recency?.detail;
+
+  const tooltipText = [
+    prereqDetail ? `Prerequisites: ${prereqDetail}` : null,
+    missingTitles.length
+      ? `Missing: ${missingTitles.join(", ")}`
+      : null,
+    streakDetail ? `Streak: ${streakDetail}` : null,
+    xpDetail ? `XP fit: ${xpDetail}` : null,
+    recencyDetail ? `Recency: ${recencyDetail}` : null,
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  return (
+    <section className="rounded-[2rem] border-4 border-black bg-white p-6 shadow-card dark:bg-[#1f1c18] dark:border-[#2e2924] space-y-4">
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex items-start gap-4">
+          <div className="bg-[#ffcc00] p-3 rounded-2xl border-2 border-black flex-shrink-0 text-2xl dark:bg-[#ffcc00]/20 dark:text-[#ffcc00]">
+            🎯
+          </div>
+          <div>
+            <h3 className="font-black text-2xl dark:text-[#f0ebe2] flex items-center gap-2">
+              Your Next Recommended Lesson
+              <span className="font-mono text-xs bg-black text-white px-2 py-0.5 rounded-full uppercase dark:bg-[#2e2924]">
+                {difficulty}
+              </span>
+            </h3>
+            <p className="font-bold text-sm text-muted dark:text-[#c4bbae] mt-1">
+              {recommended.title}
+            </p>
+          </div>
+        </div>
+
+        <Tooltip content={tooltipText}>
+          <div className="flex items-center gap-1 text-xs font-black bg-amber-50 border-2 border-amber-200 px-2 py-1 rounded-lg dark:bg-[#1c1915]">
+            <Info size={14} /> Why this?
+          </div>
+        </Tooltip>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-[1fr_auto] items-center">
+        <div className="text-xs font-bold text-black/70 dark:text-[#f0ebe2]">
+          <span className="inline-flex items-center gap-2">
+            <Sparkles size={14} /> {minutes} min • {points ? `${points} XP` : "XP ready"}
+          </span>
+        </div>
+
+        <Link
+          to={`/lessons/${recommended.slug}`}
+          className={
+            disabled
+              ? "pointer-events-none opacity-50 w-full sm:w-auto rounded-lg bg-[#e2e8f0] text-black border-2 border-black px-4 py-2 text-xs font-black uppercase tracking-wider text-center"
+              : "w-full sm:w-auto rounded-lg bg-accent text-black border-2 border-black px-4 py-2 text-xs font-black uppercase tracking-wider shadow-card-sm hover:-translate-y-0.5 transition-all text-center"
+          }
+        >
+          Start Lesson 🚀
+        </Link>
+      </div>
+    </section>
+  );
+}
+


### PR DESCRIPTION
Implemented backend “Next Lesson” recommendation endpoint + explainability payload, and added a reusable frontend widget that renders the recommendation with a “Why this?” tooltip.

Backend:

backend/apps/recommendations/next_lesson_service.py: scoring service (prerequisite gaps, streak fit, XP/difficulty fit proxy, recency) with a structured why payload.
backend/apps/recommendations/views.py: NextLessonRecommendationView returns { recommended, why }.
backend/apps/recommendations/urls.py: added route next-lesson/.
Frontend:

frontend/src/components/ui/NextLessonWidget.tsx: NextLessonWidget that consumes {recommended, why} and shows a tooltip using existing Tooltip component.
Note: wiring the widget into DashboardPage/LessonPage and calling the endpoint still remains.


closes #1554

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added personalized “Next Lesson” recommendations based on progress, prerequisites, streaks, difficulty, and recency.
  * Added an authenticated API endpoint for retrieving the recommended lesson and explanation details.
  * Added a dashboard widget displaying the recommended lesson, difficulty, estimated duration, XP, and “Why this?” insights.
  * Added a direct link to start the recommended lesson, with support for disabled states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->