### PR TITLE
Conventional Commit Message Coach

### DIFF
--- a/frontend/src/components/ui/CommitMessageCoach/CommitMessageCoach.tsx
+++ b/frontend/src/components/ui/CommitMessageCoach/CommitMessageCoach.tsx
@@ -1,0 +1,245 @@
+import React, { useMemo, useState } from "react";
+import {
+  CheckCircle2,
+  AlertCircle,
+  Copy,
+  Check,
+  Sparkles,
+  ClipboardList,
+} from "lucide-react";
+import {
+  validateCommitMessage,
+  suggestCommitRewrite,
+  buildPrChecklistTemplate,
+  COMMIT_TYPE_HINTS,
+  ALLOWED_TYPES,
+} from "../../lib/conventionalCommitCoach";
+
+export type CommitMessageCoachProps = {
+  /** Controlled value — when provided, parent owns the message */
+  value?: string;
+  /** Called whenever the message changes */
+  onChange?: (message: string) => void;
+  /** Compact layout for embedding inside simulators */
+  compact?: boolean;
+  className?: string;
+  defaultValue?: string;
+};
+
+export function CommitMessageCoach({
+  value,
+  onChange,
+  compact = false,
+  className = "",
+  defaultValue = "",
+}: CommitMessageCoachProps) {
+  const [internal, setInternal] = useState(defaultValue);
+  const [copiedKey, setCopiedKey] = useState<"message" | "pr" | null>(null);
+
+  const message = value !== undefined ? value : internal;
+
+  const setMessage = (next: string) => {
+    if (value === undefined) setInternal(next);
+    onChange?.(next);
+  };
+
+  const result = useMemo(() => validateCommitMessage(message), [message]);
+  const suggestion = useMemo(() => suggestCommitRewrite(message), [message]);
+  const showSuggestion = message.trim().length > 0 && !result.valid;
+
+  const copyText = async (text: string, key: "message" | "pr") => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopiedKey(key);
+      setTimeout(() => setCopiedKey(null), 2000);
+    } catch {
+      // Clipboard may be unavailable in insecure contexts
+    }
+  };
+
+  return (
+    <div
+      className={`rounded-2xl border-4 border-black bg-white p-4 shadow-card dark:bg-[#1f1c18] dark:border-[#2e2924] dark:shadow-none ${className}`}
+      data-testid="commit-message-coach"
+    >
+      <div className="flex items-start justify-between gap-3 mb-3">
+        <div>
+          <h3 className="text-lg font-black text-text dark:text-[#f0ebe2] flex items-center gap-2">
+            <Sparkles size={18} className="text-accent" aria-hidden />
+            Commit Message Coach
+          </h3>
+          {!compact && (
+            <p className="text-xs font-bold text-muted mt-1 dark:text-[#c4bbae]">
+              Practice Conventional Commits:{" "}
+              <code className="bg-surface-low dark:bg-black px-1 rounded font-mono">
+                type(scope): subject
+              </code>
+            </p>
+          )}
+        </div>
+        {message.trim() && (
+          <span
+            className={`shrink-0 text-[10px] font-black uppercase tracking-widest px-2 py-1 rounded-lg border-2 ${
+              result.valid
+                ? "bg-green-500/15 text-green-700 border-green-600 dark:text-green-400 dark:border-green-500"
+                : "bg-amber-500/15 text-amber-800 border-amber-600 dark:text-amber-300 dark:border-amber-500"
+            }`}
+            aria-live="polite"
+          >
+            {result.valid ? "Valid" : "Needs fixes"}
+          </span>
+        )}
+      </div>
+
+      <label className="block text-sm font-black mb-2 text-text dark:text-[#f0ebe2]">
+        Commit message
+        <input
+          type="text"
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          placeholder="e.g. feat(auth): add password reset flow"
+          className="mt-2 w-full border-4 border-black px-4 py-3 rounded-xl font-mono text-sm bg-white text-black shadow-card-sm dark:bg-[#151411] dark:border-[#2e2924] dark:text-[#f0ebe2] focus:outline-none focus:ring-2 focus:ring-accent"
+          aria-invalid={message.trim().length > 0 && !result.valid}
+          aria-describedby="commit-coach-feedback"
+        />
+      </label>
+
+      <div id="commit-coach-feedback" className="space-y-2 min-h-[1.5rem]">
+        {message.trim().length === 0 && (
+          <p className="text-xs text-muted font-bold dark:text-[#c4bbae]">
+            Tip: allowed types — {ALLOWED_TYPES.join(", ")}
+          </p>
+        )}
+
+        {result.valid && message.trim() && (
+          <div className="flex items-start gap-2 rounded-xl border-2 border-green-500 bg-green-500/10 p-3 text-sm font-bold text-green-700 dark:text-green-400">
+            <CheckCircle2 size={18} className="shrink-0 mt-0.5" aria-hidden />
+            <span>Looks great! This follows Conventional Commits.</span>
+          </div>
+        )}
+
+        {!result.valid &&
+          result.issues.map((issue) => (
+            <div
+              key={issue.code + issue.message}
+              className="flex items-start gap-2 rounded-xl border-2 border-amber-500 bg-amber-500/10 p-3 text-sm font-bold text-amber-900 dark:text-amber-200"
+              role="alert"
+            >
+              <AlertCircle size={18} className="shrink-0 mt-0.5" aria-hidden />
+              <span>{issue.message}</span>
+            </div>
+          ))}
+      </div>
+
+      {showSuggestion && (
+        <div className="mt-4 space-y-2 rounded-xl border-2 border-black/20 dark:border-[#2e2924] bg-surface-low dark:bg-[#151411] p-3">
+          <p className="text-[10px] font-black uppercase tracking-widest text-muted dark:text-[#c4bbae]">
+            Suggested rewrite
+          </p>
+          <code className="block font-mono text-sm break-all text-text dark:text-[#f0ebe2]">
+            {suggestion}
+          </code>
+          <div className="flex flex-wrap gap-2 pt-1">
+            <button
+              type="button"
+              onClick={() => setMessage(suggestion)}
+              className="px-3 py-1.5 text-xs font-black rounded-lg border-2 border-black bg-accent text-black shadow-card-sm hover:-translate-y-0.5 transition-all"
+            >
+              Apply fix
+            </button>
+            <button
+              type="button"
+              onClick={() => copyText(suggestion, "message")}
+              className="px-3 py-1.5 text-xs font-black rounded-lg border-2 border-black bg-white dark:bg-[#1f1c18] dark:text-[#f0ebe2] shadow-card-sm hover:-translate-y-0.5 transition-all inline-flex items-center gap-1"
+            >
+              {copiedKey === "message" ? (
+                <>
+                  <Check size={14} /> Copied
+                </>
+              ) : (
+                <>
+                  <Copy size={14} /> Copy rewrite
+                </>
+              )}
+            </button>
+          </div>
+        </div>
+      )}
+
+      <div className="mt-4 flex flex-wrap gap-2">
+        {result.valid && message.trim() && (
+          <button
+            type="button"
+            onClick={() => copyText(message.trim(), "message")}
+            className="px-3 py-1.5 text-xs font-black rounded-lg border-2 border-black bg-white dark:bg-[#151411] dark:text-[#f0ebe2] shadow-card-sm hover:-translate-y-0.5 transition-all inline-flex items-center gap-1"
+          >
+            {copiedKey === "message" ? (
+              <>
+                <Check size={14} /> Copied
+              </>
+            ) : (
+              <>
+                <Copy size={14} /> Copy message
+              </>
+            )}
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={() =>
+            copyText(
+              buildPrChecklistTemplate(
+                result.valid ? message.trim() : suggestion,
+              ),
+              "pr",
+            )
+          }
+          className="px-3 py-1.5 text-xs font-black rounded-lg border-2 border-black bg-white dark:bg-[#151411] dark:text-[#f0ebe2] shadow-card-sm hover:-translate-y-0.5 transition-all inline-flex items-center gap-1"
+        >
+          {copiedKey === "pr" ? (
+            <>
+              <Check size={14} /> Copied
+            </>
+          ) : (
+            <>
+              <ClipboardList size={14} /> Copy PR template
+            </>
+          )}
+        </button>
+      </div>
+
+      {!compact && (
+        <details className="mt-4 group">
+          <summary className="cursor-pointer text-xs font-black uppercase tracking-widest text-muted dark:text-[#c4bbae] list-none flex items-center gap-1">
+            <span className="group-open:rotate-90 transition-transform">▸</span>
+            Type cheat sheet
+          </summary>
+          <ul className="mt-2 grid grid-cols-1 sm:grid-cols-2 gap-1.5">
+            {COMMIT_TYPE_HINTS.map(({ type, hint }) => (
+              <li key={type}>
+                <button
+                  type="button"
+                  onClick={() =>
+                    setMessage(
+                      message.trim()
+                        ? suggestCommitRewrite(
+                            `${type}: ${result.parsed.subject ?? message}`,
+                          )
+                        : `${type}: `,
+                    )
+                  }
+                  className="w-full text-left px-2 py-1.5 rounded-lg border-2 border-black/10 dark:border-[#2e2924] hover:border-black dark:hover:border-[#c4bbae] text-xs transition-colors"
+                >
+                  <span className="font-mono font-black text-accent">{type}</span>
+                  <span className="text-muted dark:text-[#c4bbae]"> — {hint}</span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </details>
+      )}
+    </div>
+  );
+}
+
+export default CommitMessageCoach;

--- a/frontend/src/components/ui/CommitMessageCoach/index.ts
+++ b/frontend/src/components/ui/CommitMessageCoach/index.ts
@@ -1,0 +1,2 @@
+export { CommitMessageCoach } from "./CommitMessageCoach";
+export type { CommitMessageCoachProps } from "./CommitMessageCoach";

--- a/frontend/src/lib/conventionalCommitCoach.ts
+++ b/frontend/src/lib/conventionalCommitCoach.ts
@@ -1,0 +1,231 @@
+/**
+ * Conventional Commit Message Coach — validator & rewrite helpers.
+ * Spec-inspired rules for first-time open-source contributors.
+ */
+
+export const ALLOWED_TYPES = [
+  "feat",
+  "fix",
+  "docs",
+  "style",
+  "refactor",
+  "perf",
+  "test",
+  "build",
+  "ci",
+  "chore",
+  "revert",
+] as const;
+
+export type CommitType = (typeof ALLOWED_TYPES)[number];
+
+export type ValidationIssue = {
+  code:
+    | "empty"
+    | "format"
+    | "type"
+    | "scope"
+    | "subject_empty"
+    | "subject_case"
+    | "subject_period"
+    | "subject_length"
+    | "whitespace";
+  message: string;
+};
+
+export type ValidationResult = {
+  valid: boolean;
+  issues: ValidationIssue[];
+  parsed: {
+    type: string | null;
+    scope: string | null;
+    subject: string | null;
+  };
+};
+
+const HEADER_RE =
+  /^(?<type>[a-zA-Z]+)(?:\((?<scope>[^)]*)\))?(?<breaking>!)?:\s*(?<subject>.*)$/;
+
+const MAX_SUBJECT_LENGTH = 72;
+
+export function validateCommitMessage(raw: string): ValidationResult {
+  const message = raw.replace(/\r\n/g, "\n").trim();
+  const issues: ValidationIssue[] = [];
+  const parsed = { type: null as string | null, scope: null as string | null, subject: null as string | null };
+
+  if (!message) {
+    return {
+      valid: false,
+      issues: [
+        {
+          code: "empty",
+          message: "Commit message is empty. Start with a type like feat or fix.",
+        },
+      ],
+      parsed,
+    };
+  }
+
+  if (/\s{2,}/.test(message) || message !== raw.trim()) {
+    // only flag internal double spaces in the trimmed message
+    if (/\s{2,}/.test(message)) {
+      issues.push({
+        code: "whitespace",
+        message: "Avoid extra spaces. Use a single space after the colon.",
+      });
+    }
+  }
+
+  const match = message.match(HEADER_RE);
+  if (!match?.groups) {
+    issues.push({
+      code: "format",
+      message:
+        'Use the format type(scope): subject — for example "feat(auth): add login form". Scope is optional.',
+    });
+    return { valid: false, issues, parsed };
+  }
+
+  const type = match.groups.type ?? "";
+  const scope = match.groups.scope ?? null;
+  const subject = (match.groups.subject ?? "").trim();
+
+  parsed.type = type;
+  parsed.scope = scope;
+  parsed.subject = subject || null;
+
+  const typeLower = type.toLowerCase();
+  if (!(ALLOWED_TYPES as readonly string[]).includes(typeLower)) {
+    issues.push({
+      code: "type",
+      message: `"${type}" is not a known type. Allowed: ${ALLOWED_TYPES.join(", ")}.`,
+    });
+  } else if (type !== typeLower) {
+    issues.push({
+      code: "type",
+      message: `Type should be lowercase. Use "${typeLower}" instead of "${type}".`,
+    });
+  }
+
+  if (scope !== null) {
+    if (!scope.trim()) {
+      issues.push({
+        code: "scope",
+        message: "Scope is empty. Either remove the parentheses or add a short scope like (auth).",
+      });
+    } else if (/\s/.test(scope)) {
+      issues.push({
+        code: "scope",
+        message: "Scope should be a short kebab-case word without spaces (e.g. auth, api, ui).",
+      });
+    }
+  }
+
+  if (!subject) {
+    issues.push({
+      code: "subject_empty",
+      message: "Add a short subject after the colon describing what changed.",
+    });
+  } else {
+    if (/^[A-Z]/.test(subject)) {
+      issues.push({
+        code: "subject_case",
+        message: "Subject should start with a lowercase letter (e.g. \"add login form\").",
+      });
+    }
+    if (subject.endsWith(".")) {
+      issues.push({
+        code: "subject_period",
+        message: "Do not end the subject with a period.",
+      });
+    }
+    if (subject.length > MAX_SUBJECT_LENGTH) {
+      issues.push({
+        code: "subject_length",
+        message: `Subject is too long (${subject.length} chars). Keep it under ${MAX_SUBJECT_LENGTH} characters.`,
+      });
+    }
+  }
+
+  return {
+    valid: issues.length === 0,
+    issues,
+    parsed,
+  };
+}
+
+/**
+ * Attempt to rewrite an invalid (or rough) message into a valid Conventional Commit.
+ */
+export function suggestCommitRewrite(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return "feat: describe your change here";
+  }
+
+  const match = trimmed.match(HEADER_RE);
+  let type = "feat";
+  let scope: string | null = null;
+  let subject = trimmed;
+
+  if (match?.groups) {
+    const rawType = (match.groups.type ?? "").toLowerCase();
+    type = (ALLOWED_TYPES as readonly string[]).includes(rawType) ? rawType : "chore";
+    const rawScope = match.groups.scope;
+    if (rawScope && rawScope.trim() && !/\s/.test(rawScope.trim())) {
+      scope = rawScope.trim().toLowerCase();
+    }
+    subject = (match.groups.subject ?? "").trim() || "describe your change here";
+  } else {
+    // Heuristic: first word might be a type
+    const parts = trimmed.split(/\s+/);
+    const maybeType = parts[0]?.toLowerCase().replace(/:$/, "");
+    if ((ALLOWED_TYPES as readonly string[]).includes(maybeType)) {
+      type = maybeType;
+      subject = parts.slice(1).join(" ").replace(/^:\s*/, "").trim() || "describe your change here";
+    } else {
+      subject = trimmed;
+    }
+  }
+
+  subject = subject.replace(/\.$/, "");
+  if (subject) {
+    subject = subject.charAt(0).toLowerCase() + subject.slice(1);
+  }
+  if (subject.length > MAX_SUBJECT_LENGTH) {
+    subject = subject.slice(0, MAX_SUBJECT_LENGTH).trim();
+  }
+
+  return scope ? `${type}(${scope}): ${subject}` : `${type}: ${subject}`;
+}
+
+export function buildPrChecklistTemplate(commitMessage: string): string {
+  const msg = commitMessage.trim() || "feat: your change";
+  return `## Summary
+- ${msg}
+
+## Test plan
+- [ ] Ran relevant frontend/backend tests
+- [ ] Checked UI in light and dark theme (if UI change)
+- [ ] Updated docs if needed
+
+## Checklist
+- [ ] Conventional Commit message used
+- [ ] Scope matches the issue / PR title
+- [ ] No unrelated files included
+`;
+}
+
+export const COMMIT_TYPE_HINTS: { type: CommitType; hint: string }[] = [
+  { type: "feat", hint: "A new feature for users" },
+  { type: "fix", hint: "A bug fix" },
+  { type: "docs", hint: "Documentation only" },
+  { type: "style", hint: "Formatting, no logic change" },
+  { type: "refactor", hint: "Code change that neither fixes a bug nor adds a feature" },
+  { type: "perf", hint: "Performance improvement" },
+  { type: "test", hint: "Adding or fixing tests" },
+  { type: "build", hint: "Build system or dependencies" },
+  { type: "ci", hint: "CI configuration" },
+  { type: "chore", hint: "Maintenance tasks" },
+  { type: "revert", hint: "Reverts a previous commit" },
+];

--- a/frontend/src/pages/ContributorSandboxPage.tsx
+++ b/frontend/src/pages/ContributorSandboxPage.tsx
@@ -11,6 +11,8 @@ import {
   CheckCircle,
 } from "lucide-react";
 import { SectionCard } from "../components/ui/SectionCard";
+import { CommitMessageCoach } from "../components/ui/CommitMessageCoach";
+import { validateCommitMessage } from "../lib/conventionalCommitCoach";
 
 type Step = "setup" | "fix" | "commit" | "pr" | "success";
 
@@ -121,13 +123,11 @@ export function ContributorSandboxPage() {
   const startLinterRun = () => {
     if (!commitMsg.trim()) return;
 
-    // Check for conventional commit structure
-    const isConventional = /^(feat|fix|docs|refactor|chore)(\(.+\))?:/.test(
-      commitMsg,
-    );
-    if (!isConventional) {
+    const validation = validateCommitMessage(commitMsg);
+    if (!validation.valid) {
       alert(
-        "Our project requires Conventional Commits! Format: 'feat: add feature' or 'fix: resolve issue'",
+        validation.issues[0]?.message ??
+          "Our project requires Conventional Commits! Format: 'feat: add feature' or 'fix: resolve issue'",
       );
       return;
     }
@@ -357,18 +357,12 @@ export function ContributorSandboxPage() {
               </div>
 
               <div className="space-y-4">
-                <div>
-                  <label className="block text-sm font-black mb-2">
-                    Commit Message
-                  </label>
-                  <input
-                    type="text"
-                    value={commitMsg}
-                    onChange={(e) => setCommitMsg(e.target.value)}
-                    className="w-full border-4 border-black px-4 py-3 rounded-xl font-mono text-sm bg-white text-black shadow-card dark:bg-[#151411] dark:border-[#2e2924] dark:text-[#f0ebe2]"
-                    placeholder="e.g. fix: handle unexpected errors in token decoding"
-                  />
-                </div>
+                <CommitMessageCoach
+                  value={commitMsg}
+                  onChange={setCommitMsg}
+                  compact
+                  defaultValue=""
+                />
 
                 {isLinterRunning && (
                   <div className="bg-surface-low dark:bg-[#151411] p-4 rounded-xl border-2 border-black flex items-center gap-3">

--- a/frontend/src/pages/LessonPage.tsx
+++ b/frontend/src/pages/LessonPage.tsx
@@ -65,6 +65,7 @@ const MarkdownRenderer = React.lazy(() =>
 import { LessonHistoryModal } from "../components/LessonHistoryModal";
 import { GitGraph } from "../components/ui/GitGraph";
 import { NotePanel } from "../components/ui/NotePanel";
+import { CommitMessageCoach } from "../components/ui/CommitMessageCoach";
 import { LessonFeedbackWidget } from "../components/ui/LessonFeedbackWidget";
 import { PythonSandbox } from "../components/ui/PythonSandbox";
 const CollabPythonSandbox = React.lazy(() =>
@@ -179,6 +180,7 @@ export function LessonPage() {
 
   // Note Panel
   const [isNotePanelOpen, setIsNotePanelOpen] = useState(false);
+  const [isCommitCoachOpen, setIsCommitCoachOpen] = useState(false);
 
   // Reading progress scroll ref
   const mainContentRef = useRef<HTMLDivElement>(null);
@@ -1329,9 +1331,21 @@ export function LessonPage() {
         </div>
 
         {/* Mentor Help Trigger Row */}
-        <div className="border-t-4 border-black p-4 bg-white dark:bg-[#151411] dark:border-[#2e2924] flex justify-end gap-4 flex-shrink-0">
+        <div className="border-t-4 border-black p-4 bg-white dark:bg-[#151411] dark:border-[#2e2924] flex justify-end gap-4 flex-shrink-0 flex-wrap">
           <button
-            onClick={() => setIsNotePanelOpen(!isNotePanelOpen)}
+            onClick={() => {
+              setIsCommitCoachOpen(!isCommitCoachOpen);
+              if (!isCommitCoachOpen) setIsNotePanelOpen(false);
+            }}
+            className="px-4 py-2 bg-white text-text dark:bg-[#151411] dark:text-[#f0ebe2] font-black text-xs rounded-lg border-4 border-black shadow-card-sm hover:-translate-y-0.5 cursor-pointer"
+          >
+            {isCommitCoachOpen ? "Close Commit Coach" : "Commit Coach"}
+          </button>
+          <button
+            onClick={() => {
+              setIsNotePanelOpen(!isNotePanelOpen);
+              if (!isNotePanelOpen) setIsCommitCoachOpen(false);
+            }}
             className="px-4 py-2 bg-white text-text dark:bg-[#151411] dark:text-[#f0ebe2] font-black text-xs rounded-lg border-4 border-black shadow-card-sm hover:-translate-y-0.5 cursor-pointer"
           >
             {isNotePanelOpen ? "Close Notes 📝" : "Notes 📝"}
@@ -1353,6 +1367,38 @@ export function LessonPage() {
           lessonSlug={lesson.slug}
           onClose={() => setIsNotePanelOpen(false)}
         />
+      )}
+
+      {isCommitCoachOpen && (
+        <div className="fixed inset-0 z-50 flex justify-end bg-black/40">
+          <button
+            type="button"
+            aria-label="Close commit message coach"
+            className="flex-1 cursor-default"
+            onClick={() => setIsCommitCoachOpen(false)}
+          />
+          <aside className="h-full w-full max-w-md overflow-y-auto bg-surface-lowest border-l-4 border-black p-6 shadow-card space-y-4 dark:bg-[#0f0e0c] dark:border-[#2e2924]">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <h2 className="text-2xl font-black text-text dark:text-[#f0ebe2]">
+                  Practice your commit
+                </h2>
+                <p className="text-xs text-muted mt-1 dark:text-[#c4bbae]">
+                  Draft a Conventional Commit while you learn — then copy it
+                  into your real PR.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setIsCommitCoachOpen(false)}
+                className="px-3 py-1 border-2 border-black rounded-lg font-black text-xs hover:bg-surface-low dark:border-[#2e2924] dark:text-[#f0ebe2]"
+              >
+                Close
+              </button>
+            </div>
+            <CommitMessageCoach />
+          </aside>
+        </div>
       )}
 
       {isHelpPanelOpen && (

--- a/frontend/src/test/conventionalCommitCoach.test.ts
+++ b/frontend/src/test/conventionalCommitCoach.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import {
+  validateCommitMessage,
+  suggestCommitRewrite,
+  buildPrChecklistTemplate,
+  ALLOWED_TYPES,
+} from "../lib/conventionalCommitCoach";
+
+describe("validateCommitMessage", () => {
+  it("rejects empty messages", () => {
+    const result = validateCommitMessage("   ");
+    expect(result.valid).toBe(false);
+    expect(result.issues[0]?.code).toBe("empty");
+  });
+
+  it("accepts a valid feat message", () => {
+    const result = validateCommitMessage("feat: add commit coach widget");
+    expect(result.valid).toBe(true);
+    expect(result.issues).toHaveLength(0);
+    expect(result.parsed.type).toBe("feat");
+    expect(result.parsed.subject).toBe("add commit coach widget");
+  });
+
+  it("accepts optional scope", () => {
+    const result = validateCommitMessage("fix(auth): handle expired tokens");
+    expect(result.valid).toBe(true);
+    expect(result.parsed.scope).toBe("auth");
+  });
+
+  it("rejects unknown types with plain-English help", () => {
+    const result = validateCommitMessage("update: bump deps");
+    expect(result.valid).toBe(false);
+    expect(result.issues.some((i) => i.code === "type")).toBe(true);
+    expect(result.issues[0]?.message).toMatch(/not a known type/i);
+  });
+
+  it("rejects uppercase subject start", () => {
+    const result = validateCommitMessage("feat: Add login form");
+    expect(result.valid).toBe(false);
+    expect(result.issues.some((i) => i.code === "subject_case")).toBe(true);
+  });
+
+  it("rejects trailing period on subject", () => {
+    const result = validateCommitMessage("docs: update readme.");
+    expect(result.valid).toBe(false);
+    expect(result.issues.some((i) => i.code === "subject_period")).toBe(true);
+  });
+
+  it("rejects empty scope parentheses", () => {
+    const result = validateCommitMessage("chore(): clean scripts");
+    expect(result.valid).toBe(false);
+    expect(result.issues.some((i) => i.code === "scope")).toBe(true);
+  });
+
+  it("rejects malformed format", () => {
+    const result = validateCommitMessage("just a random sentence");
+    expect(result.valid).toBe(false);
+    expect(result.issues.some((i) => i.code === "format")).toBe(true);
+  });
+
+  it("exposes the allowed type list", () => {
+    expect(ALLOWED_TYPES).toContain("feat");
+    expect(ALLOWED_TYPES).toContain("fix");
+    expect(ALLOWED_TYPES).toContain("docs");
+  });
+});
+
+describe("suggestCommitRewrite", () => {
+  it("returns a starter template for empty input", () => {
+    expect(suggestCommitRewrite("")).toBe("feat: describe your change here");
+  });
+
+  it("lowercases type and subject and strips trailing period", () => {
+    expect(suggestCommitRewrite("Feat: Add Login Form.")).toBe(
+      "feat: add Login Form",
+    );
+  });
+
+  it("maps unknown typed headers to chore", () => {
+    expect(suggestCommitRewrite("update: bump lodash")).toBe(
+      "chore: bump lodash",
+    );
+  });
+
+  it("prefixes bare subjects with feat", () => {
+    expect(suggestCommitRewrite("add heatmap widget")).toBe(
+      "feat: add heatmap widget",
+    );
+  });
+});
+
+describe("buildPrChecklistTemplate", () => {
+  it("includes the commit message and checklist items", () => {
+    const text = buildPrChecklistTemplate("feat: add coach");
+    expect(text).toContain("feat: add coach");
+    expect(text).toContain("## Summary");
+    expect(text).toContain("Conventional Commit message used");
+  });
+});

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -38,9 +38,6 @@ export default defineConfig({
         type: "module",
       },
     }),
-    storybookTest({
-      configDir: path.join(dirname, ".storybook"),
-    }),
   ],
   resolve: {
     dedupe: ["react", "react-dom", "react-i18next"],
@@ -50,6 +47,7 @@ export default defineConfig({
       {
         extends: true,
         test: {
+          name: "unit",
           environment: "jsdom",
           setupFiles: "./src/test/setup.ts",
           include: ["src/**/*.test.{ts,tsx}"],
@@ -58,6 +56,11 @@ export default defineConfig({
       },
       {
         extends: true,
+        plugins: [
+          storybookTest({
+            configDir: path.join(dirname, ".storybook"),
+          }),
+        ],
         test: {
           name: "storybook",
           browser: {


### PR DESCRIPTION
# #1810 issue resolved
## Description
This PR adds a beginner-friendly Conventional Commit Message Coach to the frontend learning experience (/lessons/:slug and /contributor-sandbox).

## Features

- Live validation for type(scope): subject Conventional Commits
- Plain-English error messages (type, scope, subject case/length/period)
- Suggested rewrite with Apply fix and copy helpers
- Optional PR checklist template copy
- Dark/light theme compatible UI matching Atelier patterns
- Vitest coverage for validator and rewrite helpers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Commit Coach to help create, validate, and improve Conventional Commit messages.
  * Provides actionable feedback, rewrite suggestions, commit type hints, and clipboard copying.
  * Added an option to generate a PR checklist template from a commit message.
  * Integrated the coach into the contributor sandbox and lesson experience.

* **Bug Fixes**
  * Improved commit message validation with clearer, more specific error messages.

* **Tests**
  * Added coverage for validation, rewrite suggestions, supported commit types, and checklist generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->