### PR TITLE
fix(ui): align navigation header and sidebar borders (#1579)

### DIFF
--- a/frontend/src/components/layout/Navigation.tsx
+++ b/frontend/src/components/layout/Navigation.tsx
@@ -149,7 +149,7 @@ export function Navigation() {
         aria-label="Main sidebar"
         className="fixed inset-y-0 left-0 z-40 hidden w-[240px] border-r-4 border-black bg-surface-lowest/95 backdrop-blur-xl lg:flex lg:flex-col dark:bg-[#0f0e0c]/95 dark:border-[#2e2924]"
       >
-        <div className="border-b-4 border-black px-6 py-4 dark:border-[#2e2924]">
+        <div className="flex h-[72px] flex-col justify-center border-b-4 border-black px-6 dark:border-[#2e2924]">
           <Link
             to="/"
             className="block font-display text-xl font-black tracking-tight text-black dark:text-white uppercase"
@@ -202,8 +202,8 @@ export function Navigation() {
         </div>
       </aside>
 
-      <header className="fixed inset-x-0 top-0 z-30 border-b-4 border-black bg-white lg:left-[240px] dark:border-[#2e2924] dark:bg-[#0f0e0c]">
-        <div className="flex items-center justify-between space-x-4 px-4 py-4 sm:px-6 lg:px-8">
+      <header className="fixed inset-x-0 top-0 z-30 h-[72px] border-b-4 border-black bg-white lg:left-[240px] dark:border-[#2e2924] dark:bg-[#0f0e0c]">
+        <div className="flex h-full items-center justify-between space-x-4 px-4 sm:px-6 lg:px-8">
           <button
             onClick={() => setMobileOpen(!mobileOpen)}
             className="lg:hidden rounded-lg border-2 border-black p-2 menu-btn"


### PR DESCRIPTION
## Description

This PR fixes a visual alignment bug where the top `<header>` border didn't perfectly align with the `border-b` of the sidebar's title section. Because they both originally relied on `py-4` padding wrapping text of different sizes, their computed heights were slightly mismatched.

I applied a strict `h-[72px]` fixed height to both containers along with flex alignment rules (`flex flex-col justify-center` and `flex h-full items-center`), ensuring the borders intersect flawlessly.

Fixes #1579

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
### Automated Tests
- [x] Frontend tests pass: `cd frontend && npm run test`
- [x] Frontend builds successfully: `cd frontend && npm run build`

### Manual Verification
- Navigated to the authenticated layout (`/dashboard`) on a desktop screen and visually verified that the horizontal border of the top navigation bar seamlessly aligns with the border of the "Atelier" section in the left sidebar.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved alignment and spacing in the sidebar and main header.
  * Standardized header regions to a consistent 72px height for a more cohesive layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->