### PR TITLE
fix: resolve TabError in event_bus.py

### DIFF
--- a/backend/apps/events/services/event_bus.py
+++ b/backend/apps/events/services/event_bus.py
@@ -81,7 +81,7 @@ class EventBus:
             from django_q.tasks import async_task
             from apps.events.tasks import process_event
 
-	async_task(process_event, str(event.id))
+            async_task(process_event, str(event.id))
 
     @classmethod
     def _process_handlers(cls, event: DomainEvent, handlers: List[Dict]):


### PR DESCRIPTION
## Description
This PR resolves a critical Python `TabError` in the backend event bus service, which prevented the server from initializing when domain events were imported.
Closes #1587 
## Changes
- Fixed inconsistent tab and space indentation in `backend/apps/events/services/event_bus.py`.

## Testing
- Verified `python manage.py runserver` starts without throwing an `IndentationError` or `TabError`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved asynchronous event processing by ensuring events are correctly queued for background handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->