### PR TITLE
feat: implement cohort-based leaderboards (#1613)

### DIFF
--- a/backend/apps/progress/services/leaderboard_service.py
+++ b/backend/apps/progress/services/leaderboard_service.py
@@ -42,21 +42,50 @@ class LeaderboardService:
     def get_seasonal_key(season_name):
         return f"leaderboard:seasonal:{season_name}"
 
+    @staticmethod
+    def get_cohort_key(cohort_name):
+        return f"leaderboard:cohort:{cohort_name}"
+
+    @staticmethod
+    def determine_cohort(date_joined):
+        if not date_joined:
+            return "unknown"
+        year = date_joined.year
+        month = date_joined.month
+        if 1 <= month <= 3:
+            return f"winter_{year}"
+        elif 4 <= month <= 6:
+            return f"spring_{year}"
+        elif 7 <= month <= 9:
+            return f"summer_{year}"
+        else:
+            return f"fall_{year}"
+
     @classmethod
     def update_user_xp(cls, user_id: int, username: str, xp_delta: int):
         client = get_redis_client()
         if not client:
             return
 
-        pipeline = client.pipeline()
+        from django.contrib.auth import get_user_model
+        User = get_user_model()
+        try:
+            user = User.objects.get(id=user_id)
+            cohort = cls.determine_cohort(user.date_joined)
+        except User.DoesNotExist:
+            cohort = "unknown"
 
-        # Ensure we can map username to user_id
+        pipeline = client.pipeline()
         pipeline.hset("leaderboard:users", username, user_id)
 
-        # Update sets
+        # Update all time
         pipeline.zincrby(cls.ALL_TIME, xp_delta, username)
+        # Update weekly
         pipeline.zincrby(cls.get_weekly_key(), xp_delta, username)
+        # Update monthly
         pipeline.zincrby(cls.get_monthly_key(), xp_delta, username)
+        # Update cohort
+        pipeline.zincrby(cls.get_cohort_key(cohort), xp_delta, username)
         # Seasonal logic could be driven by an active season, for now let's assume a default season
         pipeline.zincrby(cls.get_seasonal_key("summer_2026"), xp_delta, username)
 
@@ -93,6 +122,10 @@ class LeaderboardService:
             key = cls.get_monthly_key()
         elif time_period.startswith("seasonal"):
             key = cls.get_seasonal_key("summer_2026")
+        elif time_period.startswith("cohort_"):
+            # e.g., cohort_summer_2026 -> summer_2026
+            cohort_name = time_period.replace("cohort_", "")
+            key = cls.get_cohort_key(cohort_name)
         else:
             key = cls.ALL_TIME
 
@@ -140,6 +173,9 @@ class LeaderboardService:
             key = cls.get_monthly_key()
         elif time_period.startswith("seasonal"):
             key = cls.get_seasonal_key("summer_2026")
+        elif time_period.startswith("cohort_"):
+            cohort_name = time_period.replace("cohort_", "")
+            key = cls.get_cohort_key(cohort_name)
         else:
             key = cls.ALL_TIME
 

--- a/frontend/src/pages/LeaderboardPage.tsx
+++ b/frontend/src/pages/LeaderboardPage.tsx
@@ -16,7 +16,7 @@ import { useAuth } from "../features/auth/AuthContext";
 import { ResponsiveTable } from "../components/ui/ResponsiveTable";
 import { motion, AnimatePresence } from "framer-motion";
 
-type TimePeriod = "all_time" | "weekly" | "monthly" | "seasonal";
+type TimePeriod = "all_time" | "weekly" | "monthly" | "seasonal" | string;
 
 export function LeaderboardPage() {
   const { user } = useAuth();
@@ -149,6 +149,7 @@ export function LeaderboardPage() {
 
   const timePeriods: { id: TimePeriod; label: string; icon: any }[] = [
     { id: "all_time", label: "All Time", icon: Crown },
+    { id: "cohort_summer_2026", label: "Summer '26 Cohort", icon: Sparkles },
     { id: "seasonal", label: "Season 1", icon: Sparkles },
     { id: "monthly", label: "Monthly", icon: Star },
     { id: "weekly", label: "Weekly", icon: Flame },


### PR DESCRIPTION
## Description

This PR introduces Cohort-based Leaderboards to give newer contributors a fair chance to compete locally, resolving issue #1613.

Key changes:
- Added `determine_cohort` utility to map a user's `date_joined` to a specific season/year cohort (e.g., `summer_2026`).
- Updated `LeaderboardService.update_user_xp` to additionally increment the user's cohort-specific Redis sorted set.
- Extended the `get_leaderboard` and `get_user_rank` service methods to parse and query `cohort_` prefixed time periods.
- Updated the Frontend `LeaderboardPage.tsx` to include a new "Summer '26 Cohort" tab within the Hall of Fame interface.

Fixes #1613

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update (no code changes)
- [ ] ⚙️ CI/CD or build pipeline change
- [ ] ⚡ Performance optimization
- [ ] 🛠️ Refactoring (no functional changes)

## How Has This Been Tested?

### Automated Tests
- [x] Backend tests pass: `cd backend && pytest`
- [x] Frontend tests pass: `cd frontend && npm run test`
- [x] Frontend builds successfully: `cd frontend && npm run build`

### Manual Verification
- Verified that new XP events are successfully tracked under the `leaderboard:cohort:summer_2026` Redis key for users who joined in Q3 2026.
- Verified that clicking the "Summer '26 Cohort" tab on the frontend correctly fetches and displays the filtered list of contributors.

## Pre-Push Checklist

> [!IMPORTANT]
> **All items below must be checked before requesting a review.** Our CI bot will automatically run the frontend build and backend tests on your PR. If CI fails, you will receive a comment explaining what went wrong.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or console errors
- [x] I have run `npm run build` in `frontend/` and it completes with **0 errors**
- [x] I have run `pytest` in `backend/` and all tests pass
- [x] I have run `git diff` locally and verified my changes

## Deployment Notes

> [!NOTE]
> This project is deployed on **Vercel** (Frontend) and **Hugging Face** (Backend). The CI workflow simulates both deployment environments. If your PR passes CI, it is safe to merge.

No database migrations are required since the cohort is derived dynamically from the existing `User.date_joined` field.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Summer ’26 Cohort” leaderboard tab.
  * Leaderboards can now display rankings for specific enrollment cohorts.
  * User rankings and positions are tracked within each cohort in addition to existing time periods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->