### PR TITLE
feat: Add a Markdown Code Block Copy Button in Lessons

### DIFF
--- a/frontend/src/components/ui/CopyButton.tsx
+++ b/frontend/src/components/ui/CopyButton.tsx
@@ -1,5 +1,7 @@
 import { useState } from "react";
 import Tooltip from "./Tooltip";
+import { Check } from "lucide-react";
+
 type CopyButtonProps = {
   text: string;
 };
@@ -26,9 +28,16 @@ export default function CopyButton({ text }: CopyButtonProps) {
       <button
         type="button"
         onClick={handleCopy}
-        className="rounded-lg border-2 border-black bg-surface-low px-3 py-1 text-xs font-black text-black shadow-card-sm hover:-translate-y-0.5 active:translate-y-0 transition-all cursor-pointer"
+        className="rounded-lg border-2 border-black bg-surface-low px-3 py-1 text-xs font-black text-black shadow-card-sm hover:-translate-y-0.5 active:translate-y-0 transition-all cursor-pointer flex items-center justify-center min-w-[72px]"
       >
-        {copied ? "Copied!" : "Copy"}
+        {copied ? (
+          <>
+            <Check className="w-3.5 h-3.5 mr-1" strokeWidth={3} />
+            Copied!
+          </>
+        ) : (
+          "Copy"
+        )}
       </button>
     </Tooltip>
   );

--- a/frontend/src/components/ui/MarkdownRenderer.tsx
+++ b/frontend/src/components/ui/MarkdownRenderer.tsx
@@ -108,8 +108,8 @@ export function MarkdownRenderer({ content }: MarkdownRendererProps) {
       }
       index++; // skip closing ```
       blocks.push(
-        <div key={index} className="relative my-4">
-          <div className="absolute top-2 right-2 z-10">
+        <div key={index} className="relative my-4 group">
+          <div className="absolute top-2 right-2 z-10 opacity-100 md:opacity-0 md:group-hover:opacity-100 focus-within:opacity-100 transition-opacity">
             <CopyButton text={codeContent.trim()} />
           </div>
 


### PR DESCRIPTION
## Description

Addresses issue #1389 by enhancing the user experience for reading markdown lessons.

- Added `group` and responsive visibility classes to `MarkdownRenderer.tsx` so the copy button reveals on hover (desktop) while remaining accessible on touch devices and keyboards.
- Updated `CopyButton.tsx` to include the `Check` icon from `lucide-react` and fixed-width alignment when the text transitions to "Copied!".

Fixes #1389

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

### Automated Tests
- [x] Frontend tests pass: `cd frontend && npm run test` (8/8 tests passed)
- [x] Frontend builds successfully: `cd frontend && npm run build`

### Manual Verification
- Verified the button gracefully appears on hover in desktop mode.
- Verified the clipboard API copies text successfully and displays the checkmark icon without layout jitter.

## Pre-Push Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or console errors
- [x] I have run `npm run build` in `frontend/` and it completes with **0 errors**
- [x] I have run `git diff` locally and verified my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Updated the code-copy button to display a checkmark and “Copied!” confirmation after copying.
  * Improved button alignment and sizing for a more consistent appearance.
  * Made copy controls easier to discover on mobile and appear on hover or keyboard focus on larger screens.
  * Added smooth visibility transitions for code-block copy controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->