### PR TITLE
feat: add A11y sandbox link to navigation

### DIFF
--- a/frontend/src/components/layout/Navigation.tsx
+++ b/frontend/src/components/layout/Navigation.tsx
@@ -37,6 +37,7 @@ const navItems = [
   { to: "/community", label: "Community", icon: BriefcaseBusiness },
   { to: "/chat", label: "Chat", icon: MessageSquare },
   { to: "/peer-review", label: "Peer Review", icon: Shield },
+  { to: "/a11y-sandbox", label: "A11y Sandbox", icon: Eye },
   { to: "/profile", label: "Profile Settings", icon: Settings },
 ];
 


### PR DESCRIPTION
## Description
This PR exposes the Accessibility (A11y) Editor Sandbox by linking it in the main application sidebar navigation. This allows contributors to easily access the a11y linter playground.
Closes #1553 
## Changes
- Added a new navigation item for `/a11y-sandbox` in `Navigation.tsx` utilizing the `Eye` icon.

## Testing
- Verified that the "A11y Sandbox" tab appears in the sidebar.
- Verified that clicking the tab successfully routes to the `<A11yLinterSandbox />` page.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “A11y Sandbox” option to the navigation menu for quick access to accessibility testing tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->