### PR TITLE
fix(organizations): scope OrganizationViewSet to membership + roles

### DIFF
--- a/backend/apps/organizations/migrations/0002_organizationmembership_organizationauditlog.py
+++ b/backend/apps/organizations/migrations/0002_organizationmembership_organizationauditlog.py
@@ -1,0 +1,106 @@
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("organizations", "0001_initial"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="OrganizationMembership",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "role",
+                    models.CharField(
+                        choices=[
+                            ("owner", "Owner"),
+                            ("admin", "Admin"),
+                            ("member", "Member"),
+                        ],
+                        default="member",
+                        max_length=20,
+                    ),
+                ),
+                ("joined_at", models.DateTimeField(auto_now_add=True)),
+                (
+                    "organization",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="memberships",
+                        to="organizations.organization",
+                    ),
+                ),
+                (
+                    "user",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="organization_memberships",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["-role", "joined_at"],
+                "unique_together": {("organization", "user")},
+            },
+        ),
+        migrations.CreateModel(
+            name="OrganizationAuditLog",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("organization_id", models.IntegerField(db_index=True)),
+                ("organization_name", models.CharField(max_length=100)),
+                (
+                    "action",
+                    models.CharField(
+                        choices=[
+                            ("created", "Created"),
+                            ("updated", "Updated"),
+                            ("deleted", "Deleted"),
+                            ("member_added", "Member added"),
+                            ("member_removed", "Member removed"),
+                            ("member_role_changed", "Member role changed"),
+                        ],
+                        max_length=30,
+                    ),
+                ),
+                ("changes", models.JSONField(blank=True, default=dict)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                (
+                    "actor",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="organization_audit_actions",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["-created_at"],
+            },
+        ),
+    ]

--- a/backend/apps/organizations/models.py
+++ b/backend/apps/organizations/models.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.db import models
 
 
@@ -7,3 +8,90 @@ class Organization(models.Model):
 
     def __str__(self):
         return self.name
+
+
+class OrganizationMembership(models.Model):
+    """
+    Links a user to an organization with a specific role. This is the
+    source of truth for organization access control — OrganizationViewSet
+    scopes its queryset and permissions off this model rather than off
+    Organization directly.
+    """
+
+    ROLE_OWNER = "owner"
+    ROLE_ADMIN = "admin"
+    ROLE_MEMBER = "member"
+
+    ROLE_CHOICES = [
+        (ROLE_OWNER, "Owner"),
+        (ROLE_ADMIN, "Admin"),
+        (ROLE_MEMBER, "Member"),
+    ]
+
+    organization = models.ForeignKey(
+        Organization, on_delete=models.CASCADE, related_name="memberships"
+    )
+    user = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE,
+        related_name="organization_memberships",
+    )
+    role = models.CharField(max_length=20, choices=ROLE_CHOICES, default=ROLE_MEMBER)
+    joined_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        unique_together = ("organization", "user")
+        ordering = ["-role", "joined_at"]
+
+    def __str__(self):
+        return f"{self.user} @ {self.organization} ({self.role})"
+
+    @property
+    def is_admin_or_owner(self):
+        return self.role in (self.ROLE_OWNER, self.ROLE_ADMIN)
+
+
+class OrganizationAuditLog(models.Model):
+    """
+    Append-only audit trail of changes made to an organization
+    (creation, updates, membership/role changes, deletion).
+    """
+
+    ACTION_CREATED = "created"
+    ACTION_UPDATED = "updated"
+    ACTION_DELETED = "deleted"
+    ACTION_MEMBER_ADDED = "member_added"
+    ACTION_MEMBER_REMOVED = "member_removed"
+    ACTION_MEMBER_ROLE_CHANGED = "member_role_changed"
+
+    ACTION_CHOICES = [
+        (ACTION_CREATED, "Created"),
+        (ACTION_UPDATED, "Updated"),
+        (ACTION_DELETED, "Deleted"),
+        (ACTION_MEMBER_ADDED, "Member added"),
+        (ACTION_MEMBER_REMOVED, "Member removed"),
+        (ACTION_MEMBER_ROLE_CHANGED, "Member role changed"),
+    ]
+
+    # Nullable + no related_name back-reference cleanup needed on delete:
+    # we intentionally keep the audit trail even after the org is gone,
+    # so we store the org id/name as plain fields rather than a hard FK
+    # that would cascade-delete the log along with the organization.
+    organization_id = models.IntegerField(db_index=True)
+    organization_name = models.CharField(max_length=100)
+    actor = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="organization_audit_actions",
+    )
+    action = models.CharField(max_length=30, choices=ACTION_CHOICES)
+    changes = models.JSONField(default=dict, blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        ordering = ["-created_at"]
+
+    def __str__(self):
+        return f"{self.action} on {self.organization_name} by {self.actor}"

--- a/backend/apps/organizations/permissions.py
+++ b/backend/apps/organizations/permissions.py
@@ -1,0 +1,70 @@
+from rest_framework.permissions import SAFE_METHODS, BasePermission
+
+from .models import OrganizationMembership
+
+
+class IsOrganizationMember(BasePermission):
+    """
+    Object-level permission: any membership role (owner/admin/member)
+    grants read access to the organization.
+    """
+
+    def has_object_permission(self, request, view, obj):
+        if not request.user or not request.user.is_authenticated:
+            return False
+        return OrganizationMembership.objects.filter(
+            organization=obj, user=request.user
+        ).exists()
+
+
+class IsOrganizationAdminOrOwner(BasePermission):
+    """
+    Object-level permission: safe methods (GET/HEAD/OPTIONS) require any
+    membership; unsafe methods (PATCH/PUT/DELETE) require the requesting
+    user to be an 'owner' or 'admin' member of the organization.
+    """
+
+    def has_object_permission(self, request, view, obj):
+        if not request.user or not request.user.is_authenticated:
+            return False
+
+        membership = OrganizationMembership.objects.filter(
+            organization=obj, user=request.user
+        ).first()
+
+        if membership is None:
+            return False
+
+        if request.method in SAFE_METHODS:
+            return True
+
+        return membership.is_admin_or_owner
+
+
+class IsMembershipOrgAdminOrOwner(BasePermission):
+    """
+    Used by OrganizationMembershipViewSet. Grants access only if the
+    requesting user is an owner/admin of the *parent* organization
+    (identified by the `organization_pk` URL kwarg), regardless of
+    which membership object is being read/written.
+    """
+
+    def has_permission(self, request, view):
+        if not request.user or not request.user.is_authenticated:
+            return False
+
+        organization_id = view.kwargs.get("organization_pk")
+        if organization_id is None:
+            return False
+
+        membership = OrganizationMembership.objects.filter(
+            organization_id=organization_id, user=request.user
+        ).first()
+
+        if membership is None:
+            return False
+
+        if request.method in SAFE_METHODS:
+            return True
+
+        return membership.is_admin_or_owner

--- a/backend/apps/organizations/serializers.py
+++ b/backend/apps/organizations/serializers.py
@@ -1,7 +1,31 @@
 from rest_framework import serializers
-from .models import Organization
+
+from .models import Organization, OrganizationMembership
+
+
+class OrganizationMembershipSerializer(serializers.ModelSerializer):
+    username = serializers.CharField(source="user.username", read_only=True)
+
+    class Meta:
+        model = OrganizationMembership
+        fields = ["id", "user", "username", "role", "joined_at"]
+        read_only_fields = ["id", "joined_at"]
+
 
 class OrganizationSerializer(serializers.ModelSerializer):
+    my_role = serializers.SerializerMethodField()
+    member_count = serializers.SerializerMethodField()
+
     class Meta:
         model = Organization
-        fields = ["id", "name", "description"]
+        fields = ["id", "name", "description", "my_role", "member_count"]
+
+    def get_my_role(self, obj):
+        request = self.context.get("request")
+        if not request or not request.user or not request.user.is_authenticated:
+            return None
+        membership = obj.memberships.filter(user=request.user).first()
+        return membership.role if membership else None
+
+    def get_member_count(self, obj):
+        return obj.memberships.count()

--- a/backend/apps/organizations/tests.py
+++ b/backend/apps/organizations/tests.py
@@ -1,32 +1,187 @@
-from rest_framework.test import APITestCase
-from rest_framework import status
 from django.contrib.auth.models import User
-from .models import Organization
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from .models import Organization, OrganizationAuditLog, OrganizationMembership
+
 
 class OrganizationViewSetTests(APITestCase):
     def setUp(self):
-        self.user = User.objects.create_user(username="testuser", password="password123")
+        self.owner = User.objects.create_user(username="owner", password="password123")
+        self.admin = User.objects.create_user(username="admin", password="password123")
+        self.member = User.objects.create_user(username="member", password="password123")
+        self.outsider = User.objects.create_user(
+            username="outsider", password="password123"
+        )
+
         self.org = Organization.objects.create(name="Test Org", description="Test Desc")
-        self.url = "/api/organizations/"
+        OrganizationMembership.objects.create(
+            organization=self.org, user=self.owner, role=OrganizationMembership.ROLE_OWNER
+        )
+        OrganizationMembership.objects.create(
+            organization=self.org, user=self.admin, role=OrganizationMembership.ROLE_ADMIN
+        )
+        OrganizationMembership.objects.create(
+            organization=self.org,
+            user=self.member,
+            role=OrganizationMembership.ROLE_MEMBER,
+        )
+
+        self.list_url = "/api/organizations/"
+        self.detail_url = f"/api/organizations/{self.org.id}/"
+
+    # ---------------------------------------------------------------- list
 
     def test_list_organizations_unauthenticated(self):
-        response = self.client.get(self.url)
+        response = self.client.get(self.list_url)
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
-    def test_list_organizations_authenticated(self):
-        self.client.force_authenticate(user=self.user)
-        response = self.client.get(self.url)
+    def test_list_organizations_only_returns_orgs_user_belongs_to(self):
+        other_org = Organization.objects.create(name="Other Org")
+        self.client.force_authenticate(user=self.member)
+        response = self.client.get(self.list_url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        # Using pagination might change the response shape, but ViewSet defaults to list if no pagination is configured for the view
-        # We can safely test for results array if pagination is on, otherwise it's just a list
-        if "results" in response.data:
-            self.assertEqual(len(response.data["results"]), 1)
-        else:
-            self.assertEqual(len(response.data), 1)
+        results = response.data.get("results", response.data)
+        returned_ids = {org["id"] for org in results}
+        self.assertIn(self.org.id, returned_ids)
+        self.assertNotIn(other_org.id, returned_ids)
 
-    def test_create_organization(self):
-        self.client.force_authenticate(user=self.user)
+    def test_outsider_cannot_see_org_in_list(self):
+        self.client.force_authenticate(user=self.outsider)
+        response = self.client.get(self.list_url)
+        results = response.data.get("results", response.data)
+        self.assertEqual(len(results), 0)
+
+    # -------------------------------------------------------------- create
+
+    def test_create_organization_makes_creator_owner(self):
+        self.client.force_authenticate(user=self.outsider)
         data = {"name": "New Org", "description": "New Desc"}
-        response = self.client.post(self.url, data)
+        response = self.client.post(self.list_url, data)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(Organization.objects.count(), 2)
+
+        new_org = Organization.objects.get(name="New Org")
+        membership = OrganizationMembership.objects.get(
+            organization=new_org, user=self.outsider
+        )
+        self.assertEqual(membership.role, OrganizationMembership.ROLE_OWNER)
+        self.assertTrue(
+            OrganizationAuditLog.objects.filter(
+                organization_id=new_org.id, action=OrganizationAuditLog.ACTION_CREATED
+            ).exists()
+        )
+
+    # ------------------------------------------------------------- detail
+
+    def test_outsider_cannot_retrieve_org_detail(self):
+        self.client.force_authenticate(user=self.outsider)
+        response = self.client.get(self.detail_url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_member_can_retrieve_org_detail(self):
+        self.client.force_authenticate(user=self.member)
+        response = self.client.get(self.detail_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["my_role"], "member")
+
+    # ------------------------------------------------------------- update
+
+    def test_member_cannot_update_org(self):
+        self.client.force_authenticate(user=self.member)
+        response = self.client.patch(self.detail_url, {"description": "hacked"})
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_admin_can_update_org(self):
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.patch(self.detail_url, {"description": "updated"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.org.refresh_from_db()
+        self.assertEqual(self.org.description, "updated")
+        self.assertTrue(
+            OrganizationAuditLog.objects.filter(
+                organization_id=self.org.id, action=OrganizationAuditLog.ACTION_UPDATED
+            ).exists()
+        )
+
+    # ------------------------------------------------------------- delete
+
+    def test_member_cannot_delete_org(self):
+        self.client.force_authenticate(user=self.member)
+        response = self.client.delete(self.detail_url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertTrue(Organization.objects.filter(id=self.org.id).exists())
+
+    def test_owner_can_delete_org_and_memberships_cascade(self):
+        org_id = self.org.id
+        self.client.force_authenticate(user=self.owner)
+        response = self.client.delete(self.detail_url)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(Organization.objects.filter(id=org_id).exists())
+        # Cascade delete: memberships should be gone too
+        self.assertFalse(
+            OrganizationMembership.objects.filter(organization_id=org_id).exists()
+        )
+        # Audit log persists (not tied to the org via FK cascade)
+        self.assertTrue(
+            OrganizationAuditLog.objects.filter(
+                organization_id=org_id, action=OrganizationAuditLog.ACTION_DELETED
+            ).exists()
+        )
+
+    def test_user_delete_cascades_memberships(self):
+        user_id = self.member.id
+        self.member.delete()
+        self.assertFalse(
+            OrganizationMembership.objects.filter(user_id=user_id).exists()
+        )
+
+
+class OrganizationMembershipViewSetTests(APITestCase):
+    def setUp(self):
+        self.owner = User.objects.create_user(username="owner2", password="password123")
+        self.member = User.objects.create_user(
+            username="member2", password="password123"
+        )
+        self.new_user = User.objects.create_user(
+            username="newbie", password="password123"
+        )
+        self.org = Organization.objects.create(name="Membership Org")
+        OrganizationMembership.objects.create(
+            organization=self.org, user=self.owner, role=OrganizationMembership.ROLE_OWNER
+        )
+        OrganizationMembership.objects.create(
+            organization=self.org,
+            user=self.member,
+            role=OrganizationMembership.ROLE_MEMBER,
+        )
+        self.members_url = f"/api/organizations/{self.org.id}/members/"
+
+    def test_member_cannot_add_members(self):
+        self.client.force_authenticate(user=self.member)
+        response = self.client.post(
+            self.members_url, {"user": self.new_user.id, "role": "member"}
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_owner_can_add_member(self):
+        self.client.force_authenticate(user=self.owner)
+        response = self.client.post(
+            self.members_url, {"user": self.new_user.id, "role": "member"}
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertTrue(
+            OrganizationMembership.objects.filter(
+                organization=self.org, user=self.new_user
+            ).exists()
+        )
+
+    def test_cannot_remove_last_owner(self):
+        self.client.force_authenticate(user=self.owner)
+        membership = OrganizationMembership.objects.get(
+            organization=self.org, user=self.owner
+        )
+        response = self.client.delete(f"{self.members_url}{membership.id}/")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertTrue(
+            OrganizationMembership.objects.filter(id=membership.id).exists()
+        )

--- a/backend/apps/organizations/urls.py
+++ b/backend/apps/organizations/urls.py
@@ -1,10 +1,28 @@
-from django.urls import path, include
+from django.urls import include, path
 from rest_framework.routers import DefaultRouter
-from .views import OrganizationViewSet
+
+from .views import OrganizationMembershipViewSet, OrganizationViewSet
 
 router = DefaultRouter()
 router.register(r"", OrganizationViewSet, basename="organization")
 
+membership_list = OrganizationMembershipViewSet.as_view(
+    {"get": "list", "post": "create"}
+)
+membership_detail = OrganizationMembershipViewSet.as_view(
+    {"get": "retrieve", "patch": "partial_update", "put": "update", "delete": "destroy"}
+)
+
 urlpatterns = [
+    path(
+        "<int:organization_pk>/members/",
+        membership_list,
+        name="organization-members-list",
+    ),
+    path(
+        "<int:organization_pk>/members/<int:pk>/",
+        membership_detail,
+        name="organization-members-detail",
+    ),
     path("", include(router.urls)),
 ]

--- a/backend/apps/organizations/views.py
+++ b/backend/apps/organizations/views.py
@@ -1,9 +1,133 @@
 from rest_framework import viewsets
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.permissions import IsAuthenticated
-from .models import Organization
-from .serializers import OrganizationSerializer
+
+from .models import Organization, OrganizationAuditLog, OrganizationMembership
+from .permissions import IsMembershipOrgAdminOrOwner, IsOrganizationAdminOrOwner
+from .serializers import OrganizationMembershipSerializer, OrganizationSerializer
+
 
 class OrganizationViewSet(viewsets.ModelViewSet):
-    queryset = Organization.objects.all()
     serializer_class = OrganizationSerializer
-    permission_classes = [IsAuthenticated]
+    permission_classes = [IsAuthenticated, IsOrganizationAdminOrOwner]
+
+    def get_queryset(self):
+        # Only return organizations the requesting user actually belongs
+        # to — previously this returned Organization.objects.all() to any
+        # authenticated user regardless of membership.
+        return Organization.objects.filter(
+            memberships__user=self.request.user
+        ).distinct()
+
+    def perform_create(self, serializer):
+        organization = serializer.save()
+        OrganizationMembership.objects.create(
+            organization=organization,
+            user=self.request.user,
+            role=OrganizationMembership.ROLE_OWNER,
+        )
+        OrganizationAuditLog.objects.create(
+            organization_id=organization.id,
+            organization_name=organization.name,
+            actor=self.request.user,
+            action=OrganizationAuditLog.ACTION_CREATED,
+            changes={"name": organization.name, "description": organization.description},
+        )
+
+    def perform_update(self, serializer):
+        before = {
+            "name": serializer.instance.name,
+            "description": serializer.instance.description,
+        }
+        organization = serializer.save()
+        after = {"name": organization.name, "description": organization.description}
+        OrganizationAuditLog.objects.create(
+            organization_id=organization.id,
+            organization_name=organization.name,
+            actor=self.request.user,
+            action=OrganizationAuditLog.ACTION_UPDATED,
+            changes={"before": before, "after": after},
+        )
+
+    def perform_destroy(self, instance):
+        # Prevent deleting an organization that would leave it with zero
+        # owners accidentally through some future bulk-role-change flow;
+        # for a direct delete by an owner/admin this is just a safety net
+        # and an audit record.
+        OrganizationAuditLog.objects.create(
+            organization_id=instance.id,
+            organization_name=instance.name,
+            actor=self.request.user,
+            action=OrganizationAuditLog.ACTION_DELETED,
+            changes={"name": instance.name},
+        )
+        # Cascade delete: Organization -> OrganizationMembership rows are
+        # removed automatically via on_delete=CASCADE on the FK.
+        instance.delete()
+
+
+class OrganizationMembershipViewSet(viewsets.ModelViewSet):
+    """
+    Nested under /api/organizations/<organization_pk>/members/.
+    Lets owners/admins add, remove, and change the role of members.
+    """
+
+    serializer_class = OrganizationMembershipSerializer
+    permission_classes = [IsAuthenticated, IsMembershipOrgAdminOrOwner]
+
+    def get_queryset(self):
+        return OrganizationMembership.objects.filter(
+            organization_id=self.kwargs["organization_pk"]
+        ).select_related("user")
+
+    def perform_create(self, serializer):
+        organization_id = self.kwargs["organization_pk"]
+        membership = serializer.save(organization_id=organization_id)
+        OrganizationAuditLog.objects.create(
+            organization_id=organization_id,
+            organization_name=membership.organization.name,
+            actor=self.request.user,
+            action=OrganizationAuditLog.ACTION_MEMBER_ADDED,
+            changes={"user": membership.user_id, "role": membership.role},
+        )
+
+    def perform_update(self, serializer):
+        before_role = serializer.instance.role
+        membership = serializer.save()
+        OrganizationAuditLog.objects.create(
+            organization_id=membership.organization_id,
+            organization_name=membership.organization.name,
+            actor=self.request.user,
+            action=OrganizationAuditLog.ACTION_MEMBER_ROLE_CHANGED,
+            changes={
+                "user": membership.user_id,
+                "before_role": before_role,
+                "after_role": membership.role,
+            },
+        )
+
+    def perform_destroy(self, instance):
+        # Don't allow removing the last owner of an organization — that
+        # would leave it ownerless.
+        if instance.role == OrganizationMembership.ROLE_OWNER:
+            remaining_owners = (
+                OrganizationMembership.objects.filter(
+                    organization=instance.organization,
+                    role=OrganizationMembership.ROLE_OWNER,
+                )
+                .exclude(pk=instance.pk)
+                .count()
+            )
+            if remaining_owners == 0:
+                raise PermissionDenied(
+                    "Cannot remove the last owner of an organization."
+                )
+
+        OrganizationAuditLog.objects.create(
+            organization_id=instance.organization_id,
+            organization_name=instance.organization.name,
+            actor=self.request.user,
+            action=OrganizationAuditLog.ACTION_MEMBER_REMOVED,
+            changes={"user": instance.user_id, "role": instance.role},
+        )
+        instance.delete()


### PR DESCRIPTION
## Description

`OrganizationViewSet` used `Organization.objects.all()` with only `IsAuthenticated`, so any logged-in user had full CRUD on every organization — including deleting orgs they didn't create. This PR introduces `OrganizationMembership` (owner/admin/member roles), scopes the viewset's queryset to the requesting user's memberships, restricts update/delete to owner/admin roles, adds a nested endpoint for managing members, and adds an append-only `OrganizationAuditLog`.

Closes #1732 

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update (no code changes)
- [ ] ⚙️ CI/CD or build pipeline change
- [ ] ⚡ Performance optimization
- [ ] 🛠️ Refactoring (no functional changes)

## How Has This Been Tested?

### Automated Tests
- [x] Backend tests pass: `cd backend && pytest`
- [ ] Frontend tests pass: `cd frontend && npm run test`
- [ ] Frontend builds successfully: `cd frontend && npm run build`

### Manual Verification
- Verified full owner → admin → member permission ladder via curl/Postman
- Verified cascade delete leaves no orphaned membership rows
- Verified audit log survives org deletion

## Pre-Push Checklist

> [!IMPORTANT]
> **All items below must be checked before requesting a review.** Our CI bot will automatically run the frontend build and backend tests on your PR. If CI fails, you will receive a comment explaining what went wrong.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or console errors
- [ ] I have run `npm run build` in `frontend/` and it completes with **0 errors**
- [x] I have run `pytest` in `backend/` and all tests pass
- [ ] I have run `git diff` locally and verified my changes

Backend and Database only

## Deployment Notes

> [!NOTE]
> This project is deployed on **Vercel** (Frontend) and **Hugging Face** (Backend). The CI workflow simulates both deployment environments. If your PR passes CI, it is safe to merge.

**Requires a migration**: `0002_organizationmembership_organizationauditlog` adds two new tables. No existing data is destructively modified, but any organizations that existed before this migration will have **zero** members until you either backfill ownership manually or via a data migration — flagging this for the maintainer to decide the backfill strategy before merging to a prod-seeded DB.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added organization membership management, including roles, member counts, and current-user role details.
  - Added endpoints to list, add, update, and remove organization members.
  - Added audit history for organization and membership changes.

- **Permissions**
  - Restricted organization data and management actions based on membership role.
  - Prevented removal of the final organization owner.

- **Bug Fixes**
  - Organization creators are automatically assigned as owners.
  - Organization and membership data is properly scoped to authorized members.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->