### PR TITLE
feat: implement cache-backed circuit breaker for external calls

### DIFF
--- a/backend/apps/accounts/views.py
+++ b/backend/apps/accounts/views.py
@@ -362,57 +362,62 @@ class GitHubOAuthCallbackView(APIView):
 
         callback_url = request.build_absolute_uri("/api/auth/github/callback/")
 
+        from apps.core.resilience import CircuitBreaker, CircuitOpenError
+
+        cb = CircuitBreaker("github_oauth", failure_threshold=5, recovery_timeout=30)
         try:
-            token_response = http_requests.post(
-                "https://github.com/login/oauth/access_token",
-                headers={"Accept": "application/json"},
-                data={
-                    "client_id": client_id,
-                    "client_secret": client_secret,
-                    "code": code,
-                    "redirect_uri": callback_url,
-                },
-                timeout=10,
-            )
-            token_response.raise_for_status()
-            access_token = token_response.json().get(
-                "access_token"
-            ) or token_response.json().get("access")
-            if not access_token:
-                return redirect(
-                    frontend_url(
-                        "/", {"auth_error": "GitHub did not return an access token."}
+            with cb:
+                token_response = http_requests.post(
+                    "https://github.com/login/oauth/access_token",
+                    headers={"Accept": "application/json"},
+                    data={
+                        "client_id": client_id,
+                        "client_secret": client_secret,
+                        "code": code,
+                        "redirect_uri": callback_url,
+                    },
+                    timeout=5,
+                )
+                token_response.raise_for_status()
+                access_token = token_response.json().get(
+                    "access_token"
+                ) or token_response.json().get("access")
+                if not access_token:
+                    return redirect(
+                        frontend_url(
+                            "/",
+                            {"auth_error": "GitHub did not return an access token."},
+                        )
                     )
-                )
 
-            github_headers = {
-                "Authorization": f"Bearer {access_token}",
-                "Accept": "application/vnd.github+json",
-            }
-            user_response = http_requests.get(
-                "https://api.github.com/user", headers=github_headers, timeout=10
-            )
-            user_response.raise_for_status()
-            github_user = user_response.json()
+                github_headers = {
+                    "Authorization": f"Bearer {access_token}",
+                    "Accept": "application/vnd.github+json",
+                }
+                user_response = http_requests.get(
+                    "https://api.github.com/user", headers=github_headers, timeout=5
+                )
+                user_response.raise_for_status()
+                github_user = user_response.json()
 
-            email = github_user.get("email")
-            if not email:
-                email_response = http_requests.get(
-                    "https://api.github.com/user/emails",
-                    headers=github_headers,
-                    timeout=10,
-                )
-                email_response.raise_for_status()
-                emails = email_response.json()
-                primary_email = next(
-                    (
-                        item
-                        for item in emails
-                        if item.get("primary") and item.get("verified")
-                    ),
-                    None,
-                )
-                email = primary_email.get("email") if primary_email else None
+                email = github_user.get("email")
+                if not email:
+                    email_response = http_requests.get(
+                        "https://api.github.com/user/emails",
+                        headers=github_headers,
+                        timeout=5,
+                    )
+                    email_response.raise_for_status()
+                    emails = email_response.json()
+                    primary_email = next(
+                        (
+                            item
+                            for item in emails
+                            if item.get("primary") and item.get("verified")
+                        ),
+                        None,
+                    )
+                    email = primary_email.get("email") if primary_email else None
 
             if not email:
                 return redirect(
@@ -449,6 +454,15 @@ class GitHubOAuthCallbackView(APIView):
                     {
                         "access": str(refresh.access_token),
                         "refresh": str(refresh),
+                    },
+                )
+            )
+        except CircuitOpenError:
+            return redirect(
+                frontend_url(
+                    "/",
+                    {
+                        "auth_error": "GitHub authentication service is temporarily unavailable."
                     },
                 )
             )

--- a/backend/apps/core/resilience.py
+++ b/backend/apps/core/resilience.py
@@ -1,0 +1,89 @@
+import logging
+import time
+
+from django.core.cache import cache
+
+logger = logging.getLogger(__name__)
+
+
+class CircuitOpenError(Exception):
+    """Exception raised when the circuit breaker is open."""
+
+    pass
+
+
+class CircuitBreaker:
+    """
+    Cache-backed thread-safe Circuit Breaker for fault isolation.
+    """
+
+    def __init__(
+        self, service_name: str, failure_threshold: int = 5, recovery_timeout: int = 30
+    ):
+        self.service_name = service_name
+        self.failure_threshold = failure_threshold
+        self.recovery_timeout = recovery_timeout
+        self.state_key = f"cb:{service_name}:state"
+        self.failures_key = f"cb:{service_name}:failures"
+        self.opened_at_key = f"cb:{service_name}:opened_at"
+
+    def get_state(self) -> str:
+        state = cache.get(self.state_key, "closed")
+        if state == "open":
+            opened_at = cache.get(self.opened_at_key)
+            if opened_at and (time.time() - opened_at > self.recovery_timeout):
+                # Transition to half-open
+                self.set_state("half_open")
+                return "half_open"
+        return state
+
+    def set_state(self, state: str):
+        cache.set(self.state_key, state, timeout=None)
+        if state == "open":
+            cache.set(
+                self.opened_at_key, time.time(), timeout=self.recovery_timeout * 2
+            )
+        elif state == "closed":
+            cache.delete(self.opened_at_key)
+            cache.delete(self.failures_key)
+
+    def record_success(self):
+        state = cache.get(self.state_key, "closed")
+        if state == "half_open":
+            logger.info(
+                f"Circuit breaker for service '{self.service_name}' closed after successful trial."
+            )
+            self.set_state("closed")
+        else:
+            cache.delete(self.failures_key)
+
+    def record_failure(self):
+        try:
+            failures = cache.get(self.failures_key, 0)
+        except Exception:
+            failures = 0
+        failures += 1
+        cache.set(self.failures_key, failures, timeout=self.recovery_timeout * 2)
+
+        state = self.get_state()
+        if state == "half_open" or failures >= self.failure_threshold:
+            logger.warning(
+                f"Circuit breaker for service '{self.service_name}' opened (failures: {failures})."
+            )
+            self.set_state("open")
+
+    def __enter__(self):
+        state = self.get_state()
+        if state == "open":
+            raise CircuitOpenError(
+                f"Circuit for service '{self.service_name}' is currently open."
+            )
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if exc_type is not None:
+            if not issubclass(exc_type, CircuitOpenError):
+                self.record_failure()
+        else:
+            self.record_success()
+        return False

--- a/backend/apps/core/tests.py
+++ b/backend/apps/core/tests.py
@@ -1,12 +1,13 @@
-from django.test import TestCase, override_settings
-from django.utils import timezone
 from datetime import timedelta
-from apps.core.models import PurgeLog
-from apps.dashboard.models import Issue
+from unittest.mock import patch
+
 from django.contrib.auth import get_user_model
 from django.core.cache import caches
+from django.test import TestCase, override_settings
+from django.utils import timezone
 
-from unittest.mock import patch
+from apps.core.models import PurgeLog
+from apps.dashboard.models import Issue
 
 User = get_user_model()
 
@@ -26,6 +27,7 @@ User = get_user_model()
 class MultiLevelCacheTests(TestCase):
     def setUp(self):
         from apps.core.cache import MultiLevelCache
+
         self.cache = MultiLevelCache()
         caches["default"].clear()
         caches["l1_memory"].clear()
@@ -139,3 +141,73 @@ class SoftDeleteFrameworkTests(TestCase):
         # Issue should NOT be deleted
         self.assertEqual(Issue.all_objects.count(), 1)
         self.assertEqual(Issue.deleted_objects.count(), 1)
+
+
+class CircuitBreakerTests(TestCase):
+    def setUp(self):
+        from django.core.cache import cache
+
+        cache.clear()
+
+    def test_circuit_breaker_success_flow(self):
+        from apps.core.resilience import CircuitBreaker
+
+        cb = CircuitBreaker("test_service", failure_threshold=3, recovery_timeout=2)
+
+        # Should be closed initially
+        self.assertEqual(cb.get_state(), "closed")
+
+        with cb:
+            # Do nothing, should count as success
+            pass
+
+        self.assertEqual(cb.get_state(), "closed")
+
+    def test_circuit_breaker_failure_flow_and_open(self):
+        from apps.core.resilience import CircuitBreaker, CircuitOpenError
+
+        cb = CircuitBreaker("test_service", failure_threshold=3, recovery_timeout=2)
+
+        for _ in range(3):
+            try:
+                with cb:
+                    raise ValueError("Fail")
+            except ValueError:
+                pass
+
+        # State should be open now
+        self.assertEqual(cb.get_state(), "open")
+
+        # Subsequent requests should raise CircuitOpenError immediately
+        with self.assertRaises(CircuitOpenError):
+            with cb:
+                pass
+
+    def test_circuit_breaker_recovery_half_open(self):
+        import time
+
+        from apps.core.resilience import CircuitBreaker
+
+        cb = CircuitBreaker("test_service", failure_threshold=2, recovery_timeout=1)
+
+        # Trigger failures to open circuit
+        for _ in range(2):
+            try:
+                with cb:
+                    raise ValueError("Fail")
+            except ValueError:
+                pass
+
+        self.assertEqual(cb.get_state(), "open")
+
+        # Wait for recovery timeout
+        time.sleep(1.1)
+
+        # Should transition to half-open
+        self.assertEqual(cb.get_state(), "half_open")
+
+        # A success should close the circuit
+        with cb:
+            pass
+
+        self.assertEqual(cb.get_state(), "closed")

--- a/backend/apps/webhooks/tasks.py
+++ b/backend/apps/webhooks/tasks.py
@@ -93,22 +93,36 @@ def deliver_webhook(delivery_id, attempt=1):
     delivery.attempt_count = attempt
     delivery.status = "retrying" if attempt > 1 else "pending"
 
+    from apps.core.resilience import CircuitBreaker, CircuitOpenError
+
+    cb = CircuitBreaker(
+        f"webhook:{hashlib.md5(endpoint.target_url.encode('utf-8')).hexdigest()}",
+        failure_threshold=5,
+        recovery_timeout=30,
+    )
+
     try:
-        response = requests.post(
-            endpoint.target_url, json=delivery.payload, headers=headers, timeout=10
-        )
-        delivery.status_code = response.status_code
-        delivery.response_body = response.text[:2000]
+        with cb:
+            response = requests.post(
+                endpoint.target_url, json=delivery.payload, headers=headers, timeout=5
+            )
+            delivery.status_code = response.status_code
+            delivery.response_body = response.text[:2000]
 
-        if 200 <= response.status_code < 300:
-            delivery.status = "success"
-            delivery.next_retry_at = None
-            delivery.save()
-            return
+            if 200 <= response.status_code < 300:
+                delivery.status = "success"
+                delivery.next_retry_at = None
+                delivery.save()
+                return
 
-        # Retryable: rate-limited or server-side errors
-        is_retryable = response.status_code == 429 or response.status_code >= 500
-        failure_reason = f"HTTP {response.status_code}: {response.text[:500]}"
+            # Retryable: rate-limited or server-side errors
+            is_retryable = response.status_code == 429 or response.status_code >= 500
+            failure_reason = f"HTTP {response.status_code}: {response.text[:500]}"
+
+    except CircuitOpenError as exc:
+        is_retryable = True
+        failure_reason = f"Circuit open: {str(exc)}"
+        delivery.response_body = failure_reason
 
     except requests.exceptions.RequestException as exc:
         is_retryable = True
@@ -156,11 +170,15 @@ def replay_delivery(dlq_entry_id: int) -> None:
     delivery.status = "pending"
     delivery.attempt_count = 0
     delivery.next_retry_at = None
-    delivery.save(update_fields=["status", "attempt_count", "next_retry_at", "updated_at"])
+    delivery.save(
+        update_fields=["status", "attempt_count", "next_retry_at", "updated_at"]
+    )
 
     dlq.replayed = True
     dlq.replayed_at = timezone.now()
     dlq.save(update_fields=["replayed", "replayed_at"])
 
     async_task("apps.webhooks.tasks.deliver_webhook", delivery.id, attempt=1)
-    logger.info("Queued replay for DLQ entry %s (delivery %s).", dlq_entry_id, delivery.id)
+    logger.info(
+        "Queued replay for DLQ entry %s (delivery %s).", dlq_entry_id, delivery.id
+    )


### PR DESCRIPTION
## Description

Implemented a cache-backed distributed Circuit Breaker pattern to protect against slow or down external systems (GitHub OAuth APIs and webhook listeners). If an external API is down or slow, the circuit opens, failing requests fast rather than blocking Django request threads or Django Q worker processes.

Fixes #1637

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] ⚡ Performance optimization

## How Has This Been Tested?

### Automated Tests
- [x] Backend tests pass (custom standalone suite tests circuit breaker states: CLOSED -> OPEN -> HALF-OPEN -> CLOSED)

### Manual Verification
- Verified that consecutive failures correctly transition the circuit breaker state and fast-fail subsequent executions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added resilience safeguards for GitHub authentication and webhook delivery.
  - Webhook deliveries can now be marked for retry when the service is temporarily unavailable.
  - Authentication now provides a clear temporary-unavailability message when external services cannot be reached.

- **Bug Fixes**
  - Reduced waiting time for unresponsive external requests.
  - Improved recovery handling for repeated service failures and webhook replay operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->