### PR TITLE
fix(graphql): remove duplicate legacy GraphQL route patterns that shadow gateway

### DIFF
--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -86,10 +86,7 @@ urlpatterns = [
         SpectacularSwaggerView.as_view(url_name="schema"),  # Fixed here
         name="swagger-ui",
     ),
-    
-    # ── GraphQL ────────────────────────────────────────────────────────────────
-    path("api/graphql/", csrf_exempt(GraphQLView.as_view(graphiql=True))),
-    
+
     # ── Prometheus Metrics ─────────────────────────────────────────────────────
     path("", include("django_prometheus.urls")),
 
@@ -98,9 +95,6 @@ urlpatterns = [
         SpectacularRedocView.as_view(url_name="schema"),
         name="redoc-ui",
     ),
-    # ── GraphQL ────────────────────────────────────────────────────────────────
-    path("api/graphql/", csrf_exempt(GraphQLView.as_view(graphiql=True))),
-
 ]
 
 # ── Development URLs ──────────────────────────────────────────────────────────


### PR DESCRIPTION
### Summary
This PR cleans up the URL configuration in `backend/config/urls.py` by removing duplicate, redundant legacy `/api/graphql/` mappings that shadowed the new GraphQL Federation Gateway configuration.

Fixes #1814

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected GraphQL API routing to consistently use the current gateway endpoint.
  * Preserved access to the legacy GraphQL interface at its dedicated legacy path.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->