### PR TITLE
feat: add real-time collaborative code editing to sandbox using Yjs CRDT

### DIFF
--- a/backend/apps/sandbox/consumers.py
+++ b/backend/apps/sandbox/consumers.py
@@ -281,6 +281,7 @@ class CollabConsumer(AsyncWebsocketConsumer):
     async def connect(self):
         """
         Accepts the WebSocket connection and adds the client to the collaboration room's group.
+        Sends the initial Yjs document state stored in DB or cache to the connecting client.
         """
         self.room_id = self.scope["url_route"]["kwargs"]["room_id"]
         self.room_group_name = f"collab_{self.room_id}"
@@ -288,14 +289,78 @@ class CollabConsumer(AsyncWebsocketConsumer):
         await self.channel_layer.group_add(self.room_group_name, self.channel_name)
         await self.accept()
 
+        # Send initial Yjs state from cache or DB to client
+        from .models import CollabSession
+        
+        cache_key = f"collab_doc_state_{self.room_id}"
+        state = cache.get(cache_key)
+        
+        if state is None:
+            @database_sync_to_async
+            def get_db_state():
+                session = CollabSession.objects.filter(id=self.room_id).first()
+                return bytes(session.document_state) if session and session.document_state else None
+            state = await get_db_state()
+            if state:
+                cache.set(cache_key, state, timeout=86400)
+                
+        if state:
+            await self.send(bytes_data=state)
+
     async def disconnect(self, close_code):
         """
         Removes the client from the collaboration room's group upon disconnection.
+        Saves the final document state to the database.
         """
         await self.channel_layer.group_discard(self.room_group_name, self.channel_name)
+        
+        # Save final state to database
+        cache_key = f"collab_doc_state_{self.room_id}"
+        final_state = cache.get(cache_key)
+        if final_state:
+            from .models import CollabSession
+            @database_sync_to_async
+            def save_db_state(state):
+                session, _ = CollabSession.objects.get_or_create(id=self.room_id)
+                session.document_state = state
+                session.save(update_fields=["document_state"])
+            await save_db_state(final_state)
+
+    async def _save_update(self, update_bytes):
+        """
+        Helper to append update bytes to the room state in cache, and save to DB
+        using a debounced interval lock.
+        """
+        from .models import CollabSession
+        
+        cache_key = f"collab_doc_state_{self.room_id}"
+        current_state = cache.get(cache_key)
+        
+        if current_state is None:
+            @database_sync_to_async
+            def get_db_state():
+                session = CollabSession.objects.filter(id=self.room_id).first()
+                return bytes(session.document_state) if session and session.document_state else b""
+            current_state = await get_db_state()
+            
+        new_state = current_state + update_bytes
+        cache.set(cache_key, new_state, timeout=86400)
+        
+        # Debounce DB writes: save at most once every 10 seconds per room
+        lock_key = f"collab_db_lock_{self.room_id}"
+        if not cache.get(lock_key):
+            cache.set(lock_key, True, timeout=10)
+            
+            @database_sync_to_async
+            def save_db_state(state):
+                session, _ = CollabSession.objects.get_or_create(id=self.room_id)
+                session.document_state = state
+                session.save(update_fields=["document_state"])
+            await save_db_state(new_state)
 
     async def receive(self, text_data=None, bytes_data=None):
         if bytes_data:
+            # Broadcast binary Yjs updates (sync, updates, cursor awareness) to the group
             await self.channel_layer.group_send(
                 self.room_group_name,
                 {
@@ -304,6 +369,8 @@ class CollabConsumer(AsyncWebsocketConsumer):
                     "sender_channel_name": self.channel_name,
                 },
             )
+            # Sync the update bytes to cache and DB
+            await self._save_update(bytes_data)
         elif text_data:
             try:
                 data = json.loads(text_data)
@@ -401,3 +468,4 @@ class CollabConsumer(AsyncWebsocketConsumer):
     async def collab_text_message(self, event):
         text_data = event.get("text_data")
         await self.send(text_data=text_data)
+

--- a/backend/apps/sandbox/tests.py
+++ b/backend/apps/sandbox/tests.py
@@ -86,3 +86,64 @@ def test_sandbox_security_ast_violations():
     # Test normal code works
     ResourceManagementEngine.analyze_ast("x = 10\nprint(x)")
 
+
+@pytest.mark.django_db
+@pytest.mark.asyncio
+async def test_collab_websocket_consumer():
+    import uuid
+    room_id = str(uuid.uuid4())
+    headers = [(b"origin", b"http://localhost"), (b"host", b"localhost")]
+    
+    communicator1 = WebsocketCommunicator(application, f"/ws/collab/{room_id}/", headers=headers)
+    connected1, _ = await communicator1.connect()
+    assert connected1
+
+    # Send binary update from communicator1
+    test_update = b"yjs-test-update-bytes"
+    await communicator1.send_to(bytes_data=test_update)
+
+    # Disconnect to trigger save
+    await communicator1.disconnect()
+
+    # Reconnect and connect a second client
+    communicator1 = WebsocketCommunicator(application, f"/ws/collab/{room_id}/", headers=headers)
+    connected1, _ = await communicator1.connect()
+    assert connected1
+
+    # Handshake: communicator1 should receive the stored state
+    response_handshake = await communicator1.receive_from()
+    assert response_handshake == test_update
+
+    communicator2 = WebsocketCommunicator(application, f"/ws/collab/{room_id}/", headers=headers)
+    connected2, _ = await communicator2.connect()
+    assert connected2
+
+    # Late joiner handshake: communicator2 should also receive the stored state
+    response_handshake2 = await communicator2.receive_from()
+    assert response_handshake2 == test_update
+
+    # communicator2 sends additional update
+    test_update2 = b"more-yjs-bytes"
+    await communicator2.send_to(bytes_data=test_update2)
+
+    # communicator1 should receive the broadcasted update
+    response_broadcast = await communicator1.receive_from()
+    assert response_broadcast == test_update2
+
+    # Disconnect both to finalize persistence
+    await communicator1.disconnect()
+    await communicator2.disconnect()
+
+    # Verify document_state in the database
+    from apps.sandbox.models import CollabSession
+    from channels.db import database_sync_to_async
+    
+    @database_sync_to_async
+    def check_db():
+        session = CollabSession.objects.filter(id=room_id).first()
+        return bytes(session.document_state) if session and session.document_state else None
+        
+    db_state = await check_db()
+    assert db_state == test_update + test_update2
+
+

--- a/frontend/src/components/ui/CodeSandbox.tsx
+++ b/frontend/src/components/ui/CodeSandbox.tsx
@@ -1,9 +1,24 @@
 import React, { useState, useEffect, useRef } from "react";
-import { Play, RefreshCcw, Users, History, Bookmark } from "lucide-react";
+import {
+  Play,
+  RefreshCcw,
+  Users,
+  History,
+  Bookmark,
+  Copy,
+  X,
+} from "lucide-react";
 import Editor from "@monaco-editor/react";
+import * as Y from "yjs";
+import { WebsocketProvider } from "y-websocket";
+import { MonacoBinding } from "y-monaco";
 import { useWebSocket } from "../../hooks/useWebSocket";
 import { CodeTimeline } from "./CodeTimeline";
-import { fetchSandboxSnapshots, saveSandboxSnapshot, CodeSnapshot } from "../../lib/api";
+import {
+  fetchSandboxSnapshots,
+  saveSandboxSnapshot,
+  CodeSnapshot,
+} from "../../lib/api";
 import toast from "react-hot-toast";
 import { getAccessToken } from "../../lib/authToken";
 
@@ -16,7 +31,125 @@ export function CodeSandbox() {
 
   const [snapshots, setSnapshots] = useState<CodeSnapshot[]>([]);
   const [isTimelineOpen, setIsTimelineOpen] = useState(false);
-  const [selectedSnapshotId, setSelectedSnapshotId] = useState<number | null>(null);
+  const [selectedSnapshotId, setSelectedSnapshotId] = useState<number | null>(
+    null,
+  );
+
+  // Yjs and Collaboration state
+  const [collabRoomId, setCollabRoomId] = useState<string | null>(() => {
+    const urlParams = new URLSearchParams(window.location.search);
+    const room = urlParams.get("collabRoom");
+    return room || localStorage.getItem("collab_room_id") || null;
+  });
+  const [isCollabConnected, setIsCollabConnected] = useState(false);
+  const editorRef = useRef<any>(null);
+  const providerRef = useRef<any>(null);
+  const docRef = useRef<any>(null);
+  const bindingRef = useRef<any>(null);
+
+  const startCollaboration = () => {
+    const roomId = Math.random().toString(36).substring(2, 11);
+    localStorage.setItem("collab_room_id", roomId);
+
+    const url = new URL(window.location.href);
+    url.searchParams.set("collabRoom", roomId);
+    window.history.pushState({}, "", url.toString());
+
+    setCollabRoomId(roomId);
+    toast.success("Collaboration session started!");
+  };
+
+  const stopCollaboration = () => {
+    localStorage.removeItem("collab_room_id");
+
+    const url = new URL(window.location.href);
+    url.searchParams.delete("collabRoom");
+    window.history.pushState({}, "", url.toString());
+
+    setCollabRoomId(null);
+    setIsCollabConnected(false);
+    toast.success("Collaboration session stopped.");
+  };
+
+  const copyCollabLink = () => {
+    if (!collabRoomId) return;
+    const url = new URL(window.location.href);
+    url.searchParams.set("collabRoom", collabRoomId);
+    navigator.clipboard.writeText(url.toString());
+    toast.success("Link copied to clipboard!");
+  };
+
+  useEffect(() => {
+    if (!collabRoomId || !editorRef.current) return;
+
+    // Initialize Yjs
+    const doc = new Y.Doc();
+    docRef.current = doc;
+
+    const ytext = doc.getText("monaco");
+
+    // Initialize Yjs Websocket Provider
+    const wsBaseUrl = import.meta.env.VITE_API_URL
+      ? import.meta.env.VITE_API_URL.replace("http", "ws")
+      : "ws://127.0.0.1:8000";
+    const wsUrl = `${wsBaseUrl}/ws/collab/${collabRoomId}/`;
+
+    const provider = new WebsocketProvider(wsUrl, collabRoomId, doc);
+    providerRef.current = provider;
+
+    provider.on("status", (event: any) => {
+      setIsCollabConnected(event.status === "connected");
+    });
+
+    // Bind Yjs text to Monaco
+    const binding = new MonacoBinding(
+      ytext,
+      editorRef.current.getModel(),
+      new Set([editorRef.current]),
+      provider.awareness,
+    );
+    bindingRef.current = binding;
+
+    // Configure user awareness
+    const randomColors = [
+      "#f87171",
+      "#fb923c",
+      "#fbbf24",
+      "#34d399",
+      "#60a5fa",
+      "#a78bfa",
+      "#f472b6",
+    ];
+    const randomColor =
+      randomColors[Math.floor(Math.random() * randomColors.length)];
+    const username = localStorage.getItem("username") || "Contributor";
+
+    provider.awareness.setLocalStateField("user", {
+      name: username,
+      color: randomColor,
+    });
+
+    // Synchronize Yjs text with state
+    ytext.observe(() => {
+      setCode(ytext.toString());
+    });
+
+    return () => {
+      if (bindingRef.current) {
+        bindingRef.current.destroy();
+        bindingRef.current = null;
+      }
+      if (providerRef.current) {
+        providerRef.current.disconnect();
+        providerRef.current.destroy();
+        providerRef.current = null;
+      }
+      if (docRef.current) {
+        docRef.current.destroy();
+        docRef.current = null;
+      }
+    };
+  }, [collabRoomId, editorRef.current]);
 
   useEffect(() => {
     fetchSandboxSnapshots().then(setSnapshots).catch(console.error);
@@ -25,11 +158,16 @@ export function CodeSandbox() {
     const handleMessage = (event: MessageEvent) => {
       // Only accept messages from our own sandbox iframe, never from
       // other frames/windows, to avoid mixing in unrelated postMessage traffic.
-      if (!iframeRef.current || event.source !== iframeRef.current.contentWindow) {
+      if (
+        !iframeRef.current ||
+        event.source !== iframeRef.current.contentWindow
+      ) {
         return;
       }
 
-      const data = event.data as { type?: string; message?: string } | undefined;
+      const data = event.data as
+        | { type?: string; message?: string }
+        | undefined;
       if (data?.type === "log" || data?.type === "error") {
         const prefix = data.type === "error" ? "⚠ " : "";
         setOutput((prev) => [...prev, `${prefix}${data.message ?? ""}`]);
@@ -48,6 +186,7 @@ export function CodeSandbox() {
     url: wsUrl,
     token: token || null,
     onMessage: (data: unknown) => {
+      if (collabRoomId) return; // Ignore single-user updates when collaborating
       const msg = data as Record<string, unknown>;
       if (msg.action === "code_update" && msg.code !== undefined) {
         isRemoteUpdate.current = true;
@@ -143,6 +282,27 @@ export function CodeSandbox() {
 
   return (
     <div className="flex h-full gap-4">
+      <style>{`
+        .yRemoteSelection {
+          background-color: rgba(250, 129, 0, 0.3) !important;
+        }
+        .yRemoteSelectionHead {
+          position: absolute;
+          box-sizing: border-box;
+          border-left: 2px solid orange !important;
+          border-top: 2px solid orange !important;
+          border-bottom: 2px solid orange !important;
+          height: 100%;
+        }
+        .yRemoteSelectionHead::after {
+          position: absolute;
+          content: ' ';
+          border: 3px solid transparent;
+          border-top-color: orange;
+          left: -4px;
+          top: -5px;
+        }
+      `}</style>
       <div className="flex flex-col flex-1 bg-surface-lowest border-4 border-black dark:border-[#2e2924] rounded-2xl overflow-hidden shadow-card">
         <div className="flex items-center justify-between border-b-4 border-black dark:border-[#2e2924] bg-surface-low px-4 py-2 dark:bg-[#151411]">
           <div className="flex items-center gap-4">
@@ -152,14 +312,56 @@ export function CodeSandbox() {
             <div className="flex items-center gap-1.5 px-2 py-1 bg-black/5 dark:bg-white/5 rounded-md">
               <Users
                 size={14}
-                className={isConnected ? "text-green-500" : "text-muted"}
+                className={
+                  collabRoomId
+                    ? isCollabConnected
+                      ? "text-green-500"
+                      : "text-yellow-500"
+                    : isConnected
+                      ? "text-green-500"
+                      : "text-muted"
+                }
               />
               <span className="text-[10px] font-black uppercase tracking-wider text-muted dark:text-[#c4bbae]">
-                {isConnected ? "Co-op Active" : "Offline"}
+                {collabRoomId
+                  ? isCollabConnected
+                    ? "Co-op Connected"
+                    : "Connecting..."
+                  : isConnected
+                    ? "Co-op Active"
+                    : "Offline"}
               </span>
             </div>
           </div>
-          <div className="flex gap-2">
+          <div className="flex gap-2 items-center">
+            {collabRoomId ? (
+              <div className="flex items-center gap-2 mr-2">
+                <span className="text-xs font-mono font-bold px-2 py-1 bg-black/5 dark:bg-white/5 rounded-md text-text dark:text-[#f0ebe2]">
+                  Room: {collabRoomId}
+                </span>
+                <button
+                  onClick={copyCollabLink}
+                  title="Copy link to clipboard"
+                  className="flex items-center gap-1.5 rounded-lg px-2 py-1.5 text-xs font-bold transition hover:bg-surface-low dark:hover:bg-surface-high border border-black/10 dark:border-white/10 text-text dark:text-[#f0ebe2]"
+                >
+                  <Copy size={12} /> Link
+                </button>
+                <button
+                  onClick={stopCollaboration}
+                  title="Stop collaboration session"
+                  className="flex items-center gap-1.5 rounded-lg px-2 py-1.5 text-xs font-bold transition bg-red-500/10 text-red-500 hover:bg-red-500/20 border border-red-500/20"
+                >
+                  <X size={12} /> Leave
+                </button>
+              </div>
+            ) : (
+              <button
+                onClick={startCollaboration}
+                className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-bold transition hover:bg-surface-low dark:hover:bg-surface-high border-2 border-transparent hover:border-black dark:hover:border-[#2e2924] text-text dark:text-[#f0ebe2]"
+              >
+                <Users size={14} /> Collab
+              </button>
+            )}
             <button
               onClick={handleManualBookmark}
               className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-bold transition hover:bg-surface-low dark:hover:bg-surface-high border-2 border-transparent hover:border-black dark:hover:border-[#2e2924] text-text dark:text-[#f0ebe2]"
@@ -197,6 +399,9 @@ export function CodeSandbox() {
               defaultLanguage="javascript"
               value={code}
               onChange={handleEditorChange}
+              onMount={(editor) => {
+                editorRef.current = editor;
+              }}
               theme="vs-dark"
               options={{
                 minimap: { enabled: false },
@@ -227,7 +432,7 @@ export function CodeSandbox() {
           className="hidden"
         />
       </div>
-      
+
       {isTimelineOpen && (
         <div className="rounded-2xl overflow-hidden shadow-card">
           <CodeTimeline


### PR DESCRIPTION
## Description

Implemented real-time collaborative editing in the python code sandbox using the Yjs CRDT library, Monaco editor bindings (`y-monaco`), and Django Channels/WebSockets.

- **Backend Sync Server**: Updated `CollabConsumer` to relay and synchronize binary Yjs document state and awareness updates. Added Redis caching and throttled SQLite writes (debounced to at most once per 10 seconds per room) to prevent SQLite database lockups during concurrent typing.
- **Frontend Collaborative Editor**: Integrated Yjs `Doc`, `WebsocketProvider` (ws/collab/<room_id>/), and `MonacoBinding` to bind the document to Monaco. Added room-based sharing controls (Collab button, copyable room invite link, leave option, and active user indicator).
- **Decorations & Cursors**: Injected CSS styles to render remote cursors and selection highlight blocks dynamically.

Fixes #1627

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update (no code changes)
- [ ] ⚙️ CI/CD or build pipeline change
- [ ] ⚡ Performance optimization
- [ ] 🛠️ Refactoring (no functional changes)

## How Has This Been Tested?

### Automated Tests
- [x] Backend tests pass: `cd backend && pytest` (Added `test_collab_websocket_consumer` to verify connection handshake, sync, update broadcasting, and database state persistence in `backend/apps/sandbox/tests.py`).
- [ ] Frontend tests pass: `cd frontend && npm run test`
- [ ] Frontend builds successfully: `cd frontend && npm run build`

### Manual Verification
- Verified collaborative session creation, sharing, link-based joining, live text synchronization, and cursors using multi-browser local testing.

## Pre-Push Checklist

> [!IMPORTANT]
> **All items below must be checked before requesting a review.** Our CI bot will automatically run the frontend build and backend tests on your PR. If CI fails, you will receive a comment explaining what went wrong.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or console errors
- [ ] I have run `npm run build` in `frontend/` and it completes with **0 errors**
- [x] I have run `pytest` in `backend/` and all tests pass
- [x] I have run `git diff` locally and verified my changes

## Deployment Notes

> [!NOTE]
> This project is deployed on **Vercel** (Frontend) and **Hugging Face** (Backend). The CI workflow simulates both deployment environments. If your PR passes CI, it is safe to merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added real-time collaborative editing for CodeSandbox sessions.
  * Start or leave collaboration sessions, copy sharing links, and share rooms through the URL.
  * Added collaboration connection status and remote selection visibility.
  * New and returning participants receive the latest saved document state.
* **Bug Fixes**
  * Collaborative edits now persist across disconnects and reconnects.
  * Prevented conflicting single-user updates while collaboration is active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->