### PR TITLE
fix(dashboard): compute lesson XP consistently using LessonProgress and fix NameError

### DIFF
--- a/backend/apps/dashboard/views.py
+++ b/backend/apps/dashboard/views.py
@@ -281,8 +281,8 @@ class ContributorDashboardView(APIView):
             ).count()
 
             lesson_xp = (
-                XPEvent.objects.filter(user=user, source_type="lesson").aggregate(
-                    total=Sum("xp_delta")
+                LessonProgress.objects.filter(user=user, completed=True).aggregate(
+                    total=Sum("score")
                 )["total"]
                 or 0
             )
@@ -335,9 +335,9 @@ class ContributorDashboardView(APIView):
 
             # Determine Rank based on user XP vs others
             lesson_xp_sub = (
-                XPEvent.objects.filter(user=OuterRef("pk"), source_type="lesson")
+                LessonProgress.objects.filter(user=OuterRef("pk"), completed=True)
                 .values("user")
-                .annotate(total=Sum("xp_delta"))
+                .annotate(total=Sum("score"))
                 .values("total")
             )
             issues_xp_sub = (

--- a/backend/apps/notifications/views.py
+++ b/backend/apps/notifications/views.py
@@ -8,7 +8,7 @@ from .serializers import NotificationSerializer, PushSubscriptionSerializer
 from .models import NotificationPreference
 
 class NotificationPrefsView(APIView):
-    permission_classes = [IsAuthenticated]
+    permission_classes = [permissions.IsAuthenticated]
     
     def get(self, request):
         prefs, _ = NotificationPreference.objects.get_or_create(user=request.user)


### PR DESCRIPTION
### Summary
This PR fixes the discrepancy in user XP calculation where the contributor dashboard used `XPEvent` delta summation while other views used `LessonProgress` score summation. It changes both `lesson_xp` and `lesson_xp_sub` queries in `ContributorDashboardView` to use the `LessonProgress` model.

It also resolves a NameError blocking local testing and routing in `apps/notifications/views.py` by qualifying `IsAuthenticated` with its module prefix (`permissions.IsAuthenticated`).

Fixes #1816

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Personal dashboards now include expanded streak statistics, including longest streak, current streak days, ranking, and unused streak freezes.
  * Lesson XP and rankings now reflect completed lesson scores more accurately.

* **Bug Fixes**
  * Improved access protection for notification preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->