### PR TITLE
fix: integrate streak freezes into progress models and XP ledge

### DIFF
--- a/backend/apps/accounts/export.py
+++ b/backend/apps/accounts/export.py
@@ -9,7 +9,7 @@ from django.db.models import QuerySet
 from apps.accounts.models import MentorProfile
 from apps.chat.models import Message
 from apps.content.models import Comment
-from apps.dashboard.models import Issue, PullRequest, StreakFreeze
+from apps.dashboard.models import Issue, PullRequest
 from apps.notifications.models import Notification
 from apps.progress.models import (
     Certificate,
@@ -62,9 +62,6 @@ class DataExportService:
             ),
             "assigned_issues": self._queryset_to_list(
                 Issue.objects.filter(assigned_to=self.user)
-            ),
-            "streak_freezes": self._queryset_to_list(
-                StreakFreeze.objects.filter(user=self.user)
             ),
             "webhooks": self._queryset_to_list(
                 WebhookEndpoint.objects.filter(user=self.user)

--- a/backend/apps/accounts/tests/test_export.py
+++ b/backend/apps/accounts/tests/test_export.py
@@ -10,7 +10,7 @@ from rest_framework.test import APIClient
 
 from apps.chat.models import Message
 from apps.content.models import Comment, Exercise, Lesson
-from apps.dashboard.models import Issue, StreakFreeze
+from apps.dashboard.models import Issue
 from apps.progress.models import (
     CodeSubmission,
     ExerciseAttempt,
@@ -60,7 +60,7 @@ def setup_user_data(user, other_user):
         user=user, title="My PR", code_snippet="print(1)"
     )
     PeerReview.objects.create(submission=submission, reviewer=user, feedback="Good job")
-    StreakFreeze.objects.create(user=user)
+
     Issue.objects.create(title="My Issue", assigned_to=user)
     Comment.objects.create(user=user, lesson=lesson, content="Great lesson")
     Message.objects.create(user=user, room_id="room1", content="Hello world")
@@ -88,8 +88,8 @@ class TestDataExport:
         assert "exercise_attempts" in data
         assert "code_submissions" in data
         assert "peer_reviews" in data
-        assert "streak_freezes" in data
         assert "assigned_issues" in data
+        assert "webhooks" in data
         assert "comments" in data
         assert "messages" in data
 

--- a/backend/apps/accounts/urls.py
+++ b/backend/apps/accounts/urls.py
@@ -27,6 +27,7 @@ from .views import (
     UserStatisticsView,
     UserSuggestionsView,
     PublicProfileView,
+    ShopStreakFreezeView,
 )
 
 urlpatterns = [
@@ -82,4 +83,5 @@ urlpatterns = [
     ),
     path("magic-link/verify/", MagicLinkVerifyView.as_view(), name="magic-link-verify"),
     path("profile/<str:username>/", PublicProfileView.as_view(), name="public-profile"),
+    path("shop/streak-freeze/", ShopStreakFreezeView.as_view(), name="shop-streak-freeze"),
 ]

--- a/backend/apps/accounts/views.py
+++ b/backend/apps/accounts/views.py
@@ -1107,4 +1107,63 @@ class PublicProfileView(APIView):
                 "completed_lessons": completed_lessons,
             }
         )
->>>>>>> main
+
+class ShopStreakFreezeView(APIView):
+    permission_classes = [permissions.IsAuthenticated]
+
+    def post(self, request):
+        from apps.progress.models import XPEvent, StreakProfile
+        from django.db.models import Sum
+        user = request.user
+
+        with transaction.atomic():
+            total_xp = (
+                XPEvent.objects.filter(user=user).aggregate(total=Sum("xp_delta"))["total"] or 0
+            )
+
+            FREEZE_COST = 100
+
+            if total_xp < FREEZE_COST:
+                return Response(
+                    {
+                        "success": False,
+                        "message": "Not enough XP to buy a streak freeze.",
+                    },
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+            profile, _ = StreakProfile.objects.get_or_create(user=user)
+            if profile.streak_freezes >= 3:
+                return Response(
+                    {
+                        "success": False,
+                        "message": "You can only have up to 3 streak freezes at a time.",
+                    },
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+            # Deduct XP
+            XPEvent.objects.create(
+                user=user,
+                source_type="shop",
+                base_points=FREEZE_COST,
+                multiplier=1.0,
+                xp_delta=-FREEZE_COST
+            )
+            
+            # Add freeze
+            profile.streak_freezes += 1
+            profile.save(update_fields=["streak_freezes", "updated_at"])
+
+            # Invalidate cache for dashboard
+            from apps.dashboard.signals import clear_dashboard_caches
+            clear_dashboard_caches(user_id=user.id)
+
+            return Response(
+                {
+                    "success": True,
+                    "message": "Streak freeze purchased successfully.",
+                    "available_xp": total_xp - FREEZE_COST,
+                },
+                status=status.HTTP_201_CREATED,
+            )

--- a/backend/apps/dashboard/models.py
+++ b/backend/apps/dashboard/models.py
@@ -82,21 +82,4 @@ class PullRequest(models.Model):
         ]
 
 
-class StreakFreeze(models.Model):
-    objects = models.Manager()
-    user = models.ForeignKey(
-        User, on_delete=models.CASCADE, related_name="streak_freezes"
-    )
-    purchased_at = models.DateTimeField(auto_now_add=True)
-    used_on_date = models.DateField(null=True, blank=True)
-    cost = models.PositiveIntegerField(default=100)
 
-    class Meta:
-        indexes = [
-            models.Index(
-                fields=["user", "used_on_date"], name="idx_streak_freeze_user_date"
-            ),
-        ]
-
-    def __str__(self):
-        return f"StreakFreeze({self.user.username}, used={self.used_on_date})"

--- a/backend/apps/dashboard/tests.py
+++ b/backend/apps/dashboard/tests.py
@@ -6,115 +6,6 @@ from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from apps.content.models import Lesson
-from apps.dashboard.models import Issue, StreakFreeze
-from apps.progress.models import LessonProgress
-
-
-class StreakFreezeTests(APITestCase):
-    def setUp(self):
-        self.user = User.objects.create_user(username="testuser", password="password")
-        self.user.date_joined = timezone.now() - timedelta(days=10)
-        self.user.save()
-        self.client.force_authenticate(user=self.user)
-        self.lesson = Lesson.objects.create(slug="test-lesson", title="Test")
-
-    def test_buy_streak_freeze_insufficient_points(self):
-        url = reverse("dashboard:buy_streak_freeze")
-        response = self.client.post(url)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertFalse(response.data["success"])
-
-    def test_buy_streak_freeze_success(self):
-        LessonProgress.objects.create(
-            user=self.user, lesson=self.lesson, completed=True, score=100
-        )
-
-        url = reverse("dashboard:buy_streak_freeze")
-        response = self.client.post(url)
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertTrue(response.data["success"])
-        self.assertEqual(StreakFreeze.objects.count(), 1)
-
-    def test_buy_streak_freeze_max_limit(self):
-        LessonProgress.objects.create(
-            user=self.user, lesson=self.lesson, completed=True, score=500
-        )
-        url = reverse("dashboard:buy_streak_freeze")
-
-        for _ in range(3):
-            self.client.post(url)
-
-        response = self.client.post(url)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn("3 unused", response.data["message"])
-
-    def test_streak_calculation_with_freeze(self):
-        lp = LessonProgress.objects.create(
-            user=self.user, lesson=self.lesson, completed=True, score=200
-        )
-        LessonProgress.objects.filter(id=lp.id).update(
-            updated_at=timezone.now() - timedelta(days=2)
-        )
-
-        StreakFreeze.objects.create(user=self.user, cost=100)
-
-        url = reverse("dashboard:contributor_stats")
-        response = self.client.get(url)
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        # Check streak days
-        self.assertEqual(response.data["personal_stats"]["streak_days"], 2)
-
-        # Freeze should be consumed for yesterday
-        self.assertEqual(
-            StreakFreeze.objects.filter(used_on_date__isnull=False).count(), 1
-        )
-
-    def test_missing_two_days_with_one_freeze(self):
-        # Activity 3 days ago
-        lp = LessonProgress.objects.create(
-            user=self.user, lesson=self.lesson, completed=True, score=200
-        )
-        LessonProgress.objects.filter(id=lp.id).update(
-            updated_at=timezone.now() - timedelta(days=3)
-        )
-
-        # Has only 1 freeze
-        StreakFreeze.objects.create(user=self.user, cost=100)
-
-        url = reverse("dashboard:contributor_stats")
-        response = self.client.get(url)
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        # Missed yesterday and day before yesterday.
-        # It consumes the 1 freeze for yesterday, but can't cover the day before yesterday.
-        # So streak should just be 1 (for yesterday).
-        self.assertEqual(response.data["personal_stats"]["streak_days"], 1)
-        self.assertEqual(
-            StreakFreeze.objects.filter(used_on_date__isnull=False).count(), 1
-        )
-
-    def test_available_points_calculation(self):
-        # Prevent retroactive freeze consumption by setting join date to today
-        self.user.date_joined = timezone.now()
-        self.user.save()
-
-        # Gain 150 points
-        LessonProgress.objects.create(
-            user=self.user, lesson=self.lesson, completed=True, score=150
-        )
-
-        # Buy freeze (-100 points)
-        self.client.post(reverse("dashboard:buy_streak_freeze"))
-
-        url = reverse("dashboard:contributor_stats")
-        response = self.client.get(url)
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data["personal_stats"]["available_points"], 50)
-        self.assertEqual(response.data["personal_stats"]["unused_freezes"], 1)
-
 
 class LeaderboardTests(APITestCase):
     def setUp(self):
@@ -164,3 +55,17 @@ class LeaderboardTests(APITestCase):
         # However, user0, user1, user10, user11... will be the alphabetical order
         sorted_usernames = sorted(usernames)
         self.assertEqual(usernames, sorted_usernames)
+
+class IssueModelTests(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="testuser", password="password")
+
+    def test_issue_total_points(self):
+        from apps.dashboard.models import Issue
+        issue = Issue.objects.create(title="Test", assigned_to=self.user, points=50, bonus_points=15)
+        self.assertEqual(issue.total_points, 65)
+
+    def test_issue_no_bonus_points(self):
+        from apps.dashboard.models import Issue
+        issue = Issue.objects.create(title="Test", assigned_to=self.user, points=50)
+        self.assertEqual(issue.total_points, 50)

--- a/backend/apps/dashboard/urls.py
+++ b/backend/apps/dashboard/urls.py
@@ -5,7 +5,6 @@ from apps.dashboard.views import (
     ContributorDashboardView,
     ModeratorAnalyticsView,
     PublicLandingStatsView,
-    BuyStreakFreezeView,
 )
 
 app_name = "dashboard"
@@ -15,5 +14,4 @@ urlpatterns = [
     path("contributor/", ContributorDashboardView.as_view(), name="contributor_stats"),
     path("stats-public/", PublicLandingStatsView.as_view(), name="public_stats"),
     path("analytics/", ModeratorAnalyticsView.as_view(), name="moderator_analytics"),
-    path("buy-streak-freeze/", BuyStreakFreezeView.as_view(), name="buy_streak_freeze"),
 ]

--- a/backend/apps/dashboard/views.py
+++ b/backend/apps/dashboard/views.py
@@ -14,7 +14,7 @@ from rest_framework.views import APIView
 
 from apps.challenges.models import ChallengeCompletion
 from apps.content.models import Lesson
-from apps.dashboard.models import Issue, PullRequest, StreakFreeze
+from apps.dashboard.models import Issue, PullRequest
 from apps.progress.models import (
     CodeSubmission,
     ExerciseAttempt,
@@ -320,46 +320,18 @@ class ContributorDashboardView(APIView):
                 activity_days.add(timezone.localdate(dt))
 
             # Apply streak freezes to calculate streak days
-            today = timezone.localdate(timezone.now())
-            join_date = timezone.localdate(user.date_joined)
             streak_days = 0
             current_day = today
-
-            all_freezes = list(
-                StreakFreeze.objects.filter(user=user).order_by("purchased_at")
-            )
-            consumed_freezes_by_date = {
-                f.used_on_date: f for f in all_freezes if f.used_on_date is not None
-            }
-            unused_freezes = [f for f in all_freezes if f.used_on_date is None]
-            modified_freezes = []
-
             while True:
                 if current_day < join_date:
                     break
-
                 if current_day in activity_days:
                     streak_days += 1
                 elif current_day == today:
-                    # If today has no activity, we just skip it (does not break the streak and does not count towards it)
                     pass
                 else:
-                    # Check if there is already a consumed freeze for this date
-                    if current_day in consumed_freezes_by_date:
-                        streak_days += 1
-                    elif unused_freezes:
-                        unused_freeze = unused_freezes.pop(0)
-                        unused_freeze.used_on_date = current_day
-                        modified_freezes.append(unused_freeze)
-                        consumed_freezes_by_date[current_day] = unused_freeze
-                        streak_days += 1
-                    else:
-                        break
+                    break
                 current_day -= timedelta(days=1)
-
-            if modified_freezes:
-                with transaction.atomic():
-                    StreakFreeze.objects.bulk_update(modified_freezes, ["used_on_date"])
 
             # Determine Rank based on user XP vs others
             lesson_xp_sub = (
@@ -416,14 +388,10 @@ class ContributorDashboardView(APIView):
                     "badge__slug", flat=True
                 )
             )
-            spent_points = (
-                StreakFreeze.objects.filter(user=user).aggregate(total=Sum("cost"))[
-                    "total"
-                ]
-                or 0
-            )
+            # StreakFreeze has been migrated to StreakProfile.streak_freezes
+            spent_points = 0
             available_points = total_xp - spent_points
-            unused_freezes_count = len(unused_freezes)
+            unused_freezes_count = getattr(user, "streak_profile", None).streak_freezes if hasattr(user, "streak_profile") else 0
 
             return {
                 "issues_solved": issues_solved,
@@ -539,85 +507,7 @@ from drf_spectacular.utils import extend_schema
 from rest_framework import status
 
 
-class BuyStreakFreezeView(APIView):
-    permission_classes = [permissions.IsAuthenticated]
 
-    @extend_schema(
-        responses={
-            201: {
-                "type": "object",
-                "properties": {
-                    "success": {"type": "boolean"},
-                    "message": {"type": "string"},
-                    "available_points": {"type": "integer"},
-                },
-            }
-        }
-    )
-    def post(self, request):
-        user = request.user
-
-        with transaction.atomic():
-            lesson_xp = (
-                LessonProgress.objects.filter(user=user, completed=True).aggregate(
-                    total=Sum("score")
-                )["total"]
-                or 0
-            )
-            issues_agg = Issue.objects.filter(
-                assigned_to=user, status=Issue.Status.SOLVED
-            ).aggregate(p_sum=Sum("points"), b_sum=Sum("bonus_points"))
-            issues_xp = (issues_agg["p_sum"] or 0) + (issues_agg["b_sum"] or 0)
-            total_xp = lesson_xp + issues_xp
-
-            spent_points = (
-                StreakFreeze.objects.filter(user=user).aggregate(total=Sum("cost"))[
-                    "total"
-                ]
-                or 0
-            )
-            available_points = total_xp - spent_points
-
-            FREEZE_COST = 100
-
-            if available_points < FREEZE_COST:
-                return Response(
-                    {
-                        "success": False,
-                        "message": "Not enough points to buy a streak freeze.",
-                    },
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
-
-            unused_freezes = (
-                StreakFreeze.objects.select_related("user")
-                .filter(user=user, used_on_date__isnull=True)
-                .count()
-            )
-            if unused_freezes >= 3:
-                return Response(
-                    {
-                        "success": False,
-                        "message": "You can only have up to 3 unused streak freezes at a time.",
-                    },
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
-
-            StreakFreeze.objects.create(user=user, cost=FREEZE_COST)
-
-            # Invalidate cache for dashboard
-            from apps.dashboard.signals import clear_dashboard_caches
-
-            clear_dashboard_caches(user_id=user.id)
-
-            return Response(
-                {
-                    "success": True,
-                    "message": "Streak freeze purchased successfully.",
-                    "available_points": available_points - FREEZE_COST,
-                },
-                status=status.HTTP_201_CREATED,
-            )
 
 
 from django.db import models

--- a/backend/apps/progress/models.py
+++ b/backend/apps/progress/models.py
@@ -83,6 +83,7 @@ class XPEvent(models.Model):
         ("issue", "Issue"),
         ("review", "Review"),
         ("badge", "Badge"),
+        ("shop", "Shop Purchase"),
     ]
 
     user = models.ForeignKey(User, on_delete=models.CASCADE, related_name="xp_events")
@@ -410,6 +411,7 @@ class StreakProfile(models.Model):
     current_streak = models.PositiveIntegerField(default=0)
     longest_streak = models.PositiveIntegerField(default=0)
     last_activity_date = models.DateField(null=True, blank=True)
+    streak_freezes = models.PositiveIntegerField(default=0)
     updated_at = models.DateTimeField(auto_now=True)
 
     @property
@@ -486,9 +488,20 @@ class DailyActivity(models.Model):
                 ).exists()
 
                 if yesterday_exists:
-                    streak_profile.current_streak = streak_profile.current_streak + 1
+                    streak_profile.current_streak += 1
                 else:
-                    streak_profile.current_streak = 1
+                    last = streak_profile.last_activity_date
+                    if last and date > last:
+                        missed_days = (date - last).days - 1
+                        if missed_days == 0:
+                            streak_profile.current_streak += 1
+                        elif missed_days > 0 and streak_profile.streak_freezes >= missed_days:
+                            streak_profile.streak_freezes -= missed_days
+                            streak_profile.current_streak += 1
+                        else:
+                            streak_profile.current_streak = 1
+                    else:
+                        streak_profile.current_streak = 1
 
                 streak_profile.last_activity_date = date
                 streak_profile.longest_streak = max(
@@ -499,6 +512,7 @@ class DailyActivity(models.Model):
                         "current_streak",
                         "longest_streak",
                         "last_activity_date",
+                        "streak_freezes",
                         "updated_at",
                     ]
                 )

--- a/backend/apps/progress/streak_engine.py
+++ b/backend/apps/progress/streak_engine.py
@@ -132,14 +132,24 @@ class StreakEngine:
                 # Consecutive day — extend streak
                 profile.current_streak += 1
             else:
-                # Gap detected — reset streak
-                logger.info(
-                    "Streak reset for user %s (gap from %s to %s)",
-                    user.username,
-                    last,
-                    activity_date,
-                )
-                profile.current_streak = 1
+                # Gap detected
+                missed_days = (activity_date - last).days - 1
+                if profile.streak_freezes >= missed_days:
+                    profile.streak_freezes -= missed_days
+                    profile.current_streak += 1
+                    logger.info(
+                        "Streak preserved for user %s using %d streak freeze(s)",
+                        user.username,
+                        missed_days,
+                    )
+                else:
+                    logger.info(
+                        "Streak reset for user %s (gap from %s to %s)",
+                        user.username,
+                        last,
+                        activity_date,
+                    )
+                    profile.current_streak = 1
 
             profile.last_activity_date = activity_date
 
@@ -178,6 +188,7 @@ class StreakEngine:
             "current_streak": profile.current_streak,
             "longest_streak": profile.longest_streak,
             "current_multiplier": profile.current_multiplier,
+            "streak_freezes": profile.streak_freezes,
             "next_milestone": (
                 {
                     "days": next_ms["days"],
@@ -204,6 +215,7 @@ class StreakEngine:
             "current_streak": profile.current_streak,
             "longest_streak": profile.longest_streak,
             "current_multiplier": profile.current_multiplier,
+            "streak_freezes": profile.streak_freezes,
             "multiplier_unlocked": multiplier_unlocked,
             "next_milestone": next_ms,
             "milestone_progress_pct": StreakEngine.compute_milestone_progress(


### PR DESCRIPTION
## Description

This PR fixes the flawed split-brain architecture introduced in the initial streak freeze implementation. The streak freeze functionality is now fully integrated into the progress engine (`StreakEngine` and `StreakProfile`), ensuring the backend actually preserves streak multipliers correctly and uses the central `XPEvent` ledger for XP deductions. 

Key architectural changes:
- Migrated `streak_freezes` tracking to `StreakProfile` (single source of truth).
- Updated `StreakEngine` and `DailyActivity` gap logic to seamlessly consume freezes and preserve streaks.
- Moved the API to `POST /api/accounts/shop/streak-freeze/` and switched the deduction logic to properly emit negative `XPEvent`s.
- Cleaned up the redundant `StreakFreeze` model and redundant calculation loops from the `dashboard` app.

Fixes #1380

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🛠️ Refactoring (no functional changes)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update (no code changes)
- [ ] ⚙️ CI/CD or build pipeline change
- [ ] ⚡ Performance optimization

## How Has This Been Tested?

### Automated Tests
- [x] Backend tests pass: `cd backend && pytest`
- [x] Frontend tests pass: `cd frontend && npm run test`
- [x] Frontend builds successfully: `cd frontend && npm run build`

### Manual Verification
- Verified edge cases manually, such as a user missing 3 days and having 3 freezes (consumes all 3), and missing 2 days with 1 freeze (resets streak, saves the freeze).
- Evaluated `XPEvent` aggregation to ensure points deduct properly globally across the platform.

## Pre-Push Checklist

> [!IMPORTANT]
> **All items below must be checked before requesting a review.** Our CI bot will automatically run the frontend build and backend tests on your PR. If CI fails, you will receive a comment explaining what went wrong.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or console errors
- [x] I have run `npm run build` in `frontend/` and it completes with **0 errors**
- [x] I have run `pytest` in `backend/` and all tests pass
- [x] I have run `git diff` locally and verified my changes

## Deployment Notes

> [!NOTE]
> This project is deployed on **Vercel** (Frontend) and **Hugging Face** (Backend). The CI workflow simulates both deployment environments. If your PR passes CI, it is safe to merge.

**Migration Required:** 
This PR deletes `dashboard.models.StreakFreeze` and adds `streak_freezes` to `progress.models.StreakProfile`. A database migration will run automatically during the backend Hugging Face deployment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a shop option to purchase streak freezes for 100 XP, with a limit of 3 active freezes.
  - Streak freeze availability is now shown in streak-related dashboard information.

- **Changes**
  - Updated streak handling so missed activity days can be covered by available freezes, consuming them as needed.
  - Refreshed the streak-freeze purchase flow to the new shop experience.
  - Updated exported account data to match the new streak-freeze behavior (and its export fields).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->