### PR TITLE
PR Description Diff Summarizer

### DIFF
--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -104,6 +104,12 @@ const ContributorSandboxPage = lazy(() =>
   })),
 );
 
+const PrDiffSummarizerPage = lazy(() =>
+  import("../pages/PrDiffSummarizerPage").then((module) => ({
+    default: module.PrDiffSummarizerPage,
+  })),
+);
+
 const ProfileSettingsPage = lazy(() =>
   import("../pages/ProfileSettingsPage").then((module) => ({
     default: module.ProfileSettingsPage,
@@ -353,6 +359,15 @@ export function AppRouter() {
             element={
               <ProtectedRoute>
                 <ContributorSandboxPage />
+              </ProtectedRoute>
+            }
+          />
+
+          <Route
+            path="/pr-diff-summarizer"
+            element={
+              <ProtectedRoute>
+                <PrDiffSummarizerPage />
               </ProtectedRoute>
             }
           />

--- a/frontend/src/components/layout/Navigation.tsx
+++ b/frontend/src/components/layout/Navigation.tsx
@@ -17,6 +17,7 @@ import {
   Eye,
   FileText,
   Target,
+  FileDiff,
 } from "lucide-react";
 import { Link, NavLink, useNavigate } from "react-router-dom";
 import { useTheme } from "../../hooks/useTheme";
@@ -41,6 +42,7 @@ const navGroups = [
     items: [
       { to: "/contributor-sandbox", label: "Playground", icon: TerminalSquare },
       { to: "/a11y-sandbox", label: "A11y Sandbox", icon: Eye },
+      { to: "/pr-diff-summarizer", label: "PR Summarizer", icon: FileDiff },
       { to: "/bounties", label: "Bounties", icon: Target },
     ],
   },

--- a/frontend/src/components/ui/CommitMessageCoach/CommitMessageCoach.tsx
+++ b/frontend/src/components/ui/CommitMessageCoach/CommitMessageCoach.tsx
@@ -1,0 +1,245 @@
+import React, { useMemo, useState } from "react";
+import {
+  CheckCircle2,
+  AlertCircle,
+  Copy,
+  Check,
+  Sparkles,
+  ClipboardList,
+} from "lucide-react";
+import {
+  validateCommitMessage,
+  suggestCommitRewrite,
+  buildPrChecklistTemplate,
+  COMMIT_TYPE_HINTS,
+  ALLOWED_TYPES,
+} from "../../lib/conventionalCommitCoach";
+
+export type CommitMessageCoachProps = {
+  /** Controlled value — when provided, parent owns the message */
+  value?: string;
+  /** Called whenever the message changes */
+  onChange?: (message: string) => void;
+  /** Compact layout for embedding inside simulators */
+  compact?: boolean;
+  className?: string;
+  defaultValue?: string;
+};
+
+export function CommitMessageCoach({
+  value,
+  onChange,
+  compact = false,
+  className = "",
+  defaultValue = "",
+}: CommitMessageCoachProps) {
+  const [internal, setInternal] = useState(defaultValue);
+  const [copiedKey, setCopiedKey] = useState<"message" | "pr" | null>(null);
+
+  const message = value !== undefined ? value : internal;
+
+  const setMessage = (next: string) => {
+    if (value === undefined) setInternal(next);
+    onChange?.(next);
+  };
+
+  const result = useMemo(() => validateCommitMessage(message), [message]);
+  const suggestion = useMemo(() => suggestCommitRewrite(message), [message]);
+  const showSuggestion = message.trim().length > 0 && !result.valid;
+
+  const copyText = async (text: string, key: "message" | "pr") => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopiedKey(key);
+      setTimeout(() => setCopiedKey(null), 2000);
+    } catch {
+      // Clipboard may be unavailable in insecure contexts
+    }
+  };
+
+  return (
+    <div
+      className={`rounded-2xl border-4 border-black bg-white p-4 shadow-card dark:bg-[#1f1c18] dark:border-[#2e2924] dark:shadow-none ${className}`}
+      data-testid="commit-message-coach"
+    >
+      <div className="flex items-start justify-between gap-3 mb-3">
+        <div>
+          <h3 className="text-lg font-black text-text dark:text-[#f0ebe2] flex items-center gap-2">
+            <Sparkles size={18} className="text-accent" aria-hidden />
+            Commit Message Coach
+          </h3>
+          {!compact && (
+            <p className="text-xs font-bold text-muted mt-1 dark:text-[#c4bbae]">
+              Practice Conventional Commits:{" "}
+              <code className="bg-surface-low dark:bg-black px-1 rounded font-mono">
+                type(scope): subject
+              </code>
+            </p>
+          )}
+        </div>
+        {message.trim() && (
+          <span
+            className={`shrink-0 text-[10px] font-black uppercase tracking-widest px-2 py-1 rounded-lg border-2 ${
+              result.valid
+                ? "bg-green-500/15 text-green-700 border-green-600 dark:text-green-400 dark:border-green-500"
+                : "bg-amber-500/15 text-amber-800 border-amber-600 dark:text-amber-300 dark:border-amber-500"
+            }`}
+            aria-live="polite"
+          >
+            {result.valid ? "Valid" : "Needs fixes"}
+          </span>
+        )}
+      </div>
+
+      <label className="block text-sm font-black mb-2 text-text dark:text-[#f0ebe2]">
+        Commit message
+        <input
+          type="text"
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          placeholder="e.g. feat(auth): add password reset flow"
+          className="mt-2 w-full border-4 border-black px-4 py-3 rounded-xl font-mono text-sm bg-white text-black shadow-card-sm dark:bg-[#151411] dark:border-[#2e2924] dark:text-[#f0ebe2] focus:outline-none focus:ring-2 focus:ring-accent"
+          aria-invalid={message.trim().length > 0 && !result.valid}
+          aria-describedby="commit-coach-feedback"
+        />
+      </label>
+
+      <div id="commit-coach-feedback" className="space-y-2 min-h-[1.5rem]">
+        {message.trim().length === 0 && (
+          <p className="text-xs text-muted font-bold dark:text-[#c4bbae]">
+            Tip: allowed types — {ALLOWED_TYPES.join(", ")}
+          </p>
+        )}
+
+        {result.valid && message.trim() && (
+          <div className="flex items-start gap-2 rounded-xl border-2 border-green-500 bg-green-500/10 p-3 text-sm font-bold text-green-700 dark:text-green-400">
+            <CheckCircle2 size={18} className="shrink-0 mt-0.5" aria-hidden />
+            <span>Looks great! This follows Conventional Commits.</span>
+          </div>
+        )}
+
+        {!result.valid &&
+          result.issues.map((issue) => (
+            <div
+              key={issue.code + issue.message}
+              className="flex items-start gap-2 rounded-xl border-2 border-amber-500 bg-amber-500/10 p-3 text-sm font-bold text-amber-900 dark:text-amber-200"
+              role="alert"
+            >
+              <AlertCircle size={18} className="shrink-0 mt-0.5" aria-hidden />
+              <span>{issue.message}</span>
+            </div>
+          ))}
+      </div>
+
+      {showSuggestion && (
+        <div className="mt-4 space-y-2 rounded-xl border-2 border-black/20 dark:border-[#2e2924] bg-surface-low dark:bg-[#151411] p-3">
+          <p className="text-[10px] font-black uppercase tracking-widest text-muted dark:text-[#c4bbae]">
+            Suggested rewrite
+          </p>
+          <code className="block font-mono text-sm break-all text-text dark:text-[#f0ebe2]">
+            {suggestion}
+          </code>
+          <div className="flex flex-wrap gap-2 pt-1">
+            <button
+              type="button"
+              onClick={() => setMessage(suggestion)}
+              className="px-3 py-1.5 text-xs font-black rounded-lg border-2 border-black bg-accent text-black shadow-card-sm hover:-translate-y-0.5 transition-all"
+            >
+              Apply fix
+            </button>
+            <button
+              type="button"
+              onClick={() => copyText(suggestion, "message")}
+              className="px-3 py-1.5 text-xs font-black rounded-lg border-2 border-black bg-white dark:bg-[#1f1c18] dark:text-[#f0ebe2] shadow-card-sm hover:-translate-y-0.5 transition-all inline-flex items-center gap-1"
+            >
+              {copiedKey === "message" ? (
+                <>
+                  <Check size={14} /> Copied
+                </>
+              ) : (
+                <>
+                  <Copy size={14} /> Copy rewrite
+                </>
+              )}
+            </button>
+          </div>
+        </div>
+      )}
+
+      <div className="mt-4 flex flex-wrap gap-2">
+        {result.valid && message.trim() && (
+          <button
+            type="button"
+            onClick={() => copyText(message.trim(), "message")}
+            className="px-3 py-1.5 text-xs font-black rounded-lg border-2 border-black bg-white dark:bg-[#151411] dark:text-[#f0ebe2] shadow-card-sm hover:-translate-y-0.5 transition-all inline-flex items-center gap-1"
+          >
+            {copiedKey === "message" ? (
+              <>
+                <Check size={14} /> Copied
+              </>
+            ) : (
+              <>
+                <Copy size={14} /> Copy message
+              </>
+            )}
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={() =>
+            copyText(
+              buildPrChecklistTemplate(
+                result.valid ? message.trim() : suggestion,
+              ),
+              "pr",
+            )
+          }
+          className="px-3 py-1.5 text-xs font-black rounded-lg border-2 border-black bg-white dark:bg-[#151411] dark:text-[#f0ebe2] shadow-card-sm hover:-translate-y-0.5 transition-all inline-flex items-center gap-1"
+        >
+          {copiedKey === "pr" ? (
+            <>
+              <Check size={14} /> Copied
+            </>
+          ) : (
+            <>
+              <ClipboardList size={14} /> Copy PR template
+            </>
+          )}
+        </button>
+      </div>
+
+      {!compact && (
+        <details className="mt-4 group">
+          <summary className="cursor-pointer text-xs font-black uppercase tracking-widest text-muted dark:text-[#c4bbae] list-none flex items-center gap-1">
+            <span className="group-open:rotate-90 transition-transform">▸</span>
+            Type cheat sheet
+          </summary>
+          <ul className="mt-2 grid grid-cols-1 sm:grid-cols-2 gap-1.5">
+            {COMMIT_TYPE_HINTS.map(({ type, hint }) => (
+              <li key={type}>
+                <button
+                  type="button"
+                  onClick={() =>
+                    setMessage(
+                      message.trim()
+                        ? suggestCommitRewrite(
+                            `${type}: ${result.parsed.subject ?? message}`,
+                          )
+                        : `${type}: `,
+                    )
+                  }
+                  className="w-full text-left px-2 py-1.5 rounded-lg border-2 border-black/10 dark:border-[#2e2924] hover:border-black dark:hover:border-[#c4bbae] text-xs transition-colors"
+                >
+                  <span className="font-mono font-black text-accent">{type}</span>
+                  <span className="text-muted dark:text-[#c4bbae]"> — {hint}</span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </details>
+      )}
+    </div>
+  );
+}
+
+export default CommitMessageCoach;

--- a/frontend/src/components/ui/CommitMessageCoach/index.ts
+++ b/frontend/src/components/ui/CommitMessageCoach/index.ts
@@ -1,0 +1,2 @@
+export { CommitMessageCoach } from "./CommitMessageCoach";
+export type { CommitMessageCoachProps } from "./CommitMessageCoach";

--- a/frontend/src/components/ui/PrDiffSummarizer/PrDiffSummarizer.tsx
+++ b/frontend/src/components/ui/PrDiffSummarizer/PrDiffSummarizer.tsx
@@ -1,0 +1,222 @@
+import React, { useMemo, useState } from "react";
+import { Copy, Check, FileDiff, Sparkles } from "lucide-react";
+import {
+  summarizeDiff,
+  buildPrDescription,
+  buildChecklist,
+  AREA_LABELS,
+  type ChangeArea,
+} from "../../lib/prDiffSummarizer";
+
+const SAMPLE_INPUT = `frontend/src/components/ui/PrDiffSummarizer/PrDiffSummarizer.tsx
+frontend/src/lib/prDiffSummarizer.ts
+frontend/src/test/prDiffSummarizer.test.ts
+backend/apps/progress/migrations/0012_example.py
+docs/CONTENT_GUIDE.md
+.github/pull_request_template.md`;
+
+export type PrDiffSummarizerProps = {
+  compact?: boolean;
+  className?: string;
+  defaultIssueNumber?: string;
+};
+
+export function PrDiffSummarizer({
+  compact = false,
+  className = "",
+  defaultIssueNumber = "",
+}: PrDiffSummarizerProps) {
+  const [raw, setRaw] = useState("");
+  const [issueNumber, setIssueNumber] = useState(defaultIssueNumber);
+  const [titleHint, setTitleHint] = useState("");
+  const [copied, setCopied] = useState(false);
+
+  const summary = useMemo(() => summarizeDiff(raw), [raw]);
+  const checklist = useMemo(() => buildChecklist(summary), [summary]);
+  const prBody = useMemo(
+    () =>
+      buildPrDescription(raw, {
+        issueNumber,
+        titleHint,
+        summary,
+      }),
+    [raw, issueNumber, titleHint, summary],
+  );
+
+  const hasFiles = summary.files.length > 0;
+
+  const copyBody = async () => {
+    try {
+      await navigator.clipboard.writeText(prBody);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard may be unavailable
+    }
+  };
+
+  return (
+    <div
+      className={`rounded-2xl border-4 border-black bg-white p-4 md:p-6 shadow-card dark:bg-[#1f1c18] dark:border-[#2e2924] dark:shadow-none space-y-4 ${className}`}
+      data-testid="pr-diff-summarizer"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h3 className="text-lg font-black text-text dark:text-[#f0ebe2] flex items-center gap-2">
+            <FileDiff size={18} className="text-accent" aria-hidden />
+            PR Description Diff Summarizer
+          </h3>
+          {!compact && (
+            <p className="text-xs font-bold text-muted mt-1 dark:text-[#c4bbae]">
+              Paste file paths or{" "}
+              <code className="bg-surface-low dark:bg-black px-1 rounded font-mono">
+                git diff --name-only
+              </code>{" "}
+              output — get a checklist-ready PR body.
+            </p>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={() => setRaw(SAMPLE_INPUT)}
+          className="shrink-0 px-3 py-1.5 text-xs font-black rounded-lg border-2 border-black bg-surface-low dark:bg-[#151411] dark:text-[#f0ebe2] shadow-card-sm hover:-translate-y-0.5 transition-all inline-flex items-center gap-1"
+        >
+          <Sparkles size={14} /> Try sample
+        </button>
+      </div>
+
+      <label className="block text-sm font-black text-text dark:text-[#f0ebe2]">
+        Changed files
+        <textarea
+          value={raw}
+          onChange={(e) => setRaw(e.target.value)}
+          rows={compact ? 5 : 8}
+          placeholder={`Paste paths, one per line…\nfrontend/src/App.tsx\nbackend/apps/content/models.py\ndocs/CONTENT_GUIDE.md`}
+          className="mt-2 w-full border-4 border-black px-4 py-3 rounded-xl font-mono text-xs bg-white text-black shadow-card-sm dark:bg-[#151411] dark:border-[#2e2924] dark:text-[#f0ebe2] focus:outline-none focus:ring-2 focus:ring-accent resize-y"
+          aria-describedby="pr-diff-hint"
+        />
+      </label>
+      <p id="pr-diff-hint" className="text-[11px] text-muted font-bold dark:text-[#c4bbae] -mt-2">
+        Accepts plain paths, <code className="font-mono">git status</code>, or{" "}
+        <code className="font-mono">git diff --name-only</code>.
+      </p>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <label className="block text-sm font-black text-text dark:text-[#f0ebe2]">
+          Issue number
+          <input
+            type="text"
+            value={issueNumber}
+            onChange={(e) => setIssueNumber(e.target.value.replace(/[^\d]/g, ""))}
+            placeholder="1822"
+            className="mt-2 w-full border-4 border-black px-3 py-2 rounded-xl font-mono text-sm bg-white text-black dark:bg-[#151411] dark:border-[#2e2924] dark:text-[#f0ebe2] focus:outline-none focus:ring-2 focus:ring-accent"
+          />
+        </label>
+        <label className="block text-sm font-black text-text dark:text-[#f0ebe2]">
+          Short summary (optional)
+          <input
+            type="text"
+            value={titleHint}
+            onChange={(e) => setTitleHint(e.target.value)}
+            placeholder="Add PR diff summarizer tool"
+            className="mt-2 w-full border-4 border-black px-3 py-2 rounded-xl text-sm bg-white text-black dark:bg-[#151411] dark:border-[#2e2924] dark:text-[#f0ebe2] focus:outline-none focus:ring-2 focus:ring-accent"
+          />
+        </label>
+      </div>
+
+      {!hasFiles && raw.trim() && (
+        <div
+          className="rounded-xl border-2 border-amber-500 bg-amber-500/10 p-3 text-sm font-bold text-amber-900 dark:text-amber-200"
+          role="alert"
+        >
+          No file paths detected. Paste one path per line (e.g.{" "}
+          <code className="font-mono">frontend/src/App.tsx</code>).
+        </div>
+      )}
+
+      {!raw.trim() && (
+        <p className="text-xs text-muted font-bold dark:text-[#c4bbae]">
+          Waiting for file paths… Detection covers{" "}
+          <strong>backend/</strong>, <strong>frontend/</strong>,{" "}
+          <strong>docs/</strong>, <strong>*.md</strong>, and migrations.
+        </p>
+      )}
+
+      {hasFiles && (
+        <>
+          <div className="flex flex-wrap gap-2" aria-label="Detected change areas">
+            {(Object.keys(summary.counts) as ChangeArea[]).map((area) => (
+              <span
+                key={area}
+                className="text-[10px] font-black uppercase tracking-widest px-2 py-1 rounded-lg border-2 border-black bg-accent/30 text-black dark:bg-accent/20 dark:text-[#f0ebe2] dark:border-[#2e2924]"
+              >
+                {AREA_LABELS[area]} ×{summary.counts[area]}
+              </span>
+            ))}
+          </div>
+
+          {!compact && (
+            <ul className="text-xs font-mono space-y-1 max-h-32 overflow-y-auto border-2 border-black/10 dark:border-[#2e2924] rounded-xl p-3 bg-surface-low dark:bg-[#151411]">
+              {summary.files.map((f) => (
+                <li key={f.path} className="text-text dark:text-[#f0ebe2]">
+                  <span className="text-muted dark:text-[#c4bbae]">
+                    [{f.areas.join(", ")}]
+                  </span>{" "}
+                  {f.path}
+                </li>
+              ))}
+            </ul>
+          )}
+
+          <div>
+            <p className="text-[10px] font-black uppercase tracking-widest text-muted dark:text-[#c4bbae] mb-2">
+              Suggested checklist ({checklist.length})
+            </p>
+            <ul className="space-y-1.5 text-sm font-bold text-text dark:text-[#f0ebe2]">
+              {checklist.slice(0, compact ? 5 : undefined).map((item) => (
+                <li key={item.id} className="flex gap-2">
+                  <span aria-hidden>☐</span>
+                  <span>{item.label}</span>
+                </li>
+              ))}
+              {compact && checklist.length > 5 && (
+                <li className="text-xs text-muted dark:text-[#c4bbae]">
+                  +{checklist.length - 5} more in the copied PR body
+                </li>
+              )}
+            </ul>
+          </div>
+        </>
+      )}
+
+      <div>
+        <div className="flex items-center justify-between gap-2 mb-2">
+          <p className="text-[10px] font-black uppercase tracking-widest text-muted dark:text-[#c4bbae]">
+            Generated PR body
+          </p>
+          <button
+            type="button"
+            onClick={copyBody}
+            disabled={!hasFiles}
+            className="px-3 py-1.5 text-xs font-black rounded-lg border-2 border-black bg-accent text-black shadow-card-sm hover:-translate-y-0.5 transition-all inline-flex items-center gap-1 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:translate-y-0"
+          >
+            {copied ? (
+              <>
+                <Check size={14} /> Copied
+              </>
+            ) : (
+              <>
+                <Copy size={14} /> Copy PR description
+              </>
+            )}
+          </button>
+        </div>
+        <pre className="w-full max-h-64 overflow-auto border-4 border-black rounded-xl p-3 font-mono text-[11px] leading-relaxed bg-surface-low text-black dark:bg-[#0f0e0c] dark:border-[#2e2924] dark:text-[#f0ebe2] whitespace-pre-wrap">
+          {hasFiles ? prBody : "Paste changed files to generate a PR description…"}
+        </pre>
+      </div>
+    </div>
+  );
+}
+
+export default PrDiffSummarizer;

--- a/frontend/src/components/ui/PrDiffSummarizer/index.ts
+++ b/frontend/src/components/ui/PrDiffSummarizer/index.ts
@@ -1,0 +1,2 @@
+export { PrDiffSummarizer } from "./PrDiffSummarizer";
+export type { PrDiffSummarizerProps } from "./PrDiffSummarizer";

--- a/frontend/src/lib/conventionalCommitCoach.ts
+++ b/frontend/src/lib/conventionalCommitCoach.ts
@@ -1,0 +1,231 @@
+/**
+ * Conventional Commit Message Coach — validator & rewrite helpers.
+ * Spec-inspired rules for first-time open-source contributors.
+ */
+
+export const ALLOWED_TYPES = [
+  "feat",
+  "fix",
+  "docs",
+  "style",
+  "refactor",
+  "perf",
+  "test",
+  "build",
+  "ci",
+  "chore",
+  "revert",
+] as const;
+
+export type CommitType = (typeof ALLOWED_TYPES)[number];
+
+export type ValidationIssue = {
+  code:
+    | "empty"
+    | "format"
+    | "type"
+    | "scope"
+    | "subject_empty"
+    | "subject_case"
+    | "subject_period"
+    | "subject_length"
+    | "whitespace";
+  message: string;
+};
+
+export type ValidationResult = {
+  valid: boolean;
+  issues: ValidationIssue[];
+  parsed: {
+    type: string | null;
+    scope: string | null;
+    subject: string | null;
+  };
+};
+
+const HEADER_RE =
+  /^(?<type>[a-zA-Z]+)(?:\((?<scope>[^)]*)\))?(?<breaking>!)?:\s*(?<subject>.*)$/;
+
+const MAX_SUBJECT_LENGTH = 72;
+
+export function validateCommitMessage(raw: string): ValidationResult {
+  const message = raw.replace(/\r\n/g, "\n").trim();
+  const issues: ValidationIssue[] = [];
+  const parsed = { type: null as string | null, scope: null as string | null, subject: null as string | null };
+
+  if (!message) {
+    return {
+      valid: false,
+      issues: [
+        {
+          code: "empty",
+          message: "Commit message is empty. Start with a type like feat or fix.",
+        },
+      ],
+      parsed,
+    };
+  }
+
+  if (/\s{2,}/.test(message) || message !== raw.trim()) {
+    // only flag internal double spaces in the trimmed message
+    if (/\s{2,}/.test(message)) {
+      issues.push({
+        code: "whitespace",
+        message: "Avoid extra spaces. Use a single space after the colon.",
+      });
+    }
+  }
+
+  const match = message.match(HEADER_RE);
+  if (!match?.groups) {
+    issues.push({
+      code: "format",
+      message:
+        'Use the format type(scope): subject — for example "feat(auth): add login form". Scope is optional.',
+    });
+    return { valid: false, issues, parsed };
+  }
+
+  const type = match.groups.type ?? "";
+  const scope = match.groups.scope ?? null;
+  const subject = (match.groups.subject ?? "").trim();
+
+  parsed.type = type;
+  parsed.scope = scope;
+  parsed.subject = subject || null;
+
+  const typeLower = type.toLowerCase();
+  if (!(ALLOWED_TYPES as readonly string[]).includes(typeLower)) {
+    issues.push({
+      code: "type",
+      message: `"${type}" is not a known type. Allowed: ${ALLOWED_TYPES.join(", ")}.`,
+    });
+  } else if (type !== typeLower) {
+    issues.push({
+      code: "type",
+      message: `Type should be lowercase. Use "${typeLower}" instead of "${type}".`,
+    });
+  }
+
+  if (scope !== null) {
+    if (!scope.trim()) {
+      issues.push({
+        code: "scope",
+        message: "Scope is empty. Either remove the parentheses or add a short scope like (auth).",
+      });
+    } else if (/\s/.test(scope)) {
+      issues.push({
+        code: "scope",
+        message: "Scope should be a short kebab-case word without spaces (e.g. auth, api, ui).",
+      });
+    }
+  }
+
+  if (!subject) {
+    issues.push({
+      code: "subject_empty",
+      message: "Add a short subject after the colon describing what changed.",
+    });
+  } else {
+    if (/^[A-Z]/.test(subject)) {
+      issues.push({
+        code: "subject_case",
+        message: "Subject should start with a lowercase letter (e.g. \"add login form\").",
+      });
+    }
+    if (subject.endsWith(".")) {
+      issues.push({
+        code: "subject_period",
+        message: "Do not end the subject with a period.",
+      });
+    }
+    if (subject.length > MAX_SUBJECT_LENGTH) {
+      issues.push({
+        code: "subject_length",
+        message: `Subject is too long (${subject.length} chars). Keep it under ${MAX_SUBJECT_LENGTH} characters.`,
+      });
+    }
+  }
+
+  return {
+    valid: issues.length === 0,
+    issues,
+    parsed,
+  };
+}
+
+/**
+ * Attempt to rewrite an invalid (or rough) message into a valid Conventional Commit.
+ */
+export function suggestCommitRewrite(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return "feat: describe your change here";
+  }
+
+  const match = trimmed.match(HEADER_RE);
+  let type = "feat";
+  let scope: string | null = null;
+  let subject = trimmed;
+
+  if (match?.groups) {
+    const rawType = (match.groups.type ?? "").toLowerCase();
+    type = (ALLOWED_TYPES as readonly string[]).includes(rawType) ? rawType : "chore";
+    const rawScope = match.groups.scope;
+    if (rawScope && rawScope.trim() && !/\s/.test(rawScope.trim())) {
+      scope = rawScope.trim().toLowerCase();
+    }
+    subject = (match.groups.subject ?? "").trim() || "describe your change here";
+  } else {
+    // Heuristic: first word might be a type
+    const parts = trimmed.split(/\s+/);
+    const maybeType = parts[0]?.toLowerCase().replace(/:$/, "");
+    if ((ALLOWED_TYPES as readonly string[]).includes(maybeType)) {
+      type = maybeType;
+      subject = parts.slice(1).join(" ").replace(/^:\s*/, "").trim() || "describe your change here";
+    } else {
+      subject = trimmed;
+    }
+  }
+
+  subject = subject.replace(/\.$/, "");
+  if (subject) {
+    subject = subject.charAt(0).toLowerCase() + subject.slice(1);
+  }
+  if (subject.length > MAX_SUBJECT_LENGTH) {
+    subject = subject.slice(0, MAX_SUBJECT_LENGTH).trim();
+  }
+
+  return scope ? `${type}(${scope}): ${subject}` : `${type}: ${subject}`;
+}
+
+export function buildPrChecklistTemplate(commitMessage: string): string {
+  const msg = commitMessage.trim() || "feat: your change";
+  return `## Summary
+- ${msg}
+
+## Test plan
+- [ ] Ran relevant frontend/backend tests
+- [ ] Checked UI in light and dark theme (if UI change)
+- [ ] Updated docs if needed
+
+## Checklist
+- [ ] Conventional Commit message used
+- [ ] Scope matches the issue / PR title
+- [ ] No unrelated files included
+`;
+}
+
+export const COMMIT_TYPE_HINTS: { type: CommitType; hint: string }[] = [
+  { type: "feat", hint: "A new feature for users" },
+  { type: "fix", hint: "A bug fix" },
+  { type: "docs", hint: "Documentation only" },
+  { type: "style", hint: "Formatting, no logic change" },
+  { type: "refactor", hint: "Code change that neither fixes a bug nor adds a feature" },
+  { type: "perf", hint: "Performance improvement" },
+  { type: "test", hint: "Adding or fixing tests" },
+  { type: "build", hint: "Build system or dependencies" },
+  { type: "ci", hint: "CI configuration" },
+  { type: "chore", hint: "Maintenance tasks" },
+  { type: "revert", hint: "Reverts a previous commit" },
+];

--- a/frontend/src/lib/prDiffSummarizer.ts
+++ b/frontend/src/lib/prDiffSummarizer.ts
@@ -1,0 +1,347 @@
+/**
+ * PR Description Diff Summarizer — classify changed files and build a PR body.
+ * Pure client-side helper for first-time open-source contributors.
+ */
+
+export type ChangeArea =
+  | "frontend"
+  | "backend"
+  | "docs"
+  | "migrations"
+  | "tests"
+  | "ci"
+  | "infra"
+  | "other";
+
+export type ClassifiedFile = {
+  path: string;
+  areas: ChangeArea[];
+};
+
+export type DiffSummary = {
+  files: ClassifiedFile[];
+  areas: ChangeArea[];
+  counts: Partial<Record<ChangeArea, number>>;
+};
+
+export type ChecklistItem = {
+  id: string;
+  label: string;
+  area: ChangeArea | "general";
+};
+
+const STATUS_PREFIX =
+  /^(?:modified|new file|deleted|renamed|copied|both modified|added|unmerged):\s*/i;
+const SHORT_STATUS = /^[ MADRCU?!]{1,2}\s+/;
+
+/**
+ * Parse pasted file paths or `git status` / `git diff --name-only` output.
+ */
+export function parseChangedFiles(raw: string): string[] {
+  const lines = raw.replace(/\r\n/g, "\n").split("\n");
+  const paths: string[] = [];
+  const seen = new Set<string>();
+
+  for (const line of lines) {
+    let trimmed = line.trim();
+    if (!trimmed) continue;
+
+    // Skip decorative / header lines
+    if (
+      /^(changes|on branch|your branch|head detached|untracked|no changes|nothing to|#)/i.test(
+        trimmed,
+      )
+    ) {
+      continue;
+    }
+
+    // Drop "git status" style prefixes
+    trimmed = trimmed.replace(STATUS_PREFIX, "");
+    trimmed = trimmed.replace(SHORT_STATUS, "");
+
+    // Renames: "a -> b" or "a => b"
+    if (/\s->\s|\s=>\s/.test(trimmed)) {
+      trimmed = trimmed.split(/\s->\s|\s=>\s/).pop()?.trim() ?? trimmed;
+    }
+
+    // Strip surrounding quotes
+    trimmed = trimmed.replace(/^["']|["']$/g, "");
+
+    // Ignore lines that still look like prose (spaces without a path separator / extension)
+    if (!trimmed.includes("/") && !/\.\w+$/.test(trimmed)) {
+      continue;
+    }
+
+    // Normalize slashes
+    const path = trimmed.replace(/\\/g, "/");
+    if (!path || seen.has(path)) continue;
+    seen.add(path);
+    paths.push(path);
+  }
+
+  return paths;
+}
+
+export function classifyPath(path: string): ChangeArea[] {
+  const p = path.replace(/\\/g, "/").toLowerCase();
+  const areas: ChangeArea[] = [];
+
+  const isMigration =
+    /(^|\/)migrations?\//.test(p) ||
+    /\/\d{4}_.+\.py$/.test(p) ||
+    p.includes("migrate");
+
+  const isTest =
+    /(^|\/)tests?\//.test(p) ||
+    /(^|\/)e2e\//.test(p) ||
+    /\.(test|spec)\.[jt]sx?$/.test(p) ||
+    /_test\.py$/.test(p) ||
+    /test_.+\.py$/.test(p);
+
+  const isDocs =
+    /(^|\/)docs\//.test(p) ||
+    /\.mdx?$/.test(p) ||
+    /(^|\/)readme(\.|$)/i.test(p) ||
+    p.includes("contributing");
+
+  const isCi =
+    /(^|\/)\.github\//.test(p) ||
+    p.includes("workflow") ||
+    p.endsWith(".yml") ||
+    p.endsWith(".yaml");
+
+  const isInfra =
+    p.includes("docker") ||
+    p.includes("infra/") ||
+    p.includes("render.yaml") ||
+    p.includes("vercel.json");
+
+  const isFrontend =
+    /(^|\/)frontend\//.test(p) ||
+    /\.(tsx?|jsx?|css|scss)$/.test(p) ||
+    p.includes("tailwind") ||
+    p.includes("vite.config");
+
+  const isBackend =
+    /(^|\/)backend\//.test(p) ||
+    /\.py$/.test(p) ||
+    p.includes("requirements") ||
+    p.includes("manage.py") ||
+    p.includes("pytest");
+
+  if (isMigration) areas.push("migrations");
+  if (isTest) areas.push("tests");
+  if (isDocs) areas.push("docs");
+  if (isCi) areas.push("ci");
+  if (isInfra) areas.push("infra");
+  if (isFrontend) areas.push("frontend");
+  if (isBackend) areas.push("backend");
+
+  if (areas.length === 0) areas.push("other");
+  return [...new Set(areas)];
+}
+
+export function summarizeDiff(raw: string): DiffSummary {
+  const paths = parseChangedFiles(raw);
+  const files = paths.map((path) => ({
+    path,
+    areas: classifyPath(path),
+  }));
+
+  const counts: Partial<Record<ChangeArea, number>> = {};
+  for (const file of files) {
+    for (const area of file.areas) {
+      counts[area] = (counts[area] ?? 0) + 1;
+    }
+  }
+
+  const areas = (Object.keys(counts) as ChangeArea[]).sort();
+  return { files, areas, counts };
+}
+
+export function buildChecklist(summary: DiffSummary): ChecklistItem[] {
+  const items: ChecklistItem[] = [
+    {
+      id: "self-review",
+      label: "I have performed a self-review of my own code",
+      area: "general",
+    },
+    {
+      id: "style",
+      label: "My code follows the style guidelines of this project",
+      area: "general",
+    },
+  ];
+
+  const has = (area: ChangeArea) => (summary.counts[area] ?? 0) > 0;
+
+  if (has("frontend")) {
+    items.push(
+      {
+        id: "fe-test",
+        label: "Frontend tests pass: `cd frontend && npm run test`",
+        area: "frontend",
+      },
+      {
+        id: "fe-build",
+        label: "Frontend builds successfully: `cd frontend && npm run build`",
+        area: "frontend",
+      },
+      {
+        id: "fe-theme",
+        label: "Checked UI in light and dark theme (if UI change)",
+        area: "frontend",
+      },
+    );
+  }
+
+  if (has("backend")) {
+    items.push({
+      id: "be-test",
+      label: "Backend tests pass: `cd backend && pytest`",
+      area: "backend",
+    });
+  }
+
+  if (has("docs")) {
+    items.push({
+      id: "docs",
+      label: "Documentation updated (CONTENT_GUIDE / README / docs as needed)",
+      area: "docs",
+    });
+  }
+
+  if (has("migrations")) {
+    items.push({
+      id: "migrations",
+      label: "Noted migration steps / ran `python manage.py migrate` locally",
+      area: "migrations",
+    });
+  }
+
+  if (has("tests")) {
+    items.push({
+      id: "tests-added",
+      label: "Added or updated tests covering this change",
+      area: "tests",
+    });
+  }
+
+  if (has("ci")) {
+    items.push({
+      id: "ci",
+      label: "CI / workflow changes reviewed for breakage",
+      area: "ci",
+    });
+  }
+
+  if (has("infra")) {
+    items.push({
+      id: "infra",
+      label: "Deployment / Docker / env notes added if needed",
+      area: "infra",
+    });
+  }
+
+  items.push({
+    id: "git-diff",
+    label: "I have run `git diff` locally and verified my changes",
+    area: "general",
+  });
+
+  return items;
+}
+
+export type BuildPrBodyOptions = {
+  issueNumber?: string;
+  titleHint?: string;
+  summary?: DiffSummary;
+};
+
+/**
+ * Build a PR description inspired by `.github/pull_request_template.md`.
+ */
+export function buildPrDescription(
+  raw: string,
+  options: BuildPrBodyOptions = {},
+): string {
+  const summary = options.summary ?? summarizeDiff(raw);
+  const checklist = buildChecklist(summary);
+  const issue = options.issueNumber?.trim() || "<!-- issue number -->";
+  const titleHint =
+    options.titleHint?.trim() ||
+    (summary.files.length
+      ? `Update ${summary.areas.join(", ") || "project"} files`
+      : "Describe your changes");
+
+  const fileList =
+    summary.files.length > 0
+      ? summary.files.map((f) => `- \`${f.path}\` (${f.areas.join(", ")})`).join("\n")
+      : "- <!-- paste changed files after generating -->";
+
+  const typeChecks = [
+    summary.areas.includes("docs") && !summary.areas.some((a) => a !== "docs")
+      ? "- [x] 📝 Documentation update (no code changes)"
+      : "- [ ] 📝 Documentation update (no code changes)",
+    summary.areas.includes("frontend") || summary.areas.includes("backend")
+      ? "- [x] ✨ New feature (non-breaking change which adds functionality)"
+      : "- [ ] ✨ New feature (non-breaking change which adds functionality)",
+    "- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)",
+    "- [ ] 🛠️ Refactoring (no functional changes)",
+    summary.areas.includes("ci")
+      ? "- [x] ⚙️ CI/CD or build pipeline change"
+      : "- [ ] ⚙️ CI/CD or build pipeline change",
+  ].join("\n");
+
+  const howTested = checklist
+    .filter((i) => i.area === "frontend" || i.area === "backend")
+    .map((i) => `- [ ] ${i.label}`)
+    .join("\n");
+
+  const prePush = checklist.map((i) => `- [ ] ${i.label}`).join("\n");
+
+  return `## Description
+
+${titleHint}
+
+Fixes #${issue}
+
+### Changed files
+${fileList}
+
+## Type of Change
+
+${typeChecks}
+
+## How Has This Been Tested?
+
+### Automated Tests
+${howTested || "- [ ] Add relevant test commands based on changed areas"}
+
+### Manual Verification
+- [ ] Verified the user flow related to this change
+
+## Pre-Push Checklist
+
+${prePush}
+
+## Deployment Notes
+
+${
+  summary.areas.includes("migrations")
+    ? "- Requires running database migrations after deploy"
+    : "- <!-- Add deployment / env notes if needed -->"
+}
+`;
+}
+
+export const AREA_LABELS: Record<ChangeArea, string> = {
+  frontend: "Frontend",
+  backend: "Backend",
+  docs: "Docs",
+  migrations: "Migrations",
+  tests: "Tests",
+  ci: "CI",
+  infra: "Infra",
+  other: "Other",
+};

--- a/frontend/src/pages/ContributorSandboxPage.tsx
+++ b/frontend/src/pages/ContributorSandboxPage.tsx
@@ -11,6 +11,8 @@ import {
   CheckCircle,
 } from "lucide-react";
 import { SectionCard } from "../components/ui/SectionCard";
+import { CommitMessageCoach } from "../components/ui/CommitMessageCoach";
+import { validateCommitMessage } from "../lib/conventionalCommitCoach";
 
 type Step = "setup" | "fix" | "commit" | "pr" | "success";
 
@@ -121,13 +123,11 @@ export function ContributorSandboxPage() {
   const startLinterRun = () => {
     if (!commitMsg.trim()) return;
 
-    // Check for conventional commit structure
-    const isConventional = /^(feat|fix|docs|refactor|chore)(\(.+\))?:/.test(
-      commitMsg,
-    );
-    if (!isConventional) {
+    const validation = validateCommitMessage(commitMsg);
+    if (!validation.valid) {
       alert(
-        "Our project requires Conventional Commits! Format: 'feat: add feature' or 'fix: resolve issue'",
+        validation.issues[0]?.message ??
+          "Our project requires Conventional Commits! Format: 'feat: add feature' or 'fix: resolve issue'",
       );
       return;
     }
@@ -357,18 +357,12 @@ export function ContributorSandboxPage() {
               </div>
 
               <div className="space-y-4">
-                <div>
-                  <label className="block text-sm font-black mb-2">
-                    Commit Message
-                  </label>
-                  <input
-                    type="text"
-                    value={commitMsg}
-                    onChange={(e) => setCommitMsg(e.target.value)}
-                    className="w-full border-4 border-black px-4 py-3 rounded-xl font-mono text-sm bg-white text-black shadow-card dark:bg-[#151411] dark:border-[#2e2924] dark:text-[#f0ebe2]"
-                    placeholder="e.g. fix: handle unexpected errors in token decoding"
-                  />
-                </div>
+                <CommitMessageCoach
+                  value={commitMsg}
+                  onChange={setCommitMsg}
+                  compact
+                  defaultValue=""
+                />
 
                 {isLinterRunning && (
                   <div className="bg-surface-low dark:bg-[#151411] p-4 rounded-xl border-2 border-black flex items-center gap-3">

--- a/frontend/src/pages/ContributorSandboxPage.tsx
+++ b/frontend/src/pages/ContributorSandboxPage.tsx
@@ -12,7 +12,9 @@ import {
 } from "lucide-react";
 import { SectionCard } from "../components/ui/SectionCard";
 import { CommitMessageCoach } from "../components/ui/CommitMessageCoach";
+import { PrDiffSummarizer } from "../components/ui/PrDiffSummarizer";
 import { validateCommitMessage } from "../lib/conventionalCommitCoach";
+import { Link } from "react-router-dom";
 
 type Step = "setup" | "fix" | "commit" | "pr" | "success";
 
@@ -451,6 +453,27 @@ export function ContributorSandboxPage() {
                     credentials leaked
                   </div>
                 </div>
+              </div>
+
+              <div className="space-y-2">
+                <p className="text-sm font-black text-text dark:text-[#f0ebe2]">
+                  Practice writing your PR description
+                </p>
+                <p className="text-xs text-muted dark:text-[#c4bbae] font-bold">
+                  Paste changed files to generate a checklist-ready PR body. Full
+                  tool:{" "}
+                  <Link
+                    to="/pr-diff-summarizer"
+                    className="underline text-accent hover:opacity-80"
+                  >
+                    /pr-diff-summarizer
+                  </Link>
+                </p>
+                <PrDiffSummarizer
+                  compact
+                  defaultIssueNumber=""
+                  className="shadow-none"
+                />
               </div>
 
               <div className="flex justify-end gap-3 mt-6">

--- a/frontend/src/pages/LessonPage.tsx
+++ b/frontend/src/pages/LessonPage.tsx
@@ -65,6 +65,7 @@ const MarkdownRenderer = React.lazy(() =>
 import { LessonHistoryModal } from "../components/LessonHistoryModal";
 import { GitGraph } from "../components/ui/GitGraph";
 import { NotePanel } from "../components/ui/NotePanel";
+import { CommitMessageCoach } from "../components/ui/CommitMessageCoach";
 import { LessonFeedbackWidget } from "../components/ui/LessonFeedbackWidget";
 import { PythonSandbox } from "../components/ui/PythonSandbox";
 const CollabPythonSandbox = React.lazy(() =>
@@ -179,6 +180,7 @@ export function LessonPage() {
 
   // Note Panel
   const [isNotePanelOpen, setIsNotePanelOpen] = useState(false);
+  const [isCommitCoachOpen, setIsCommitCoachOpen] = useState(false);
 
   // Reading progress scroll ref
   const mainContentRef = useRef<HTMLDivElement>(null);
@@ -1329,9 +1331,21 @@ export function LessonPage() {
         </div>
 
         {/* Mentor Help Trigger Row */}
-        <div className="border-t-4 border-black p-4 bg-white dark:bg-[#151411] dark:border-[#2e2924] flex justify-end gap-4 flex-shrink-0">
+        <div className="border-t-4 border-black p-4 bg-white dark:bg-[#151411] dark:border-[#2e2924] flex justify-end gap-4 flex-shrink-0 flex-wrap">
           <button
-            onClick={() => setIsNotePanelOpen(!isNotePanelOpen)}
+            onClick={() => {
+              setIsCommitCoachOpen(!isCommitCoachOpen);
+              if (!isCommitCoachOpen) setIsNotePanelOpen(false);
+            }}
+            className="px-4 py-2 bg-white text-text dark:bg-[#151411] dark:text-[#f0ebe2] font-black text-xs rounded-lg border-4 border-black shadow-card-sm hover:-translate-y-0.5 cursor-pointer"
+          >
+            {isCommitCoachOpen ? "Close Commit Coach" : "Commit Coach"}
+          </button>
+          <button
+            onClick={() => {
+              setIsNotePanelOpen(!isNotePanelOpen);
+              if (!isNotePanelOpen) setIsCommitCoachOpen(false);
+            }}
             className="px-4 py-2 bg-white text-text dark:bg-[#151411] dark:text-[#f0ebe2] font-black text-xs rounded-lg border-4 border-black shadow-card-sm hover:-translate-y-0.5 cursor-pointer"
           >
             {isNotePanelOpen ? "Close Notes 📝" : "Notes 📝"}
@@ -1353,6 +1367,38 @@ export function LessonPage() {
           lessonSlug={lesson.slug}
           onClose={() => setIsNotePanelOpen(false)}
         />
+      )}
+
+      {isCommitCoachOpen && (
+        <div className="fixed inset-0 z-50 flex justify-end bg-black/40">
+          <button
+            type="button"
+            aria-label="Close commit message coach"
+            className="flex-1 cursor-default"
+            onClick={() => setIsCommitCoachOpen(false)}
+          />
+          <aside className="h-full w-full max-w-md overflow-y-auto bg-surface-lowest border-l-4 border-black p-6 shadow-card space-y-4 dark:bg-[#0f0e0c] dark:border-[#2e2924]">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <h2 className="text-2xl font-black text-text dark:text-[#f0ebe2]">
+                  Practice your commit
+                </h2>
+                <p className="text-xs text-muted mt-1 dark:text-[#c4bbae]">
+                  Draft a Conventional Commit while you learn — then copy it
+                  into your real PR.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setIsCommitCoachOpen(false)}
+                className="px-3 py-1 border-2 border-black rounded-lg font-black text-xs hover:bg-surface-low dark:border-[#2e2924] dark:text-[#f0ebe2]"
+              >
+                Close
+              </button>
+            </div>
+            <CommitMessageCoach />
+          </aside>
+        </div>
       )}
 
       {isHelpPanelOpen && (

--- a/frontend/src/pages/PrDiffSummarizerPage.tsx
+++ b/frontend/src/pages/PrDiffSummarizerPage.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { SectionCard } from "../components/ui/SectionCard";
+import { PrDiffSummarizer } from "../components/ui/PrDiffSummarizer";
+
+export function PrDiffSummarizerPage() {
+  return (
+    <div className="space-y-8 max-w-4xl mx-auto pb-16">
+      <SectionCard
+        eyebrow="Contribution Workflow"
+        title="PR Description Diff Summarizer"
+      >
+        <p className="max-w-3xl text-sm leading-6 text-muted dark:text-[#c4bbae] font-bold">
+          Paste your changed files (or{" "}
+          <code className="bg-surface-low dark:bg-black px-1.5 py-0.5 rounded font-mono">
+            git diff --name-only
+          </code>
+          ) and get a beginner-friendly PR checklist + description template —
+          no API keys, fully client-side.
+        </p>
+      </SectionCard>
+
+      <PrDiffSummarizer />
+    </div>
+  );
+}
+
+export default PrDiffSummarizerPage;

--- a/frontend/src/test/conventionalCommitCoach.test.ts
+++ b/frontend/src/test/conventionalCommitCoach.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import {
+  validateCommitMessage,
+  suggestCommitRewrite,
+  buildPrChecklistTemplate,
+  ALLOWED_TYPES,
+} from "../lib/conventionalCommitCoach";
+
+describe("validateCommitMessage", () => {
+  it("rejects empty messages", () => {
+    const result = validateCommitMessage("   ");
+    expect(result.valid).toBe(false);
+    expect(result.issues[0]?.code).toBe("empty");
+  });
+
+  it("accepts a valid feat message", () => {
+    const result = validateCommitMessage("feat: add commit coach widget");
+    expect(result.valid).toBe(true);
+    expect(result.issues).toHaveLength(0);
+    expect(result.parsed.type).toBe("feat");
+    expect(result.parsed.subject).toBe("add commit coach widget");
+  });
+
+  it("accepts optional scope", () => {
+    const result = validateCommitMessage("fix(auth): handle expired tokens");
+    expect(result.valid).toBe(true);
+    expect(result.parsed.scope).toBe("auth");
+  });
+
+  it("rejects unknown types with plain-English help", () => {
+    const result = validateCommitMessage("update: bump deps");
+    expect(result.valid).toBe(false);
+    expect(result.issues.some((i) => i.code === "type")).toBe(true);
+    expect(result.issues[0]?.message).toMatch(/not a known type/i);
+  });
+
+  it("rejects uppercase subject start", () => {
+    const result = validateCommitMessage("feat: Add login form");
+    expect(result.valid).toBe(false);
+    expect(result.issues.some((i) => i.code === "subject_case")).toBe(true);
+  });
+
+  it("rejects trailing period on subject", () => {
+    const result = validateCommitMessage("docs: update readme.");
+    expect(result.valid).toBe(false);
+    expect(result.issues.some((i) => i.code === "subject_period")).toBe(true);
+  });
+
+  it("rejects empty scope parentheses", () => {
+    const result = validateCommitMessage("chore(): clean scripts");
+    expect(result.valid).toBe(false);
+    expect(result.issues.some((i) => i.code === "scope")).toBe(true);
+  });
+
+  it("rejects malformed format", () => {
+    const result = validateCommitMessage("just a random sentence");
+    expect(result.valid).toBe(false);
+    expect(result.issues.some((i) => i.code === "format")).toBe(true);
+  });
+
+  it("exposes the allowed type list", () => {
+    expect(ALLOWED_TYPES).toContain("feat");
+    expect(ALLOWED_TYPES).toContain("fix");
+    expect(ALLOWED_TYPES).toContain("docs");
+  });
+});
+
+describe("suggestCommitRewrite", () => {
+  it("returns a starter template for empty input", () => {
+    expect(suggestCommitRewrite("")).toBe("feat: describe your change here");
+  });
+
+  it("lowercases type and subject and strips trailing period", () => {
+    expect(suggestCommitRewrite("Feat: Add Login Form.")).toBe(
+      "feat: add Login Form",
+    );
+  });
+
+  it("maps unknown typed headers to chore", () => {
+    expect(suggestCommitRewrite("update: bump lodash")).toBe(
+      "chore: bump lodash",
+    );
+  });
+
+  it("prefixes bare subjects with feat", () => {
+    expect(suggestCommitRewrite("add heatmap widget")).toBe(
+      "feat: add heatmap widget",
+    );
+  });
+});
+
+describe("buildPrChecklistTemplate", () => {
+  it("includes the commit message and checklist items", () => {
+    const text = buildPrChecklistTemplate("feat: add coach");
+    expect(text).toContain("feat: add coach");
+    expect(text).toContain("## Summary");
+    expect(text).toContain("Conventional Commit message used");
+  });
+});

--- a/frontend/src/test/prDiffSummarizer.test.ts
+++ b/frontend/src/test/prDiffSummarizer.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseChangedFiles,
+  classifyPath,
+  summarizeDiff,
+  buildChecklist,
+  buildPrDescription,
+} from "../lib/prDiffSummarizer";
+
+describe("parseChangedFiles", () => {
+  it("parses plain paths", () => {
+    const paths = parseChangedFiles(
+      "frontend/src/App.tsx\nbackend/apps/content/models.py\n",
+    );
+    expect(paths).toEqual([
+      "frontend/src/App.tsx",
+      "backend/apps/content/models.py",
+    ]);
+  });
+
+  it("parses git status style lines", () => {
+    const paths = parseChangedFiles(`
+On branch feat/pr-tool
+Changes not staged for commit:
+  modified:   frontend/src/lib/prDiffSummarizer.ts
+  new file:   docs/CONTENT_GUIDE.md
+`);
+    expect(paths).toContain("frontend/src/lib/prDiffSummarizer.ts");
+    expect(paths).toContain("docs/CONTENT_GUIDE.md");
+  });
+
+  it("parses short status prefixes", () => {
+    const paths = parseChangedFiles("M  frontend/src/a.ts\n?? backend/b.py\n");
+    expect(paths).toEqual(["frontend/src/a.ts", "backend/b.py"]);
+  });
+
+  it("deduplicates paths", () => {
+    const paths = parseChangedFiles("a/b.ts\na/b.ts\n");
+    expect(paths).toEqual(["a/b.ts"]);
+  });
+});
+
+describe("classifyPath", () => {
+  it("detects frontend paths", () => {
+    expect(classifyPath("frontend/src/App.tsx")).toContain("frontend");
+  });
+
+  it("detects backend paths", () => {
+    expect(classifyPath("backend/apps/content/views.py")).toContain("backend");
+  });
+
+  it("detects docs and markdown", () => {
+    expect(classifyPath("docs/CONTENT_GUIDE.md")).toEqual(
+      expect.arrayContaining(["docs"]),
+    );
+    expect(classifyPath("README.md")).toContain("docs");
+  });
+
+  it("detects migrations", () => {
+    expect(
+      classifyPath("backend/apps/progress/migrations/0012_example.py"),
+    ).toEqual(expect.arrayContaining(["migrations", "backend"]));
+  });
+
+  it("detects tests", () => {
+    expect(classifyPath("frontend/src/test/prDiffSummarizer.test.ts")).toEqual(
+      expect.arrayContaining(["tests", "frontend"]),
+    );
+  });
+
+  it("detects ci workflows", () => {
+    expect(classifyPath(".github/workflows/ci.yml")).toEqual(
+      expect.arrayContaining(["ci"]),
+    );
+  });
+});
+
+describe("summarizeDiff + checklist", () => {
+  it("aggregates areas and builds relevant checklist items", () => {
+    const summary = summarizeDiff(`
+frontend/src/pages/PrDiffSummarizerPage.tsx
+backend/apps/accounts/models.py
+backend/apps/accounts/migrations/0003_foo.py
+docs/ARCHITECTURE.md
+`);
+    expect(summary.areas).toEqual(
+      expect.arrayContaining(["frontend", "backend", "migrations", "docs"]),
+    );
+
+    const checklist = buildChecklist(summary);
+    const labels = checklist.map((i) => i.label).join("\n");
+    expect(labels).toMatch(/npm run test/);
+    expect(labels).toMatch(/pytest/);
+    expect(labels).toMatch(/migrate/i);
+    expect(labels).toMatch(/Documentation/);
+  });
+});
+
+describe("buildPrDescription", () => {
+  it("includes issue number, files, and template sections", () => {
+    const body = buildPrDescription("frontend/src/App.tsx\ndocs/README.md", {
+      issueNumber: "1822",
+      titleHint: "Add PR summarizer",
+    });
+    expect(body).toContain("Fixes #1822");
+    expect(body).toContain("Add PR summarizer");
+    expect(body).toContain("frontend/src/App.tsx");
+    expect(body).toContain("## Pre-Push Checklist");
+    expect(body).toContain("## Type of Change");
+  });
+
+  it("handles empty input without crashing", () => {
+    const body = buildPrDescription("   ");
+    expect(body).toContain("## Description");
+  });
+});

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -38,9 +38,6 @@ export default defineConfig({
         type: "module",
       },
     }),
-    storybookTest({
-      configDir: path.join(dirname, ".storybook"),
-    }),
   ],
   resolve: {
     dedupe: ["react", "react-dom", "react-i18next"],
@@ -50,6 +47,7 @@ export default defineConfig({
       {
         extends: true,
         test: {
+          name: "unit",
           environment: "jsdom",
           setupFiles: "./src/test/setup.ts",
           include: ["src/**/*.test.{ts,tsx}"],
@@ -58,6 +56,11 @@ export default defineConfig({
       },
       {
         extends: true,
+        plugins: [
+          storybookTest({
+            configDir: path.join(dirname, ".storybook"),
+          }),
+        ],
         test: {
           name: "storybook",
           browser: {


### PR DESCRIPTION
# #1822 issue resolved
## Description
This PR adds a beginner-friendly PR Description Diff Summarizer under the contribution workflow experience (/pr-diff-summarizer and /contributor-sandbox).

## Features

- Paste file paths or git status / git diff --name-only output
- Detects backend/, frontend/, docs/, *.md, and migrations
- Auto-builds a PR checklist from detected change areas
- Generates a PR body template in project PR-template style
- One-click copy-to-clipboard for the full PR description
- Dark/light theme compatible UI with Vitest coverage for classification rules