### PR TITLE
fix(readiness): reconfigure stdout stream encoding to UTF-8 on Windows

### DIFF
--- a/verify_readiness.py
+++ b/verify_readiness.py
@@ -5,10 +5,15 @@ import subprocess
 import shutil
 from pathlib import Path
 
-# Fix terminal encoding issues on Windows
-if sys.platform == "win32":
-    import io
-    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
+# Configure standard streams to use UTF-8 on Windows to prevent UnicodeEncodeError
+try:
+    if sys.platform == "win32":
+        if hasattr(sys.stdout, "reconfigure"):
+            sys.stdout.reconfigure(encoding="utf-8")
+        if hasattr(sys.stderr, "reconfigure"):
+            sys.stderr.reconfigure(encoding="utf-8")
+except Exception:
+    pass
 
 # ANSI Escape Sequences for beautiful terminal outputs
 BLUE = "\033[94m"


### PR DESCRIPTION
### Summary
This PR fixes `verify_readiness.py` Windows compatibility issues. It reconfigures stdout and stderr streams to use UTF-8 encoding, preventing `UnicodeEncodeError` crashes on Windows terminals when printing emojis (e.g., `🚀`).

Fixes #1812

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows output handling to reliably display UTF-8 characters.
  * Prevented encoding setup issues from interrupting readiness verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->