### PR TITLE
fix(feed): require JWT auth and add per-user/org channel isolation

### DIFF
--- a/backend/apps/feed/consumers.py
+++ b/backend/apps/feed/consumers.py
@@ -1,14 +1,130 @@
+"""
+WebSocket consumer for the platform activity feed.
+
+@file consumers.py
+@location backend/apps/feed/consumers.py
+"""
+
+import asyncio
 import json
+import logging
+import time
+
+from channels.db import database_sync_to_async
 from channels.generic.websocket import AsyncWebsocketConsumer
-from .models import FeedEvent
+
+logger = logging.getLogger(__name__)
+
+# Close early enough before hard token expiry that the client has time to
+# refresh its access token and reconnect before it's dropped mid-session.
+TOKEN_EXPIRY_GRACE_SECONDS = 10
+CLOSE_CODE_UNAUTHENTICATED = 4001
+CLOSE_CODE_TOKEN_EXPIRED = 4003
+
 
 class FeedConsumer(AsyncWebsocketConsumer):
+    """
+    Every connection must be authenticated (JWT, via JWTAuthMiddleware —
+    see config/asgi.py). Once connected, the client is placed into:
+
+      - a personal group  ``feed_user_<id>``      -> events targeted at them
+      - an org-scoped group ``feed_org_<org_id>``  -> only if the user
+        belongs to an organization, for org-wide feed events
+
+    Clients no longer receive the entire platform's feed; only events
+    broadcast to a group they're actually a member of.
+    """
+
     async def connect(self):
-        await self.channel_layer.group_add("feed", self.channel_name)
+        user = self.scope.get("user")
+
+        if not user or not user.is_authenticated:
+            logger.warning("Feed WS rejected: unauthenticated connection attempt")
+            await self.close(code=CLOSE_CODE_UNAUTHENTICATED)
+            return
+
+        self.user_id = str(user.id)
+        self.personal_group = f"feed_user_{self.user_id}"
+        self.org_group = None
+        self._expiry_task = None
+
+        await self.channel_layer.group_add(self.personal_group, self.channel_name)
+
+        org_id = await self.get_organization_id(user)
+        if org_id is not None:
+            self.org_group = f"feed_org_{org_id}"
+            await self.channel_layer.group_add(self.org_group, self.channel_name)
+
         await self.accept()
-    
+        logger.info(
+            "Feed WS connected: user=%s personal_group=%s org_group=%s",
+            self.user_id,
+            self.personal_group,
+            self.org_group,
+        )
+
+        # Handle auth token expiry gracefully: schedule a proactive close
+        # shortly before the JWT expires so the client can refresh its
+        # token and reconnect, instead of being dropped without warning
+        # (or, worse, staying "connected" on a channel layer group after
+        # its auth has technically lapsed).
+        expires_at = self.scope.get("token_expires_at")
+        if expires_at:
+            self._expiry_task = asyncio.ensure_future(
+                self._close_on_token_expiry(expires_at)
+            )
+
     async def disconnect(self, close_code):
-        await self.channel_layer.group_discard("feed", self.channel_name)
-    
+        if getattr(self, "_expiry_task", None):
+            self._expiry_task.cancel()
+        if hasattr(self, "personal_group"):
+            await self.channel_layer.group_discard(
+                self.personal_group, self.channel_name
+            )
+        if getattr(self, "org_group", None):
+            await self.channel_layer.group_discard(self.org_group, self.channel_name)
+        logger.info(
+            "Feed WS disconnected: user=%s code=%s",
+            getattr(self, "user_id", "anonymous"),
+            close_code,
+        )
+
+    async def receive(self, text_data=None, bytes_data=None):
+        # The feed is a read-only broadcast channel today; the only inbound
+        # message we support is a keep-alive ping from the client.
+        try:
+            data = json.loads(text_data or "{}")
+        except json.JSONDecodeError:
+            return
+        if data.get("action") == "ping":
+            await self.send(text_data=json.dumps({"type": "pong"}))
+
+    # ------------------------------------------------------------------ #
+    # Channel-layer event handlers (called by group_send)                #
+    # ------------------------------------------------------------------ #
     async def feed_event(self, event):
-        await self.send(text_data=json.dumps(event['data']))
+        """Relay a feed event pushed via group_send to this client."""
+        await self.send(text_data=json.dumps(event["data"]))
+
+    # ------------------------------------------------------------------ #
+    # Helpers                                                             #
+    # ------------------------------------------------------------------ #
+    @database_sync_to_async
+    def get_organization_id(self, user):
+        profile = getattr(user, "user_profile", None)
+        if profile and profile.organization_id:
+            return profile.organization_id
+        return None
+
+    async def _close_on_token_expiry(self, expires_at):
+        delay = max(0, expires_at - time.time() - TOKEN_EXPIRY_GRACE_SECONDS)
+        try:
+            await asyncio.sleep(delay)
+            logger.info(
+                "Feed WS closing due to token expiry: user=%s",
+                getattr(self, "user_id", "anonymous"),
+            )
+            await self.close(code=CLOSE_CODE_TOKEN_EXPIRED)
+        except asyncio.CancelledError:
+            # Client disconnected normally before expiry — nothing to do.
+            pass

--- a/backend/apps/feed/routing.py
+++ b/backend/apps/feed/routing.py
@@ -2,5 +2,5 @@ from django.urls import path
 from .consumers import FeedConsumer
 
 websocket_urlpatterns = [
-    path('ws/feed/', FeedConsumer.as_asgi()),
+    path("ws/feed/", FeedConsumer.as_asgi()),
 ]

--- a/backend/apps/feed/tests.py
+++ b/backend/apps/feed/tests.py
@@ -1,0 +1,157 @@
+"""
+Tests for FeedConsumer authentication and channel isolation.
+
+@file tests.py
+@location backend/apps/feed/tests.py
+"""
+
+import pytest
+from channels.db import database_sync_to_async
+from channels.testing import WebsocketCommunicator
+from django.contrib.auth import get_user_model
+from rest_framework_simplejwt.tokens import AccessToken
+
+from apps.organizations.models import Organization
+from config.asgi import application
+
+User = get_user_model()
+
+
+@database_sync_to_async
+def create_user(username, organization=None):
+    user = User.objects.create_user(username=username, password="testpassword123")
+    if organization is not None:
+        from apps.accounts.models import UserProfile
+
+        UserProfile.objects.update_or_create(
+            user=user, defaults={"organization": organization}
+        )
+    return user
+
+
+@database_sync_to_async
+def create_organization(name):
+    return Organization.objects.create(name=name)
+
+
+@pytest.fixture
+def token_for():
+    def _token_for(user):
+        return str(AccessToken.for_user(user))
+
+    return _token_for
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+class TestFeedConsumer:
+    async def test_unauthenticated_connection_rejected(self):
+        communicator = WebsocketCommunicator(application, "/ws/feed/")
+        connected, subprotocol = await communicator.connect()
+        assert not connected
+        await communicator.disconnect()
+
+    async def test_invalid_token_rejected(self):
+        communicator = WebsocketCommunicator(
+            application, "/ws/feed/?token=not-a-real-token"
+        )
+        connected, _ = await communicator.connect()
+        assert not connected
+        await communicator.disconnect()
+
+    async def test_authenticated_connection_accepted(self, token_for):
+        user = await create_user("feeduser1")
+        token = token_for(user)
+        communicator = WebsocketCommunicator(application, f"/ws/feed/?token={token}")
+        connected, _ = await communicator.connect()
+        assert connected
+        await communicator.disconnect()
+
+    async def test_ping_pong(self, token_for):
+        user = await create_user("feeduser2")
+        token = token_for(user)
+        communicator = WebsocketCommunicator(application, f"/ws/feed/?token={token}")
+        connected, _ = await communicator.connect()
+        assert connected
+
+        await communicator.send_json_to({"action": "ping"})
+        response = await communicator.receive_json_from()
+        assert response == {"type": "pong"}
+
+        await communicator.disconnect()
+
+    async def test_users_only_receive_events_from_their_own_group(self, token_for):
+        """
+        User isolation: an event sent to user A's personal group must not
+        be delivered to user B's connection.
+        """
+        from channels.layers import get_channel_layer
+
+        user_a = await create_user("feeduser_a")
+        user_b = await create_user("feeduser_b")
+
+        comm_a = WebsocketCommunicator(
+            application, f"/ws/feed/?token={token_for(user_a)}"
+        )
+        comm_b = WebsocketCommunicator(
+            application, f"/ws/feed/?token={token_for(user_b)}"
+        )
+        assert (await comm_a.connect())[0]
+        assert (await comm_b.connect())[0]
+
+        channel_layer = get_channel_layer()
+        await channel_layer.group_send(
+            f"feed_user_{user_a.id}",
+            {"type": "feed_event", "data": {"event": "only_for_a"}},
+        )
+
+        # A receives it
+        message = await comm_a.receive_json_from()
+        assert message == {"event": "only_for_a"}
+
+        # B must NOT receive it
+        assert await comm_b.receive_nothing(timeout=0.2)
+
+        await comm_a.disconnect()
+        await comm_b.disconnect()
+
+    async def test_org_group_scoping(self, token_for):
+        """
+        Users in the same organization both receive an org-broadcast
+        event; a user in a different (or no) organization does not.
+        """
+        from channels.layers import get_channel_layer
+
+        org = await create_organization("Acme Corp")
+        other_org = await create_organization("Other Corp")
+
+        member_1 = await create_user("org_member_1", organization=org)
+        member_2 = await create_user("org_member_2", organization=org)
+        outsider = await create_user("org_outsider", organization=other_org)
+
+        comm_1 = WebsocketCommunicator(
+            application, f"/ws/feed/?token={token_for(member_1)}"
+        )
+        comm_2 = WebsocketCommunicator(
+            application, f"/ws/feed/?token={token_for(member_2)}"
+        )
+        comm_outsider = WebsocketCommunicator(
+            application, f"/ws/feed/?token={token_for(outsider)}"
+        )
+        assert (await comm_1.connect())[0]
+        assert (await comm_2.connect())[0]
+        assert (await comm_outsider.connect())[0]
+
+        channel_layer = get_channel_layer()
+        await channel_layer.group_send(
+            f"feed_org_{org.id}",
+            {"type": "feed_event", "data": {"event": "org_wide"}},
+        )
+
+        assert await comm_1.receive_json_from() == {"event": "org_wide"}
+        assert await comm_2.receive_json_from() == {"event": "org_wide"}
+        assert await comm_outsider.receive_nothing(timeout=0.2)
+
+        await comm_1.disconnect()
+        await comm_2.disconnect()
+        await comm_outsider.disconnect()

--- a/backend/apps/notifications/middleware.py
+++ b/backend/apps/notifications/middleware.py
@@ -22,6 +22,23 @@ def get_user_from_token(token_key):
         return AnonymousUser()
 
 
+def get_token_expiry(token_key):
+    """
+    Returns the token's expiry as a POSIX timestamp (float), or None if the
+    token is missing/invalid. Kept synchronous + side-effect free so it's
+    cheap to call from the async middleware without a thread hop.
+    """
+    if not token_key:
+        return None
+    try:
+        from rest_framework_simplejwt.tokens import AccessToken
+
+        token = AccessToken(token_key)
+        return float(token["exp"])
+    except Exception:
+        return None
+
+
 class JWTAuthMiddleware:
     """ASGI middleware: attaches an authenticated user to the scope."""
 
@@ -38,5 +55,10 @@ class JWTAuthMiddleware:
             scope["user"] = (
                 await get_user_from_token(token) if token else AnonymousUser()
             )
+            # Attaches when the current token expires (POSIX timestamp) so
+            # long-lived WebSocket consumers (e.g. FeedConsumer) can close
+            # gracefully near expiry instead of the client silently losing
+            # events after the token dies.
+            scope["token_expires_at"] = get_token_expiry(token)
 
         return await self.inner(scope, receive, send)

--- a/backend/config/asgi.py
+++ b/backend/config/asgi.py
@@ -19,6 +19,7 @@ django_asgi_app = get_asgi_application()
 
 from apps.chat.routing import websocket_urlpatterns as chat_ws  # noqa: E402
 from apps.dashboard.routing import websocket_urlpatterns as dashboard_ws  # noqa: E402
+from apps.feed.routing import websocket_urlpatterns as feed_ws  # noqa: E402
 from apps.notifications.middleware import JWTAuthMiddleware  # noqa: E402
 from apps.notifications.routing import (  # noqa: E402
     websocket_urlpatterns as notifications_ws,
@@ -27,7 +28,10 @@ from apps.sandbox.routing import websocket_urlpatterns as sandbox_ws  # noqa: E4
 
 # Combine all WebSocket patterns across the platform modules
 # Including dashboard_ws which handles real-time metric distributions
-combined_websocket_urlpatterns = notifications_ws + dashboard_ws + chat_ws + sandbox_ws
+# Including feed_ws — previously omitted, meaning ws/feed/ was unroutable
+combined_websocket_urlpatterns = (
+    notifications_ws + dashboard_ws + chat_ws + sandbox_ws + feed_ws
+)
 
 from apps.chat.middleware import ProfanityFilterMiddleware
 from apps.core.middleware import WebSocketRateLimitMiddleware


### PR DESCRIPTION
## Description

`FeedConsumer.connect()` accepted every WebSocket connection with no authentication and immediately joined a single global "feed" group, meaning any client — authenticated or not — would receive every feed event broadcast platform-wide.

This PR adds JWT auth (reusing the existing `JWTAuthMiddleware` already used by `NotificationConsumer`), replaces the global group with per-user (`feed_user_<id>`) and per-organization (`feed_org_<id>`) groups, handles token-expiry-driven reconnection, and adds rate limiting via the platform's existing per-IP WebSocket rate limiter.

**Note beyond the issue's listed files:** `config/asgi.py` never actually included `apps.feed.routing.websocket_urlpatterns` in `combined_websocket_urlpatterns`, so `ws/feed/` was completely unroutable before this change — I had to fix that for this PR to have any effect. Flagging it explicitly since it wasn't in the original file list.

Closes #1731 

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update (no code changes)
- [ ] ⚙️ CI/CD or build pipeline change
- [ ] ⚡ Performance optimization
- [ ] 🛠️ Refactoring (no functional changes)

## How Has This Been Tested?

### Automated Tests
- [x] Backend tests pass: `cd backend && pytest`
- [ ] Frontend tests pass: `cd frontend && npm run test`
- [ ] Frontend builds successfully: `cd frontend && npm run build`

### Manual Verification
- Verified rejected connections via `wscat` with no/invalid token
- Verified `group_send` to `feed_user_<id>` only reaches that user
- Verified `group_send` to `feed_org_<id>` reaches all org members only
- Verified full `pytest` suite still passes after the `asgi.py` change

## Pre-Push Checklist

> [!IMPORTANT]
> **All items below must be checked before requesting a review.** Our CI bot will automatically run the frontend build and backend tests on your PR. If CI fails, you will receive a comment explaining what went wrong.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or console errors
- [ ] I have run `npm run build` in `frontend/` and it completes with **0 errors**
- [x] I have run `pytest` in `backend/` and all tests pass
- [x] I have run `git diff` locally and verified my changes

Backend only

## Deployment Notes

> [!NOTE]
> This project is deployed on **Vercel** (Frontend) and **Hugging Face** (Backend). The CI workflow simulates both deployment environments. If your PR passes CI, it is safe to merge.

No new environment variables. No migrations. `config/asgi.py` changed — worth a quick smoke test against the Daphne/ASGI process in staging before promoting, since it affects the WebSocket router directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an authenticated real-time activity feed over WebSockets.
  - Activity updates are scoped to individual users and their organizations.
  - Added keep-alive ping and pong messaging.
  - Connections now close automatically when authentication tokens expire.
  - Enabled routing for the activity feed WebSocket endpoint.

- **Bug Fixes**
  - Prevented unauthenticated or invalid-token connections.
  - Ensured activity events are not delivered outside their intended scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->