### PR TITLE
Lesson “Explain Like I’m New” Glossary Drawer

### DIFF
--- a/docs/CONTENT_GUIDE.md
+++ b/docs/CONTENT_GUIDE.md
@@ -12,6 +12,8 @@ All educational content is located in the `frontend/public/content/` folder:
 ```text
 frontend/public/content/
 ├── curriculum.json             # Main catalog mapping modules, lessons, quizzes, and tasks
+├── glossary.json               # “Explain like I’m new” OSS jargon for lesson markdown
+├── git-cheatsheet-map.json     # Contextual Git terminal cheat-sheet by lesson/module
 ├── module-1/                   # Markdown files for Module 1
 │   ├── what-is-open-source.md
 │   └── ...
@@ -101,3 +103,37 @@ We support:
    Use `-` for bullets, and `1.` for ordered lists.
 5. **Inline Styling**:
    Use `**bold**`, `` `inline code` ``, and `[links](url)`.
+
+---
+
+## Part 4: Lesson Glossary (“Explain Like I’m New”)
+
+Lessons automatically highlight known open-source jargon from [`glossary.json`](../frontend/public/content/glossary.json). Clicking a dotted-underline term opens a short plain-English drawer.
+
+### Adding a term
+
+Edit `frontend/public/content/glossary.json` and append an object to `"terms"`:
+
+```json
+{
+  "id": "upstream",
+  "term": "upstream",
+  "aliases": [],
+  "short": "The original project you forked from.",
+  "definition": "Upstream usually means the main/original repository…"
+}
+```
+
+- **`id`**: Stable unique key (kebab-case).
+- **`term`**: Primary phrase shown in the drawer title.
+- **`aliases`**: Optional alternate spellings/plurals matched in lesson text (e.g. `"PRs"`, `"pull requests"`).
+- **`short`**: One-line summary (also used for `aria-describedby` / tooltip).
+- **`definition`**: Beginner-friendly explanation.
+
+### Matching rules
+
+- Matching is **case-insensitive** and uses **word boundaries** (so `commit` won’t match `commitment`).
+- Longer phrases win (e.g. `good first issue` before `issue`).
+- Terms inside **fenced code blocks** and **inline `` `code` ``** are **not** linked (avoids false positives).
+
+No React or database changes are required to add glossary terms.

--- a/frontend/public/content/git-cheatsheet-map.json
+++ b/frontend/public/content/git-cheatsheet-map.json
@@ -1,0 +1,145 @@
+{
+  "defaultCommandIds": [
+    "git-status",
+    "git-init",
+    "git-add",
+    "git-commit",
+    "git-log"
+  ],
+  "modules": {
+    "module-1": ["git-status", "git-clone", "git-log"],
+    "module-2": [
+      "git-init",
+      "git-status",
+      "git-add",
+      "git-commit",
+      "git-branch",
+      "git-switch",
+      "git-checkout",
+      "git-merge",
+      "git-log",
+      "git-diff"
+    ],
+    "module-3": [
+      "git-clone",
+      "git-remote",
+      "git-fetch",
+      "git-pull",
+      "git-push",
+      "git-status",
+      "git-branch",
+      "git-log"
+    ],
+    "module-4": ["git-status", "git-log", "git-diff", "git-commit"],
+    "module-5": [
+      "git-clone",
+      "git-switch",
+      "git-add",
+      "git-commit",
+      "git-push",
+      "git-status",
+      "git-remote"
+    ],
+    "module-6": [
+      "git-status",
+      "git-pull",
+      "git-push",
+      "git-log",
+      "git-diff"
+    ],
+    "module-7": [
+      "git-rebase",
+      "git-status",
+      "git-add",
+      "git-commit",
+      "git-log",
+      "git-diff",
+      "git-merge"
+    ],
+    "module-8": ["git-clone", "git-remote", "git-status", "git-log"]
+  },
+  "lessons": {
+    "repositories-and-commits": [
+      "git-init",
+      "git-status",
+      "git-add",
+      "git-commit",
+      "git-log"
+    ],
+    "branches": [
+      "git-branch",
+      "git-switch",
+      "git-checkout",
+      "git-status",
+      "git-log"
+    ],
+    "merging": ["git-merge", "git-status", "git-log", "git-diff"],
+    "remotes": ["git-remote", "git-fetch", "git-pull", "git-push", "git-status"],
+    "git-workflow": [
+      "git-status",
+      "git-add",
+      "git-commit",
+      "git-diff",
+      "git-log"
+    ],
+    "github-repositories": ["git-clone", "git-remote", "git-status", "git-log"],
+    "forks": ["git-clone", "git-remote", "git-fetch", "git-pull", "git-push"],
+    "pull-requests": [
+      "git-switch",
+      "git-push",
+      "git-status",
+      "git-log",
+      "git-diff"
+    ],
+    "first-contribution-walkthrough": [
+      "git-clone",
+      "git-switch",
+      "git-add",
+      "git-commit",
+      "git-push",
+      "git-status"
+    ],
+    "rebasing-and-squashing": [
+      "git-rebase",
+      "git-status",
+      "git-log",
+      "git-commit"
+    ],
+    "conflict-resolution": [
+      "git-status",
+      "git-add",
+      "git-diff",
+      "git-merge",
+      "git-rebase"
+    ]
+  },
+  "slugToModule": {
+    "what-is-open-source": "module-1",
+    "why-open-source-matters": "module-1",
+    "history-of-open-source": "module-1",
+    "benefits-of-contributing": "module-1",
+    "common-misconceptions": "module-1",
+    "open-source-licenses": "module-1",
+    "repositories-and-commits": "module-2",
+    "branches": "module-2",
+    "merging": "module-2",
+    "remotes": "module-2",
+    "git-workflow": "module-2",
+    "github-repositories": "module-3",
+    "forks": "module-3",
+    "pull-requests": "module-3",
+    "issues": "module-3",
+    "discussions": "module-3",
+    "organizations": "module-3",
+    "respect-and-communication": "module-4",
+    "read-readme-and-contributing": "module-4",
+    "professional-prs-and-issues": "module-4",
+    "maintainer-review-processes": "module-4",
+    "first-contribution-walkthrough": "module-5",
+    "contribution-lifecycle": "module-6",
+    "rebasing-and-squashing": "module-7",
+    "conflict-resolution": "module-7",
+    "code-reviews-and-cicd": "module-7",
+    "finding-projects": "module-8"
+  }
+}

--- a/frontend/public/content/glossary.json
+++ b/frontend/public/content/glossary.json
@@ -1,0 +1,144 @@
+{
+  "terms": [
+    {
+      "id": "fork",
+      "term": "fork",
+      "aliases": ["forks", "forked"],
+      "short": "Your personal copy of someone else’s repository on GitHub.",
+      "definition": "A fork is your own copy of a project. You can change it freely, then open a pull request to suggest those changes back to the original project."
+    },
+    {
+      "id": "upstream",
+      "term": "upstream",
+      "aliases": [],
+      "short": "The original project you forked from.",
+      "definition": "Upstream usually means the main/original repository. After you fork, you pull updates from upstream so your copy stays current."
+    },
+    {
+      "id": "origin",
+      "term": "origin",
+      "aliases": [],
+      "short": "The default name for your remote repository on GitHub.",
+      "definition": "Origin is just a nickname Git uses for a remote URL—usually your fork or the repo you cloned. It is not a special Git command."
+    },
+    {
+      "id": "clone",
+      "term": "clone",
+      "aliases": ["cloning"],
+      "short": "Download a repository to your computer.",
+      "definition": "Cloning copies a remote Git repo (including history) onto your machine so you can work locally."
+    },
+    {
+      "id": "commit",
+      "term": "commit",
+      "aliases": ["commits"],
+      "short": "A saved snapshot of your changes with a message.",
+      "definition": "A commit records a set of staged changes plus a message. Think of it as a checkpoint you can return to later."
+    },
+    {
+      "id": "branch",
+      "term": "branch",
+      "aliases": ["branches"],
+      "short": "A separate line of work in Git.",
+      "definition": "Branches let you try changes without breaking the main line of the project. You usually create a branch for each bugfix or feature."
+    },
+    {
+      "id": "rebase",
+      "term": "rebase",
+      "aliases": ["rebasing"],
+      "short": "Replay your commits on top of another branch.",
+      "definition": "Rebasing moves your commits onto a newer base (often main). It can keep history cleaner, but you should avoid rebasing shared commits until you know the risks."
+    },
+    {
+      "id": "merge-conflict",
+      "term": "merge conflict",
+      "aliases": ["merge conflicts"],
+      "short": "When Git can’t auto-combine two sets of edits.",
+      "definition": "A merge conflict happens when two branches changed the same lines. You manually choose the correct final text, then mark the conflict resolved."
+    },
+    {
+      "id": "pull-request",
+      "term": "pull request",
+      "aliases": ["pull requests", "PR", "PRs"],
+      "short": "A proposal to merge your changes into a project.",
+      "definition": "A pull request (PR) shows your commits, lets others review them, and—if approved—merges your branch into the target branch (often main)."
+    },
+    {
+      "id": "issue",
+      "term": "issue",
+      "aliases": ["issues"],
+      "short": "A tracked bug report, idea, or task on GitHub.",
+      "definition": "Issues are discussion tickets. They help maintainers and contributors track bugs, features, and questions in one place."
+    },
+    {
+      "id": "maintainer",
+      "term": "maintainer",
+      "aliases": ["maintainers"],
+      "short": "People who review and steward the project.",
+      "definition": "Maintainers decide what gets merged, keep the project healthy, and guide contributors. Be patient and respectful when waiting for review."
+    },
+    {
+      "id": "contributor",
+      "term": "contributor",
+      "aliases": ["contributors"],
+      "short": "Anyone who helps a project (code, docs, design, triage).",
+      "definition": "Contributors improve a project by submitting PRs, fixing docs, reporting bugs, or helping others. You don’t need to be an expert to contribute."
+    },
+    {
+      "id": "lgtm",
+      "term": "LGTM",
+      "aliases": ["lgtm"],
+      "short": "“Looks Good To Me” — a friendly approval shorthand.",
+      "definition": "Reviewers often write LGTM when a change looks ready to merge. It is informal approval, not a special GitHub button by itself."
+    },
+    {
+      "id": "good-first-issue",
+      "term": "good first issue",
+      "aliases": ["good-first-issue", "good first issues"],
+      "short": "A beginner-friendly task labeled for new contributors.",
+      "definition": "Projects mark some issues as good first issues so newcomers can start with smaller, well-scoped tasks."
+    },
+    {
+      "id": "code-review",
+      "term": "code review",
+      "aliases": ["code reviews"],
+      "short": "When someone checks your PR before it merges.",
+      "definition": "Code review is feedback on your changes—correctness, style, tests, and clarity. Treat comments as collaboration, not personal criticism."
+    },
+    {
+      "id": "ci",
+      "term": "CI",
+      "aliases": ["continuous integration"],
+      "short": "Automated checks that run on your PR.",
+      "definition": "Continuous Integration (CI) runs tests, linting, and builds automatically. A red CI check usually means something needs fixing before merge."
+    },
+    {
+      "id": "remote",
+      "term": "remote",
+      "aliases": ["remotes"],
+      "short": "A Git nickname for a repo hosted elsewhere (like GitHub).",
+      "definition": "A remote is a pointer to another copy of the repository, often on GitHub. Common remotes are origin (your copy) and upstream (the original)."
+    },
+    {
+      "id": "staging",
+      "term": "staging",
+      "aliases": ["staged", "stage"],
+      "short": "The holding area for files you plan to commit next.",
+      "definition": "Staging (`git add`) selects which changes go into the next commit. Unstaged edits stay in your working files until you add them."
+    },
+    {
+      "id": "main",
+      "term": "main",
+      "aliases": ["master"],
+      "short": "The default primary branch in many projects.",
+      "definition": "Main (sometimes still called master) is usually the stable default branch. Feature work typically happens on other branches, then merges into main."
+    },
+    {
+      "id": "changelog",
+      "term": "changelog",
+      "aliases": ["change log"],
+      "short": "A human-readable list of what changed between versions.",
+      "definition": "A changelog summarizes features, fixes, and breaking changes so users and contributors can quickly see what is new."
+    }
+  ]
+}

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -104,6 +104,12 @@ const ContributorSandboxPage = lazy(() =>
   })),
 );
 
+const PrDiffSummarizerPage = lazy(() =>
+  import("../pages/PrDiffSummarizerPage").then((module) => ({
+    default: module.PrDiffSummarizerPage,
+  })),
+);
+
 const ProfileSettingsPage = lazy(() =>
   import("../pages/ProfileSettingsPage").then((module) => ({
     default: module.ProfileSettingsPage,
@@ -353,6 +359,15 @@ export function AppRouter() {
             element={
               <ProtectedRoute>
                 <ContributorSandboxPage />
+              </ProtectedRoute>
+            }
+          />
+
+          <Route
+            path="/pr-diff-summarizer"
+            element={
+              <ProtectedRoute>
+                <PrDiffSummarizerPage />
               </ProtectedRoute>
             }
           />

--- a/frontend/src/components/layout/Navigation.tsx
+++ b/frontend/src/components/layout/Navigation.tsx
@@ -17,6 +17,7 @@ import {
   Eye,
   FileText,
   Target,
+  FileDiff,
 } from "lucide-react";
 import { Link, NavLink, useNavigate } from "react-router-dom";
 import { useTheme } from "../../hooks/useTheme";
@@ -41,6 +42,7 @@ const navGroups = [
     items: [
       { to: "/contributor-sandbox", label: "Playground", icon: TerminalSquare },
       { to: "/a11y-sandbox", label: "A11y Sandbox", icon: Eye },
+      { to: "/pr-diff-summarizer", label: "PR Summarizer", icon: FileDiff },
       { to: "/bounties", label: "Bounties", icon: Target },
     ],
   },

--- a/frontend/src/components/ui/CommitMessageCoach/CommitMessageCoach.tsx
+++ b/frontend/src/components/ui/CommitMessageCoach/CommitMessageCoach.tsx
@@ -1,0 +1,245 @@
+import React, { useMemo, useState } from "react";
+import {
+  CheckCircle2,
+  AlertCircle,
+  Copy,
+  Check,
+  Sparkles,
+  ClipboardList,
+} from "lucide-react";
+import {
+  validateCommitMessage,
+  suggestCommitRewrite,
+  buildPrChecklistTemplate,
+  COMMIT_TYPE_HINTS,
+  ALLOWED_TYPES,
+} from "../../lib/conventionalCommitCoach";
+
+export type CommitMessageCoachProps = {
+  /** Controlled value — when provided, parent owns the message */
+  value?: string;
+  /** Called whenever the message changes */
+  onChange?: (message: string) => void;
+  /** Compact layout for embedding inside simulators */
+  compact?: boolean;
+  className?: string;
+  defaultValue?: string;
+};
+
+export function CommitMessageCoach({
+  value,
+  onChange,
+  compact = false,
+  className = "",
+  defaultValue = "",
+}: CommitMessageCoachProps) {
+  const [internal, setInternal] = useState(defaultValue);
+  const [copiedKey, setCopiedKey] = useState<"message" | "pr" | null>(null);
+
+  const message = value !== undefined ? value : internal;
+
+  const setMessage = (next: string) => {
+    if (value === undefined) setInternal(next);
+    onChange?.(next);
+  };
+
+  const result = useMemo(() => validateCommitMessage(message), [message]);
+  const suggestion = useMemo(() => suggestCommitRewrite(message), [message]);
+  const showSuggestion = message.trim().length > 0 && !result.valid;
+
+  const copyText = async (text: string, key: "message" | "pr") => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopiedKey(key);
+      setTimeout(() => setCopiedKey(null), 2000);
+    } catch {
+      // Clipboard may be unavailable in insecure contexts
+    }
+  };
+
+  return (
+    <div
+      className={`rounded-2xl border-4 border-black bg-white p-4 shadow-card dark:bg-[#1f1c18] dark:border-[#2e2924] dark:shadow-none ${className}`}
+      data-testid="commit-message-coach"
+    >
+      <div className="flex items-start justify-between gap-3 mb-3">
+        <div>
+          <h3 className="text-lg font-black text-text dark:text-[#f0ebe2] flex items-center gap-2">
+            <Sparkles size={18} className="text-accent" aria-hidden />
+            Commit Message Coach
+          </h3>
+          {!compact && (
+            <p className="text-xs font-bold text-muted mt-1 dark:text-[#c4bbae]">
+              Practice Conventional Commits:{" "}
+              <code className="bg-surface-low dark:bg-black px-1 rounded font-mono">
+                type(scope): subject
+              </code>
+            </p>
+          )}
+        </div>
+        {message.trim() && (
+          <span
+            className={`shrink-0 text-[10px] font-black uppercase tracking-widest px-2 py-1 rounded-lg border-2 ${
+              result.valid
+                ? "bg-green-500/15 text-green-700 border-green-600 dark:text-green-400 dark:border-green-500"
+                : "bg-amber-500/15 text-amber-800 border-amber-600 dark:text-amber-300 dark:border-amber-500"
+            }`}
+            aria-live="polite"
+          >
+            {result.valid ? "Valid" : "Needs fixes"}
+          </span>
+        )}
+      </div>
+
+      <label className="block text-sm font-black mb-2 text-text dark:text-[#f0ebe2]">
+        Commit message
+        <input
+          type="text"
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          placeholder="e.g. feat(auth): add password reset flow"
+          className="mt-2 w-full border-4 border-black px-4 py-3 rounded-xl font-mono text-sm bg-white text-black shadow-card-sm dark:bg-[#151411] dark:border-[#2e2924] dark:text-[#f0ebe2] focus:outline-none focus:ring-2 focus:ring-accent"
+          aria-invalid={message.trim().length > 0 && !result.valid}
+          aria-describedby="commit-coach-feedback"
+        />
+      </label>
+
+      <div id="commit-coach-feedback" className="space-y-2 min-h-[1.5rem]">
+        {message.trim().length === 0 && (
+          <p className="text-xs text-muted font-bold dark:text-[#c4bbae]">
+            Tip: allowed types — {ALLOWED_TYPES.join(", ")}
+          </p>
+        )}
+
+        {result.valid && message.trim() && (
+          <div className="flex items-start gap-2 rounded-xl border-2 border-green-500 bg-green-500/10 p-3 text-sm font-bold text-green-700 dark:text-green-400">
+            <CheckCircle2 size={18} className="shrink-0 mt-0.5" aria-hidden />
+            <span>Looks great! This follows Conventional Commits.</span>
+          </div>
+        )}
+
+        {!result.valid &&
+          result.issues.map((issue) => (
+            <div
+              key={issue.code + issue.message}
+              className="flex items-start gap-2 rounded-xl border-2 border-amber-500 bg-amber-500/10 p-3 text-sm font-bold text-amber-900 dark:text-amber-200"
+              role="alert"
+            >
+              <AlertCircle size={18} className="shrink-0 mt-0.5" aria-hidden />
+              <span>{issue.message}</span>
+            </div>
+          ))}
+      </div>
+
+      {showSuggestion && (
+        <div className="mt-4 space-y-2 rounded-xl border-2 border-black/20 dark:border-[#2e2924] bg-surface-low dark:bg-[#151411] p-3">
+          <p className="text-[10px] font-black uppercase tracking-widest text-muted dark:text-[#c4bbae]">
+            Suggested rewrite
+          </p>
+          <code className="block font-mono text-sm break-all text-text dark:text-[#f0ebe2]">
+            {suggestion}
+          </code>
+          <div className="flex flex-wrap gap-2 pt-1">
+            <button
+              type="button"
+              onClick={() => setMessage(suggestion)}
+              className="px-3 py-1.5 text-xs font-black rounded-lg border-2 border-black bg-accent text-black shadow-card-sm hover:-translate-y-0.5 transition-all"
+            >
+              Apply fix
+            </button>
+            <button
+              type="button"
+              onClick={() => copyText(suggestion, "message")}
+              className="px-3 py-1.5 text-xs font-black rounded-lg border-2 border-black bg-white dark:bg-[#1f1c18] dark:text-[#f0ebe2] shadow-card-sm hover:-translate-y-0.5 transition-all inline-flex items-center gap-1"
+            >
+              {copiedKey === "message" ? (
+                <>
+                  <Check size={14} /> Copied
+                </>
+              ) : (
+                <>
+                  <Copy size={14} /> Copy rewrite
+                </>
+              )}
+            </button>
+          </div>
+        </div>
+      )}
+
+      <div className="mt-4 flex flex-wrap gap-2">
+        {result.valid && message.trim() && (
+          <button
+            type="button"
+            onClick={() => copyText(message.trim(), "message")}
+            className="px-3 py-1.5 text-xs font-black rounded-lg border-2 border-black bg-white dark:bg-[#151411] dark:text-[#f0ebe2] shadow-card-sm hover:-translate-y-0.5 transition-all inline-flex items-center gap-1"
+          >
+            {copiedKey === "message" ? (
+              <>
+                <Check size={14} /> Copied
+              </>
+            ) : (
+              <>
+                <Copy size={14} /> Copy message
+              </>
+            )}
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={() =>
+            copyText(
+              buildPrChecklistTemplate(
+                result.valid ? message.trim() : suggestion,
+              ),
+              "pr",
+            )
+          }
+          className="px-3 py-1.5 text-xs font-black rounded-lg border-2 border-black bg-white dark:bg-[#151411] dark:text-[#f0ebe2] shadow-card-sm hover:-translate-y-0.5 transition-all inline-flex items-center gap-1"
+        >
+          {copiedKey === "pr" ? (
+            <>
+              <Check size={14} /> Copied
+            </>
+          ) : (
+            <>
+              <ClipboardList size={14} /> Copy PR template
+            </>
+          )}
+        </button>
+      </div>
+
+      {!compact && (
+        <details className="mt-4 group">
+          <summary className="cursor-pointer text-xs font-black uppercase tracking-widest text-muted dark:text-[#c4bbae] list-none flex items-center gap-1">
+            <span className="group-open:rotate-90 transition-transform">▸</span>
+            Type cheat sheet
+          </summary>
+          <ul className="mt-2 grid grid-cols-1 sm:grid-cols-2 gap-1.5">
+            {COMMIT_TYPE_HINTS.map(({ type, hint }) => (
+              <li key={type}>
+                <button
+                  type="button"
+                  onClick={() =>
+                    setMessage(
+                      message.trim()
+                        ? suggestCommitRewrite(
+                            `${type}: ${result.parsed.subject ?? message}`,
+                          )
+                        : `${type}: `,
+                    )
+                  }
+                  className="w-full text-left px-2 py-1.5 rounded-lg border-2 border-black/10 dark:border-[#2e2924] hover:border-black dark:hover:border-[#c4bbae] text-xs transition-colors"
+                >
+                  <span className="font-mono font-black text-accent">{type}</span>
+                  <span className="text-muted dark:text-[#c4bbae]"> — {hint}</span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </details>
+      )}
+    </div>
+  );
+}
+
+export default CommitMessageCoach;

--- a/frontend/src/components/ui/CommitMessageCoach/index.ts
+++ b/frontend/src/components/ui/CommitMessageCoach/index.ts
@@ -1,0 +1,2 @@
+export { CommitMessageCoach } from "./CommitMessageCoach";
+export type { CommitMessageCoachProps } from "./CommitMessageCoach";

--- a/frontend/src/components/ui/ContextualGitCheatSheet.tsx
+++ b/frontend/src/components/ui/ContextualGitCheatSheet.tsx
@@ -1,0 +1,222 @@
+import React, { useEffect, useId, useRef, useState } from "react";
+import { HelpCircle, X, Copy, Check } from "lucide-react";
+import {
+  loadGitCheatSheetMap,
+  resolveContextualCommands,
+  type ContextualGitCommand,
+} from "../../lib/contextualGitCheatSheet";
+
+export type ContextualGitCheatSheetProps = {
+  lessonSlug?: string;
+  moduleId?: string;
+  /** Insert command into terminal input */
+  onInsertCommand?: (command: string) => void;
+  /** Compact floating "?" only (default true) */
+  className?: string;
+};
+
+export function ContextualGitCheatSheet({
+  lessonSlug,
+  moduleId,
+  onInsertCommand,
+  className = "",
+}: ContextualGitCheatSheetProps) {
+  const [open, setOpen] = useState(false);
+  const [commands, setCommands] = useState<ContextualGitCommand[]>([]);
+  const [sourceLabel, setSourceLabel] = useState("");
+  const [loadError, setLoadError] = useState("");
+  const [copied, setCopied] = useState<string | null>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const closeRef = useRef<HTMLButtonElement>(null);
+  const titleId = useId();
+
+  useEffect(() => {
+    let cancelled = false;
+    loadGitCheatSheetMap()
+      .then((map) => {
+        if (cancelled) return;
+        const resolved = resolveContextualCommands(lessonSlug, moduleId, map);
+        setCommands(resolved.commands);
+        const label =
+          resolved.source === "lesson" && lessonSlug
+            ? `For lesson: ${lessonSlug}`
+            : resolved.source === "module" && resolved.resolvedModuleId
+              ? `For module: ${resolved.resolvedModuleId}`
+              : "Starter Git commands";
+        setSourceLabel(label);
+        setLoadError("");
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setLoadError("Could not load contextual commands.");
+          setCommands([]);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [lessonSlug, moduleId]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setOpen(false);
+        triggerRef.current?.focus();
+      }
+    };
+
+    document.addEventListener("keydown", onKeyDown);
+    // Focus close button when opened
+    queueMicrotask(() => closeRef.current?.focus());
+
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [open]);
+
+  const handleCopy = async (command: string) => {
+    try {
+      await navigator.clipboard.writeText(command);
+      setCopied(command);
+      setTimeout(() => setCopied(null), 1500);
+    } catch {
+      // ignore
+    }
+  };
+
+  return (
+    <div className={`relative inline-flex ${className}`}>
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        aria-controls={open ? titleId : undefined}
+        title="Contextual Git cheat sheet"
+        onClick={() => setOpen(true)}
+        className="inline-flex items-center justify-center w-9 h-9 rounded-full border-4 border-black bg-accent text-black font-black shadow-card-sm hover:-translate-y-0.5 active:translate-y-0 transition-all dark:border-[#2e2924] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+      >
+        <HelpCircle size={18} aria-hidden />
+        <span className="sr-only">Open contextual Git cheat sheet</span>
+      </button>
+
+      {open && (
+        <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-4">
+          <button
+            type="button"
+            aria-label="Close cheat sheet backdrop"
+            className="absolute inset-0 bg-black/50"
+            onClick={() => {
+              setOpen(false);
+              triggerRef.current?.focus();
+            }}
+          />
+
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={titleId}
+            className="relative w-full max-w-lg max-h-[80vh] overflow-hidden rounded-2xl border-4 border-black bg-white shadow-card flex flex-col dark:bg-[#1f1c18] dark:border-[#2e2924]"
+          >
+            <div className="flex items-start justify-between gap-3 p-4 border-b-4 border-black dark:border-[#2e2924]">
+              <div>
+                <h2
+                  id={titleId}
+                  className="text-lg font-black text-text dark:text-[#f0ebe2]"
+                >
+                  Git cheat sheet
+                </h2>
+                <p className="text-xs font-bold text-muted mt-1 dark:text-[#c4bbae]">
+                  {sourceLabel || "Loading…"} · Press Esc to close
+                </p>
+              </div>
+              <button
+                ref={closeRef}
+                type="button"
+                onClick={() => {
+                  setOpen(false);
+                  triggerRef.current?.focus();
+                }}
+                className="p-2 rounded-lg border-2 border-black hover:bg-surface-low dark:border-[#2e2924] dark:text-[#f0ebe2] dark:hover:bg-[#151411]"
+                aria-label="Close cheat sheet"
+              >
+                <X size={18} />
+              </button>
+            </div>
+
+            <div className="overflow-y-auto p-4 space-y-3">
+              {loadError && (
+                <p className="text-sm font-bold text-red-600" role="alert">
+                  {loadError}
+                </p>
+              )}
+
+              {!loadError && commands.length === 0 && (
+                <p className="text-sm font-bold text-muted dark:text-[#c4bbae]">
+                  Loading commands…
+                </p>
+              )}
+
+              {commands.map((cmd) => (
+                <article
+                  key={cmd.id}
+                  className="rounded-xl border-2 border-black/15 dark:border-[#2e2924] bg-surface-low dark:bg-[#151411] p-3 space-y-1"
+                >
+                  <div className="flex items-start justify-between gap-2">
+                    <h3 className="text-sm font-black text-text dark:text-[#f0ebe2]">
+                      {cmd.name}
+                    </h3>
+                    <div className="flex gap-1 shrink-0">
+                      <button
+                        type="button"
+                        onClick={() => handleCopy(cmd.command)}
+                        className="px-2 py-1 text-[10px] font-black rounded-md border-2 border-black bg-white dark:bg-[#1f1c18] dark:text-[#f0ebe2] dark:border-[#2e2924] inline-flex items-center gap-1"
+                      >
+                        {copied === cmd.command ? (
+                          <>
+                            <Check size={12} /> Copied
+                          </>
+                        ) : (
+                          <>
+                            <Copy size={12} /> Copy
+                          </>
+                        )}
+                      </button>
+                      {onInsertCommand && (
+                        <button
+                          type="button"
+                          onClick={() => {
+                            onInsertCommand(cmd.command);
+                            setOpen(false);
+                            triggerRef.current?.focus();
+                          }}
+                          className="px-2 py-1 text-[10px] font-black rounded-md border-2 border-black bg-accent text-black"
+                        >
+                          Use
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                  <code className="block font-mono text-xs text-accent break-all">
+                    {cmd.command}
+                  </code>
+                  <p className="text-xs font-bold text-muted dark:text-[#c4bbae]">
+                    {cmd.description}
+                  </p>
+                  {cmd.example && (
+                    <pre className="text-[11px] font-mono whitespace-pre-wrap text-text/80 dark:text-[#c4bbae] bg-black/5 dark:bg-black/30 rounded-lg p-2 mt-1">
+                      {cmd.example}
+                    </pre>
+                  )}
+                </article>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default ContextualGitCheatSheet;

--- a/frontend/src/components/ui/GitTerminal.tsx
+++ b/frontend/src/components/ui/GitTerminal.tsx
@@ -6,6 +6,7 @@ import { useTerminalAutocomplete } from "../../hooks/useTerminalAutocomplete";
 import { useFailureAnimation } from "../../hooks/useFailureAnimation";
 import { Textarea } from "./Textarea";
 import { GitCheatSheet } from "./GitCheatSheet";
+import { ContextualGitCheatSheet } from "./ContextualGitCheatSheet";
 
 interface GitTerminalProps {
   /** Called when a lesson-objective command succeeds */
@@ -16,6 +17,10 @@ interface GitTerminalProps {
   title?: string;
   /** XP reward amount */
   xp?: number;
+  /** Current lesson slug — enables contextual cheat-sheet overlay */
+  lessonSlug?: string;
+  /** Curriculum module id (e.g. module-2) */
+  moduleId?: string;
 }
 
 function LineRenderer({ line }: { line: TerminalLine }) {
@@ -54,6 +59,8 @@ export function GitTerminal({
   hint,
   title = "Git Sandbox Terminal",
   xp = 20,
+  lessonSlug,
+  moduleId,
 }: GitTerminalProps) {
   const [isExecuting, setIsExecuting] = useState(false);
   const [inputVal, setInputVal] = useState("");
@@ -294,6 +301,13 @@ export function GitTerminal({
           <span className="text-xs font-black text-yellow-300 bg-black/40 px-2 py-0.5 rounded-full">
             {xp} XP
           </span>
+          {(lessonSlug || moduleId) && (
+            <ContextualGitCheatSheet
+              lessonSlug={lessonSlug}
+              moduleId={moduleId}
+              onInsertCommand={(command) => setInputVal(command)}
+            />
+          )}
           <button
             onClick={() => setShowCheatSheet(true)}
             title="Git Cheat Sheet"

--- a/frontend/src/components/ui/GlossaryDrawer.tsx
+++ b/frontend/src/components/ui/GlossaryDrawer.tsx
@@ -1,0 +1,103 @@
+import React, { useEffect, useRef } from "react";
+import { X, BookOpen } from "lucide-react";
+import type { GlossaryEntry } from "../../lib/glossary";
+
+export type GlossaryDrawerProps = {
+  entry: GlossaryEntry | null;
+  onClose: () => void;
+};
+
+export function GlossaryDrawer({ entry, onClose }: GlossaryDrawerProps) {
+  const closeRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!entry) return;
+
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    document.addEventListener("keydown", onKey);
+    queueMicrotask(() => closeRef.current?.focus());
+    return () => document.removeEventListener("keydown", onKey);
+  }, [entry, onClose]);
+
+  if (!entry) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex justify-end" role="presentation">
+      <button
+        type="button"
+        className="flex-1 cursor-default bg-black/40"
+        aria-label="Close glossary drawer"
+        onClick={onClose}
+      />
+      <aside
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="glossary-drawer-title"
+        className="h-full w-full max-w-md overflow-y-auto border-l-4 border-black bg-white p-6 shadow-card space-y-4 dark:bg-[#0f0e0c] dark:border-[#2e2924]"
+      >
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex items-start gap-3">
+            <span className="mt-1 p-2 rounded-xl border-2 border-black bg-accent/40 dark:border-[#2e2924]">
+              <BookOpen size={18} aria-hidden />
+            </span>
+            <div>
+              <p className="text-[10px] font-black uppercase tracking-widest text-muted dark:text-[#c4bbae]">
+                Explain like I&apos;m new
+              </p>
+              <h2
+                id="glossary-drawer-title"
+                className="text-2xl font-black text-text dark:text-[#f0ebe2]"
+              >
+                {entry.term}
+              </h2>
+            </div>
+          </div>
+          <button
+            ref={closeRef}
+            type="button"
+            onClick={onClose}
+            className="px-3 py-1 border-2 border-black rounded-lg font-black text-xs hover:bg-surface-low dark:border-[#2e2924] dark:text-[#f0ebe2]"
+            aria-label="Close glossary"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        <p className="text-sm font-black text-primary">{entry.short}</p>
+        <p className="text-sm font-bold leading-relaxed text-muted dark:text-[#c4bbae]">
+          {entry.definition}
+        </p>
+
+        {entry.aliases && entry.aliases.length > 0 && (
+          <div>
+            <p className="text-[10px] font-black uppercase tracking-widest text-muted dark:text-[#c4bbae] mb-2">
+              Also matched as
+            </p>
+            <div className="flex flex-wrap gap-2">
+              {entry.aliases.map((alias) => (
+                <span
+                  key={alias}
+                  className="text-xs font-mono font-bold px-2 py-1 rounded-lg border-2 border-black/15 dark:border-[#2e2924] bg-surface-low dark:bg-[#151411]"
+                >
+                  {alias}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <p className="text-xs font-bold text-muted dark:text-[#c4bbae] pt-2 border-t-2 border-black/10 dark:border-[#2e2924]">
+          Tip: glossary terms are underlined with dots in lesson text. Press Esc
+          to close.
+        </p>
+      </aside>
+    </div>
+  );
+}
+
+export default GlossaryDrawer;

--- a/frontend/src/components/ui/GlossaryTerm.tsx
+++ b/frontend/src/components/ui/GlossaryTerm.tsx
@@ -1,0 +1,40 @@
+import React, { useId } from "react";
+import type { GlossaryEntry } from "../../lib/glossary";
+
+export type GlossaryTermProps = {
+  entry: GlossaryEntry;
+  children: React.ReactNode;
+  onOpen: (entry: GlossaryEntry) => void;
+};
+
+/**
+ * Clickable / keyboard-activatable glossary term in lesson prose.
+ */
+export function GlossaryTerm({ entry, children, onOpen }: GlossaryTermProps) {
+  const descId = useId();
+
+  return (
+    <>
+      <button
+        type="button"
+        className="glossary-term inline p-0 m-0 border-0 bg-transparent cursor-pointer font-inherit text-inherit underline decoration-dotted decoration-2 underline-offset-2 decoration-accent text-primary hover:decoration-solid focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent rounded-sm"
+        onClick={() => onOpen(entry)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onOpen(entry);
+          }
+        }}
+        aria-describedby={descId}
+        title={entry.short}
+      >
+        {children}
+      </button>
+      <span id={descId} className="sr-only">
+        Glossary: {entry.short}
+      </span>
+    </>
+  );
+}
+
+export default GlossaryTerm;

--- a/frontend/src/components/ui/MarkdownRenderer.tsx
+++ b/frontend/src/components/ui/MarkdownRenderer.tsx
@@ -1,6 +1,13 @@
-import React from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import CopyButton from "./CopyButton";
 import { pluginRegistry } from "../../lib/markdownPlugins";
+import { GlossaryTerm } from "./GlossaryTerm";
+import { GlossaryDrawer } from "./GlossaryDrawer";
+import {
+  loadGlossary,
+  splitTextWithGlossary,
+  type GlossaryEntry,
+} from "../../lib/glossary";
 
 interface MarkdownRendererProps {
   content: string;
@@ -39,35 +46,82 @@ function splitTableRow(row: string): string[] {
 }
 
 export function MarkdownRenderer({ content }: MarkdownRendererProps) {
+  const [glossary, setGlossary] = useState<GlossaryEntry[]>([]);
+  const [activeTerm, setActiveTerm] = useState<GlossaryEntry | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    loadGlossary()
+      .then((terms) => {
+        if (!cancelled) setGlossary(terms);
+      })
+      .catch(() => {
+        if (!cancelled) setGlossary([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const renderGlossaryText = useCallback(
+    (text: string, keyPrefix: string): React.ReactNode[] => {
+      if (!glossary.length) return [text];
+      return splitTextWithGlossary(text, glossary).map((seg, i) => {
+        if (seg.type === "text") {
+          return (
+            <React.Fragment key={`${keyPrefix}-t-${i}`}>
+              {seg.value}
+            </React.Fragment>
+          );
+        }
+        return (
+          <GlossaryTerm
+            key={`${keyPrefix}-g-${i}-${seg.entry.id}`}
+            entry={seg.entry}
+            onOpen={setActiveTerm}
+          >
+            {seg.value}
+          </GlossaryTerm>
+        );
+      });
+    },
+    [glossary],
+  );
+
   // Helper to parse inline formats: bold, inline code, links
+  // Inline code is never glossarized (avoids false positives).
   const parseInline = (text: string): React.ReactNode[] => {
-    // Regular expressions for matching bold, code, and links
     const inlineRegex = /(\*\*.*?\*\*|`.*?`|\[.*?\]\(.*?\))/g;
     const matches = text.split(inlineRegex);
 
-    return matches.map((part, i) => {
+    return matches.flatMap((part, i) => {
+      if (!part) return [];
+
       if (part.startsWith("**") && part.endsWith("**")) {
-        return (
-          <strong key={i} className="font-extrabold text-black dark:text-white">
-            {part.slice(2, -2)}
-          </strong>
-        );
+        return [
+          <strong
+            key={i}
+            className="font-extrabold text-black dark:text-white"
+          >
+            {renderGlossaryText(part.slice(2, -2), `b${i}`)}
+          </strong>,
+        ];
       }
       if (part.startsWith("`") && part.endsWith("`")) {
-        return (
+        return [
           <code
             key={i}
             className="font-mono text-sm bg-surface-low border border-black/20 rounded px-1.5 py-0.5 text-primary dark:bg-black/45 dark:border-[#2e2924]"
           >
             {part.slice(1, -1)}
-          </code>
-        );
+          </code>,
+        ];
       }
       if (part.startsWith("[") && part.includes("](")) {
         const linkMatch = part.match(/\[(.*?)\]\((.*?)\)/);
         if (linkMatch) {
           const [, label, href] = linkMatch;
-          return (
+          return [
             <a
               key={i}
               href={href}
@@ -75,12 +129,12 @@ export function MarkdownRenderer({ content }: MarkdownRendererProps) {
               rel="noopener noreferrer"
               className="text-primary underline font-bold hover:text-accent transition-colors"
             >
-              {label}
-            </a>
-          );
+              {renderGlossaryText(label, `a${i}`)}
+            </a>,
+          ];
         }
       }
-      return part;
+      return renderGlossaryText(part, `p${i}`);
     });
   };
 
@@ -433,5 +487,10 @@ export function MarkdownRenderer({ content }: MarkdownRendererProps) {
     index++;
   }
 
-  return <div className="space-y-2">{blocks}</div>;
+  return (
+    <div className="space-y-2">
+      {blocks}
+      <GlossaryDrawer entry={activeTerm} onClose={() => setActiveTerm(null)} />
+    </div>
+  );
 }

--- a/frontend/src/components/ui/PrDiffSummarizer/PrDiffSummarizer.tsx
+++ b/frontend/src/components/ui/PrDiffSummarizer/PrDiffSummarizer.tsx
@@ -1,0 +1,222 @@
+import React, { useMemo, useState } from "react";
+import { Copy, Check, FileDiff, Sparkles } from "lucide-react";
+import {
+  summarizeDiff,
+  buildPrDescription,
+  buildChecklist,
+  AREA_LABELS,
+  type ChangeArea,
+} from "../../lib/prDiffSummarizer";
+
+const SAMPLE_INPUT = `frontend/src/components/ui/PrDiffSummarizer/PrDiffSummarizer.tsx
+frontend/src/lib/prDiffSummarizer.ts
+frontend/src/test/prDiffSummarizer.test.ts
+backend/apps/progress/migrations/0012_example.py
+docs/CONTENT_GUIDE.md
+.github/pull_request_template.md`;
+
+export type PrDiffSummarizerProps = {
+  compact?: boolean;
+  className?: string;
+  defaultIssueNumber?: string;
+};
+
+export function PrDiffSummarizer({
+  compact = false,
+  className = "",
+  defaultIssueNumber = "",
+}: PrDiffSummarizerProps) {
+  const [raw, setRaw] = useState("");
+  const [issueNumber, setIssueNumber] = useState(defaultIssueNumber);
+  const [titleHint, setTitleHint] = useState("");
+  const [copied, setCopied] = useState(false);
+
+  const summary = useMemo(() => summarizeDiff(raw), [raw]);
+  const checklist = useMemo(() => buildChecklist(summary), [summary]);
+  const prBody = useMemo(
+    () =>
+      buildPrDescription(raw, {
+        issueNumber,
+        titleHint,
+        summary,
+      }),
+    [raw, issueNumber, titleHint, summary],
+  );
+
+  const hasFiles = summary.files.length > 0;
+
+  const copyBody = async () => {
+    try {
+      await navigator.clipboard.writeText(prBody);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard may be unavailable
+    }
+  };
+
+  return (
+    <div
+      className={`rounded-2xl border-4 border-black bg-white p-4 md:p-6 shadow-card dark:bg-[#1f1c18] dark:border-[#2e2924] dark:shadow-none space-y-4 ${className}`}
+      data-testid="pr-diff-summarizer"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h3 className="text-lg font-black text-text dark:text-[#f0ebe2] flex items-center gap-2">
+            <FileDiff size={18} className="text-accent" aria-hidden />
+            PR Description Diff Summarizer
+          </h3>
+          {!compact && (
+            <p className="text-xs font-bold text-muted mt-1 dark:text-[#c4bbae]">
+              Paste file paths or{" "}
+              <code className="bg-surface-low dark:bg-black px-1 rounded font-mono">
+                git diff --name-only
+              </code>{" "}
+              output — get a checklist-ready PR body.
+            </p>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={() => setRaw(SAMPLE_INPUT)}
+          className="shrink-0 px-3 py-1.5 text-xs font-black rounded-lg border-2 border-black bg-surface-low dark:bg-[#151411] dark:text-[#f0ebe2] shadow-card-sm hover:-translate-y-0.5 transition-all inline-flex items-center gap-1"
+        >
+          <Sparkles size={14} /> Try sample
+        </button>
+      </div>
+
+      <label className="block text-sm font-black text-text dark:text-[#f0ebe2]">
+        Changed files
+        <textarea
+          value={raw}
+          onChange={(e) => setRaw(e.target.value)}
+          rows={compact ? 5 : 8}
+          placeholder={`Paste paths, one per line…\nfrontend/src/App.tsx\nbackend/apps/content/models.py\ndocs/CONTENT_GUIDE.md`}
+          className="mt-2 w-full border-4 border-black px-4 py-3 rounded-xl font-mono text-xs bg-white text-black shadow-card-sm dark:bg-[#151411] dark:border-[#2e2924] dark:text-[#f0ebe2] focus:outline-none focus:ring-2 focus:ring-accent resize-y"
+          aria-describedby="pr-diff-hint"
+        />
+      </label>
+      <p id="pr-diff-hint" className="text-[11px] text-muted font-bold dark:text-[#c4bbae] -mt-2">
+        Accepts plain paths, <code className="font-mono">git status</code>, or{" "}
+        <code className="font-mono">git diff --name-only</code>.
+      </p>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <label className="block text-sm font-black text-text dark:text-[#f0ebe2]">
+          Issue number
+          <input
+            type="text"
+            value={issueNumber}
+            onChange={(e) => setIssueNumber(e.target.value.replace(/[^\d]/g, ""))}
+            placeholder="1822"
+            className="mt-2 w-full border-4 border-black px-3 py-2 rounded-xl font-mono text-sm bg-white text-black dark:bg-[#151411] dark:border-[#2e2924] dark:text-[#f0ebe2] focus:outline-none focus:ring-2 focus:ring-accent"
+          />
+        </label>
+        <label className="block text-sm font-black text-text dark:text-[#f0ebe2]">
+          Short summary (optional)
+          <input
+            type="text"
+            value={titleHint}
+            onChange={(e) => setTitleHint(e.target.value)}
+            placeholder="Add PR diff summarizer tool"
+            className="mt-2 w-full border-4 border-black px-3 py-2 rounded-xl text-sm bg-white text-black dark:bg-[#151411] dark:border-[#2e2924] dark:text-[#f0ebe2] focus:outline-none focus:ring-2 focus:ring-accent"
+          />
+        </label>
+      </div>
+
+      {!hasFiles && raw.trim() && (
+        <div
+          className="rounded-xl border-2 border-amber-500 bg-amber-500/10 p-3 text-sm font-bold text-amber-900 dark:text-amber-200"
+          role="alert"
+        >
+          No file paths detected. Paste one path per line (e.g.{" "}
+          <code className="font-mono">frontend/src/App.tsx</code>).
+        </div>
+      )}
+
+      {!raw.trim() && (
+        <p className="text-xs text-muted font-bold dark:text-[#c4bbae]">
+          Waiting for file paths… Detection covers{" "}
+          <strong>backend/</strong>, <strong>frontend/</strong>,{" "}
+          <strong>docs/</strong>, <strong>*.md</strong>, and migrations.
+        </p>
+      )}
+
+      {hasFiles && (
+        <>
+          <div className="flex flex-wrap gap-2" aria-label="Detected change areas">
+            {(Object.keys(summary.counts) as ChangeArea[]).map((area) => (
+              <span
+                key={area}
+                className="text-[10px] font-black uppercase tracking-widest px-2 py-1 rounded-lg border-2 border-black bg-accent/30 text-black dark:bg-accent/20 dark:text-[#f0ebe2] dark:border-[#2e2924]"
+              >
+                {AREA_LABELS[area]} ×{summary.counts[area]}
+              </span>
+            ))}
+          </div>
+
+          {!compact && (
+            <ul className="text-xs font-mono space-y-1 max-h-32 overflow-y-auto border-2 border-black/10 dark:border-[#2e2924] rounded-xl p-3 bg-surface-low dark:bg-[#151411]">
+              {summary.files.map((f) => (
+                <li key={f.path} className="text-text dark:text-[#f0ebe2]">
+                  <span className="text-muted dark:text-[#c4bbae]">
+                    [{f.areas.join(", ")}]
+                  </span>{" "}
+                  {f.path}
+                </li>
+              ))}
+            </ul>
+          )}
+
+          <div>
+            <p className="text-[10px] font-black uppercase tracking-widest text-muted dark:text-[#c4bbae] mb-2">
+              Suggested checklist ({checklist.length})
+            </p>
+            <ul className="space-y-1.5 text-sm font-bold text-text dark:text-[#f0ebe2]">
+              {checklist.slice(0, compact ? 5 : undefined).map((item) => (
+                <li key={item.id} className="flex gap-2">
+                  <span aria-hidden>☐</span>
+                  <span>{item.label}</span>
+                </li>
+              ))}
+              {compact && checklist.length > 5 && (
+                <li className="text-xs text-muted dark:text-[#c4bbae]">
+                  +{checklist.length - 5} more in the copied PR body
+                </li>
+              )}
+            </ul>
+          </div>
+        </>
+      )}
+
+      <div>
+        <div className="flex items-center justify-between gap-2 mb-2">
+          <p className="text-[10px] font-black uppercase tracking-widest text-muted dark:text-[#c4bbae]">
+            Generated PR body
+          </p>
+          <button
+            type="button"
+            onClick={copyBody}
+            disabled={!hasFiles}
+            className="px-3 py-1.5 text-xs font-black rounded-lg border-2 border-black bg-accent text-black shadow-card-sm hover:-translate-y-0.5 transition-all inline-flex items-center gap-1 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:translate-y-0"
+          >
+            {copied ? (
+              <>
+                <Check size={14} /> Copied
+              </>
+            ) : (
+              <>
+                <Copy size={14} /> Copy PR description
+              </>
+            )}
+          </button>
+        </div>
+        <pre className="w-full max-h-64 overflow-auto border-4 border-black rounded-xl p-3 font-mono text-[11px] leading-relaxed bg-surface-low text-black dark:bg-[#0f0e0c] dark:border-[#2e2924] dark:text-[#f0ebe2] whitespace-pre-wrap">
+          {hasFiles ? prBody : "Paste changed files to generate a PR description…"}
+        </pre>
+      </div>
+    </div>
+  );
+}
+
+export default PrDiffSummarizer;

--- a/frontend/src/components/ui/PrDiffSummarizer/index.ts
+++ b/frontend/src/components/ui/PrDiffSummarizer/index.ts
@@ -1,0 +1,2 @@
+export { PrDiffSummarizer } from "./PrDiffSummarizer";
+export type { PrDiffSummarizerProps } from "./PrDiffSummarizer";

--- a/frontend/src/lib/contextualGitCheatSheet.ts
+++ b/frontend/src/lib/contextualGitCheatSheet.ts
@@ -1,0 +1,217 @@
+/**
+ * Contextual Git cheat-sheet — resolve lesson/module → focused command list.
+ * Does not change the sandbox allowlist; display-only helper.
+ */
+
+export type ContextualGitCommand = {
+  id: string;
+  name: string;
+  command: string;
+  description: string;
+  example?: string;
+};
+
+export type GitCheatSheetMap = {
+  defaultCommandIds: string[];
+  modules: Record<string, string[]>;
+  lessons: Record<string, string[]>;
+  slugToModule?: Record<string, string>;
+};
+
+/** Catalog of beginner-safe commands (subset of common Git; allowlist-friendly). */
+export const COMMAND_CATALOG: Record<string, ContextualGitCommand> = {
+  "git-init": {
+    id: "git-init",
+    name: "Initialize repository",
+    command: "git init",
+    description: "Create a new Git repository in the current directory",
+    example: "git init",
+  },
+  "git-status": {
+    id: "git-status",
+    name: "Check status",
+    command: "git status",
+    description: "Show modified, staged, and untracked files",
+    example: "git status",
+  },
+  "git-add": {
+    id: "git-add",
+    name: "Stage changes",
+    command: "git add <file>",
+    description: "Add file changes to the staging area",
+    example: "git add .\ngit add README.md",
+  },
+  "git-commit": {
+    id: "git-commit",
+    name: "Commit changes",
+    command: "git commit -m 'message'",
+    description: "Save staged changes with a message",
+    example: "git commit -m 'feat: add readme'",
+  },
+  "git-log": {
+    id: "git-log",
+    name: "View history",
+    command: "git log",
+    description: "Show commit history",
+    example: "git log --oneline",
+  },
+  "git-diff": {
+    id: "git-diff",
+    name: "View changes",
+    command: "git diff",
+    description: "Show unstaged (or staged) differences",
+    example: "git diff\ngit diff --staged",
+  },
+  "git-branch": {
+    id: "git-branch",
+    name: "List branches",
+    command: "git branch",
+    description: "List local branches",
+    example: "git branch\ngit branch -a",
+  },
+  "git-switch": {
+    id: "git-switch",
+    name: "Switch / create branch",
+    command: "git switch <branch>",
+    description: "Switch branches, or create with -c",
+    example: "git switch main\ngit switch -c feat/add-readme",
+  },
+  "git-checkout": {
+    id: "git-checkout",
+    name: "Checkout branch",
+    command: "git checkout <branch>",
+    description: "Older way to switch or create branches",
+    example: "git checkout -b feat/add-readme",
+  },
+  "git-merge": {
+    id: "git-merge",
+    name: "Merge branch",
+    command: "git merge <branch>",
+    description: "Merge another branch into the current branch",
+    example: "git merge feat/add-readme",
+  },
+  "git-clone": {
+    id: "git-clone",
+    name: "Clone repository",
+    command: "git clone <url>",
+    description: "Copy a remote repository to your machine",
+    example: "git clone https://github.com/org/repo.git",
+  },
+  "git-remote": {
+    id: "git-remote",
+    name: "List remotes",
+    command: "git remote -v",
+    description: "Show remote names and URLs",
+    example: "git remote -v",
+  },
+  "git-fetch": {
+    id: "git-fetch",
+    name: "Fetch updates",
+    command: "git fetch",
+    description: "Download remote changes without merging",
+    example: "git fetch origin",
+  },
+  "git-pull": {
+    id: "git-pull",
+    name: "Pull updates",
+    command: "git pull",
+    description: "Fetch and integrate remote changes",
+    example: "git pull origin main",
+  },
+  "git-push": {
+    id: "git-push",
+    name: "Push commits",
+    command: "git push",
+    description: "Upload local commits to a remote",
+    example: "git push -u origin feat/my-first-pr",
+  },
+  "git-rebase": {
+    id: "git-rebase",
+    name: "Rebase branch",
+    command: "git rebase <branch>",
+    description: "Replay commits onto another base branch",
+    example: "git rebase main",
+  },
+};
+
+export function idsToCommands(ids: string[]): ContextualGitCommand[] {
+  const seen = new Set<string>();
+  const result: ContextualGitCommand[] = [];
+  for (const id of ids) {
+    if (seen.has(id)) continue;
+    const cmd = COMMAND_CATALOG[id];
+    if (!cmd) continue;
+    seen.add(id);
+    result.push(cmd);
+  }
+  return result;
+}
+
+export function resolveModuleId(
+  lessonSlug: string | undefined,
+  moduleId: string | undefined,
+  map: GitCheatSheetMap,
+): string | undefined {
+  if (moduleId && map.modules[moduleId]) return moduleId;
+  if (lessonSlug && map.slugToModule?.[lessonSlug]) {
+    return map.slugToModule[lessonSlug];
+  }
+  return undefined;
+}
+
+/**
+ * Prefer lesson-specific commands, then module defaults, then global defaults.
+ */
+export function resolveContextualCommands(
+  lessonSlug: string | undefined,
+  moduleId: string | undefined,
+  map: GitCheatSheetMap,
+): { commands: ContextualGitCommand[]; source: "lesson" | "module" | "default"; resolvedModuleId?: string } {
+  if (lessonSlug && map.lessons[lessonSlug]?.length) {
+    return {
+      commands: idsToCommands(map.lessons[lessonSlug]),
+      source: "lesson",
+      resolvedModuleId: resolveModuleId(lessonSlug, moduleId, map),
+    };
+  }
+
+  const resolvedModuleId = resolveModuleId(lessonSlug, moduleId, map);
+  if (resolvedModuleId && map.modules[resolvedModuleId]?.length) {
+    return {
+      commands: idsToCommands(map.modules[resolvedModuleId]),
+      source: "module",
+      resolvedModuleId,
+    };
+  }
+
+  return {
+    commands: idsToCommands(map.defaultCommandIds),
+    source: "default",
+    resolvedModuleId,
+  };
+}
+
+export function moduleIdFromFilePath(filePath?: string): string | undefined {
+  if (!filePath) return undefined;
+  const match = filePath.replace(/\\/g, "/").match(/(module-[\w-]+)/);
+  return match?.[1];
+}
+
+let cachedMap: GitCheatSheetMap | null = null;
+
+export async function loadGitCheatSheetMap(
+  url = "/content/git-cheatsheet-map.json",
+): Promise<GitCheatSheetMap> {
+  if (cachedMap) return cachedMap;
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Failed to load git cheat-sheet map (${res.status})`);
+  }
+  cachedMap = (await res.json()) as GitCheatSheetMap;
+  return cachedMap;
+}
+
+/** Test helper — clear fetch cache */
+export function clearGitCheatSheetMapCache(): void {
+  cachedMap = null;
+}

--- a/frontend/src/lib/conventionalCommitCoach.ts
+++ b/frontend/src/lib/conventionalCommitCoach.ts
@@ -1,0 +1,231 @@
+/**
+ * Conventional Commit Message Coach — validator & rewrite helpers.
+ * Spec-inspired rules for first-time open-source contributors.
+ */
+
+export const ALLOWED_TYPES = [
+  "feat",
+  "fix",
+  "docs",
+  "style",
+  "refactor",
+  "perf",
+  "test",
+  "build",
+  "ci",
+  "chore",
+  "revert",
+] as const;
+
+export type CommitType = (typeof ALLOWED_TYPES)[number];
+
+export type ValidationIssue = {
+  code:
+    | "empty"
+    | "format"
+    | "type"
+    | "scope"
+    | "subject_empty"
+    | "subject_case"
+    | "subject_period"
+    | "subject_length"
+    | "whitespace";
+  message: string;
+};
+
+export type ValidationResult = {
+  valid: boolean;
+  issues: ValidationIssue[];
+  parsed: {
+    type: string | null;
+    scope: string | null;
+    subject: string | null;
+  };
+};
+
+const HEADER_RE =
+  /^(?<type>[a-zA-Z]+)(?:\((?<scope>[^)]*)\))?(?<breaking>!)?:\s*(?<subject>.*)$/;
+
+const MAX_SUBJECT_LENGTH = 72;
+
+export function validateCommitMessage(raw: string): ValidationResult {
+  const message = raw.replace(/\r\n/g, "\n").trim();
+  const issues: ValidationIssue[] = [];
+  const parsed = { type: null as string | null, scope: null as string | null, subject: null as string | null };
+
+  if (!message) {
+    return {
+      valid: false,
+      issues: [
+        {
+          code: "empty",
+          message: "Commit message is empty. Start with a type like feat or fix.",
+        },
+      ],
+      parsed,
+    };
+  }
+
+  if (/\s{2,}/.test(message) || message !== raw.trim()) {
+    // only flag internal double spaces in the trimmed message
+    if (/\s{2,}/.test(message)) {
+      issues.push({
+        code: "whitespace",
+        message: "Avoid extra spaces. Use a single space after the colon.",
+      });
+    }
+  }
+
+  const match = message.match(HEADER_RE);
+  if (!match?.groups) {
+    issues.push({
+      code: "format",
+      message:
+        'Use the format type(scope): subject — for example "feat(auth): add login form". Scope is optional.',
+    });
+    return { valid: false, issues, parsed };
+  }
+
+  const type = match.groups.type ?? "";
+  const scope = match.groups.scope ?? null;
+  const subject = (match.groups.subject ?? "").trim();
+
+  parsed.type = type;
+  parsed.scope = scope;
+  parsed.subject = subject || null;
+
+  const typeLower = type.toLowerCase();
+  if (!(ALLOWED_TYPES as readonly string[]).includes(typeLower)) {
+    issues.push({
+      code: "type",
+      message: `"${type}" is not a known type. Allowed: ${ALLOWED_TYPES.join(", ")}.`,
+    });
+  } else if (type !== typeLower) {
+    issues.push({
+      code: "type",
+      message: `Type should be lowercase. Use "${typeLower}" instead of "${type}".`,
+    });
+  }
+
+  if (scope !== null) {
+    if (!scope.trim()) {
+      issues.push({
+        code: "scope",
+        message: "Scope is empty. Either remove the parentheses or add a short scope like (auth).",
+      });
+    } else if (/\s/.test(scope)) {
+      issues.push({
+        code: "scope",
+        message: "Scope should be a short kebab-case word without spaces (e.g. auth, api, ui).",
+      });
+    }
+  }
+
+  if (!subject) {
+    issues.push({
+      code: "subject_empty",
+      message: "Add a short subject after the colon describing what changed.",
+    });
+  } else {
+    if (/^[A-Z]/.test(subject)) {
+      issues.push({
+        code: "subject_case",
+        message: "Subject should start with a lowercase letter (e.g. \"add login form\").",
+      });
+    }
+    if (subject.endsWith(".")) {
+      issues.push({
+        code: "subject_period",
+        message: "Do not end the subject with a period.",
+      });
+    }
+    if (subject.length > MAX_SUBJECT_LENGTH) {
+      issues.push({
+        code: "subject_length",
+        message: `Subject is too long (${subject.length} chars). Keep it under ${MAX_SUBJECT_LENGTH} characters.`,
+      });
+    }
+  }
+
+  return {
+    valid: issues.length === 0,
+    issues,
+    parsed,
+  };
+}
+
+/**
+ * Attempt to rewrite an invalid (or rough) message into a valid Conventional Commit.
+ */
+export function suggestCommitRewrite(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return "feat: describe your change here";
+  }
+
+  const match = trimmed.match(HEADER_RE);
+  let type = "feat";
+  let scope: string | null = null;
+  let subject = trimmed;
+
+  if (match?.groups) {
+    const rawType = (match.groups.type ?? "").toLowerCase();
+    type = (ALLOWED_TYPES as readonly string[]).includes(rawType) ? rawType : "chore";
+    const rawScope = match.groups.scope;
+    if (rawScope && rawScope.trim() && !/\s/.test(rawScope.trim())) {
+      scope = rawScope.trim().toLowerCase();
+    }
+    subject = (match.groups.subject ?? "").trim() || "describe your change here";
+  } else {
+    // Heuristic: first word might be a type
+    const parts = trimmed.split(/\s+/);
+    const maybeType = parts[0]?.toLowerCase().replace(/:$/, "");
+    if ((ALLOWED_TYPES as readonly string[]).includes(maybeType)) {
+      type = maybeType;
+      subject = parts.slice(1).join(" ").replace(/^:\s*/, "").trim() || "describe your change here";
+    } else {
+      subject = trimmed;
+    }
+  }
+
+  subject = subject.replace(/\.$/, "");
+  if (subject) {
+    subject = subject.charAt(0).toLowerCase() + subject.slice(1);
+  }
+  if (subject.length > MAX_SUBJECT_LENGTH) {
+    subject = subject.slice(0, MAX_SUBJECT_LENGTH).trim();
+  }
+
+  return scope ? `${type}(${scope}): ${subject}` : `${type}: ${subject}`;
+}
+
+export function buildPrChecklistTemplate(commitMessage: string): string {
+  const msg = commitMessage.trim() || "feat: your change";
+  return `## Summary
+- ${msg}
+
+## Test plan
+- [ ] Ran relevant frontend/backend tests
+- [ ] Checked UI in light and dark theme (if UI change)
+- [ ] Updated docs if needed
+
+## Checklist
+- [ ] Conventional Commit message used
+- [ ] Scope matches the issue / PR title
+- [ ] No unrelated files included
+`;
+}
+
+export const COMMIT_TYPE_HINTS: { type: CommitType; hint: string }[] = [
+  { type: "feat", hint: "A new feature for users" },
+  { type: "fix", hint: "A bug fix" },
+  { type: "docs", hint: "Documentation only" },
+  { type: "style", hint: "Formatting, no logic change" },
+  { type: "refactor", hint: "Code change that neither fixes a bug nor adds a feature" },
+  { type: "perf", hint: "Performance improvement" },
+  { type: "test", hint: "Adding or fixing tests" },
+  { type: "build", hint: "Build system or dependencies" },
+  { type: "ci", hint: "CI configuration" },
+  { type: "chore", hint: "Maintenance tasks" },
+  { type: "revert", hint: "Reverts a previous commit" },
+];

--- a/frontend/src/lib/glossary.ts
+++ b/frontend/src/lib/glossary.ts
@@ -1,0 +1,157 @@
+/**
+ * Lesson glossary — content-driven OSS jargon for Markdown lessons.
+ */
+
+export type GlossaryEntry = {
+  id: string;
+  term: string;
+  aliases?: string[];
+  short: string;
+  definition: string;
+};
+
+export type GlossaryFile = {
+  terms: GlossaryEntry[];
+};
+
+export type GlossarySegment =
+  | { type: "text"; value: string }
+  | { type: "term"; value: string; entry: GlossaryEntry };
+
+/** All matchable phrases for an entry (term + aliases), longest first. */
+export function entryPhrases(entry: GlossaryEntry): string[] {
+  const phrases = [entry.term, ...(entry.aliases ?? [])]
+    .map((p) => p.trim())
+    .filter(Boolean);
+  return [...new Set(phrases)].sort((a, b) => b.length - a.length);
+}
+
+/**
+ * Split plain text into text/term segments.
+ * Uses word boundaries; case-insensitive match; preserves original casing.
+ * Callers must only pass non-code text (skip fenced/inline code themselves).
+ */
+export function splitTextWithGlossary(
+  text: string,
+  terms: GlossaryEntry[],
+): GlossarySegment[] {
+  if (!text || terms.length === 0) {
+    return text ? [{ type: "text", value: text }] : [];
+  }
+
+  type Pattern = { phrase: string; entry: GlossaryEntry; regex: RegExp };
+  const patterns: Pattern[] = [];
+
+  for (const entry of terms) {
+    for (const phrase of entryPhrases(entry)) {
+      const escaped = phrase.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      // Allow spaces in multi-word phrases; word boundaries on edges
+      const source = `\\b${escaped.replace(/\s+/g, "\\s+")}\\b`;
+      patterns.push({
+        phrase,
+        entry,
+        regex: new RegExp(source, "i"),
+      });
+    }
+  }
+
+  // Longest phrases first so "pull request" wins over "PR" inside longer matches… 
+  // (PR is separate; "good first issue" before "issue")
+  patterns.sort((a, b) => b.phrase.length - a.phrase.length);
+
+  const segments: GlossarySegment[] = [];
+  let remaining = text;
+
+  while (remaining.length > 0) {
+    let earliest: { index: number; length: number; entry: GlossaryEntry; matched: string } | null =
+      null;
+
+    for (const { entry, regex } of patterns) {
+      regex.lastIndex = 0;
+      const match = regex.exec(remaining);
+      if (!match || match.index === undefined) continue;
+      if (
+        earliest === null ||
+        match.index < earliest.index ||
+        (match.index === earliest.index && match[0].length > earliest.length)
+      ) {
+        earliest = {
+          index: match.index,
+          length: match[0].length,
+          entry,
+          matched: match[0],
+        };
+      }
+    }
+
+    if (!earliest) {
+      segments.push({ type: "text", value: remaining });
+      break;
+    }
+
+    if (earliest.index > 0) {
+      segments.push({
+        type: "text",
+        value: remaining.slice(0, earliest.index),
+      });
+    }
+
+    segments.push({
+      type: "term",
+      value: earliest.matched,
+      entry: earliest.entry,
+    });
+
+    remaining = remaining.slice(earliest.index + earliest.length);
+  }
+
+  return segments;
+}
+
+/**
+ * Strip inline code spans so glossary matching isn't run on them.
+ * Returns alternating plain / code chunks; code chunks should not be glossarized.
+ */
+export function splitIgnoringInlineCode(
+  text: string,
+): Array<{ kind: "plain" | "code"; value: string }> {
+  const parts: Array<{ kind: "plain" | "code"; value: string }> = [];
+  const re = /`[^`]*`/g;
+  let last = 0;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(text)) !== null) {
+    if (match.index > last) {
+      parts.push({ kind: "plain", value: text.slice(last, match.index) });
+    }
+    parts.push({ kind: "code", value: match[0] });
+    last = match.index + match[0].length;
+  }
+  if (last < text.length) {
+    parts.push({ kind: "plain", value: text.slice(last) });
+  }
+  return parts.length ? parts : [{ kind: "plain", value: text }];
+}
+
+let cached: GlossaryEntry[] | null = null;
+
+export async function loadGlossary(
+  url = "/content/glossary.json",
+): Promise<GlossaryEntry[]> {
+  if (cached) return cached;
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`Failed to load glossary (${res.status})`);
+  const data = (await res.json()) as GlossaryFile;
+  cached = data.terms ?? [];
+  return cached;
+}
+
+export function clearGlossaryCache(): void {
+  cached = null;
+}
+
+export function findEntryById(
+  terms: GlossaryEntry[],
+  id: string,
+): GlossaryEntry | undefined {
+  return terms.find((t) => t.id === id);
+}

--- a/frontend/src/lib/prDiffSummarizer.ts
+++ b/frontend/src/lib/prDiffSummarizer.ts
@@ -1,0 +1,347 @@
+/**
+ * PR Description Diff Summarizer — classify changed files and build a PR body.
+ * Pure client-side helper for first-time open-source contributors.
+ */
+
+export type ChangeArea =
+  | "frontend"
+  | "backend"
+  | "docs"
+  | "migrations"
+  | "tests"
+  | "ci"
+  | "infra"
+  | "other";
+
+export type ClassifiedFile = {
+  path: string;
+  areas: ChangeArea[];
+};
+
+export type DiffSummary = {
+  files: ClassifiedFile[];
+  areas: ChangeArea[];
+  counts: Partial<Record<ChangeArea, number>>;
+};
+
+export type ChecklistItem = {
+  id: string;
+  label: string;
+  area: ChangeArea | "general";
+};
+
+const STATUS_PREFIX =
+  /^(?:modified|new file|deleted|renamed|copied|both modified|added|unmerged):\s*/i;
+const SHORT_STATUS = /^[ MADRCU?!]{1,2}\s+/;
+
+/**
+ * Parse pasted file paths or `git status` / `git diff --name-only` output.
+ */
+export function parseChangedFiles(raw: string): string[] {
+  const lines = raw.replace(/\r\n/g, "\n").split("\n");
+  const paths: string[] = [];
+  const seen = new Set<string>();
+
+  for (const line of lines) {
+    let trimmed = line.trim();
+    if (!trimmed) continue;
+
+    // Skip decorative / header lines
+    if (
+      /^(changes|on branch|your branch|head detached|untracked|no changes|nothing to|#)/i.test(
+        trimmed,
+      )
+    ) {
+      continue;
+    }
+
+    // Drop "git status" style prefixes
+    trimmed = trimmed.replace(STATUS_PREFIX, "");
+    trimmed = trimmed.replace(SHORT_STATUS, "");
+
+    // Renames: "a -> b" or "a => b"
+    if (/\s->\s|\s=>\s/.test(trimmed)) {
+      trimmed = trimmed.split(/\s->\s|\s=>\s/).pop()?.trim() ?? trimmed;
+    }
+
+    // Strip surrounding quotes
+    trimmed = trimmed.replace(/^["']|["']$/g, "");
+
+    // Ignore lines that still look like prose (spaces without a path separator / extension)
+    if (!trimmed.includes("/") && !/\.\w+$/.test(trimmed)) {
+      continue;
+    }
+
+    // Normalize slashes
+    const path = trimmed.replace(/\\/g, "/");
+    if (!path || seen.has(path)) continue;
+    seen.add(path);
+    paths.push(path);
+  }
+
+  return paths;
+}
+
+export function classifyPath(path: string): ChangeArea[] {
+  const p = path.replace(/\\/g, "/").toLowerCase();
+  const areas: ChangeArea[] = [];
+
+  const isMigration =
+    /(^|\/)migrations?\//.test(p) ||
+    /\/\d{4}_.+\.py$/.test(p) ||
+    p.includes("migrate");
+
+  const isTest =
+    /(^|\/)tests?\//.test(p) ||
+    /(^|\/)e2e\//.test(p) ||
+    /\.(test|spec)\.[jt]sx?$/.test(p) ||
+    /_test\.py$/.test(p) ||
+    /test_.+\.py$/.test(p);
+
+  const isDocs =
+    /(^|\/)docs\//.test(p) ||
+    /\.mdx?$/.test(p) ||
+    /(^|\/)readme(\.|$)/i.test(p) ||
+    p.includes("contributing");
+
+  const isCi =
+    /(^|\/)\.github\//.test(p) ||
+    p.includes("workflow") ||
+    p.endsWith(".yml") ||
+    p.endsWith(".yaml");
+
+  const isInfra =
+    p.includes("docker") ||
+    p.includes("infra/") ||
+    p.includes("render.yaml") ||
+    p.includes("vercel.json");
+
+  const isFrontend =
+    /(^|\/)frontend\//.test(p) ||
+    /\.(tsx?|jsx?|css|scss)$/.test(p) ||
+    p.includes("tailwind") ||
+    p.includes("vite.config");
+
+  const isBackend =
+    /(^|\/)backend\//.test(p) ||
+    /\.py$/.test(p) ||
+    p.includes("requirements") ||
+    p.includes("manage.py") ||
+    p.includes("pytest");
+
+  if (isMigration) areas.push("migrations");
+  if (isTest) areas.push("tests");
+  if (isDocs) areas.push("docs");
+  if (isCi) areas.push("ci");
+  if (isInfra) areas.push("infra");
+  if (isFrontend) areas.push("frontend");
+  if (isBackend) areas.push("backend");
+
+  if (areas.length === 0) areas.push("other");
+  return [...new Set(areas)];
+}
+
+export function summarizeDiff(raw: string): DiffSummary {
+  const paths = parseChangedFiles(raw);
+  const files = paths.map((path) => ({
+    path,
+    areas: classifyPath(path),
+  }));
+
+  const counts: Partial<Record<ChangeArea, number>> = {};
+  for (const file of files) {
+    for (const area of file.areas) {
+      counts[area] = (counts[area] ?? 0) + 1;
+    }
+  }
+
+  const areas = (Object.keys(counts) as ChangeArea[]).sort();
+  return { files, areas, counts };
+}
+
+export function buildChecklist(summary: DiffSummary): ChecklistItem[] {
+  const items: ChecklistItem[] = [
+    {
+      id: "self-review",
+      label: "I have performed a self-review of my own code",
+      area: "general",
+    },
+    {
+      id: "style",
+      label: "My code follows the style guidelines of this project",
+      area: "general",
+    },
+  ];
+
+  const has = (area: ChangeArea) => (summary.counts[area] ?? 0) > 0;
+
+  if (has("frontend")) {
+    items.push(
+      {
+        id: "fe-test",
+        label: "Frontend tests pass: `cd frontend && npm run test`",
+        area: "frontend",
+      },
+      {
+        id: "fe-build",
+        label: "Frontend builds successfully: `cd frontend && npm run build`",
+        area: "frontend",
+      },
+      {
+        id: "fe-theme",
+        label: "Checked UI in light and dark theme (if UI change)",
+        area: "frontend",
+      },
+    );
+  }
+
+  if (has("backend")) {
+    items.push({
+      id: "be-test",
+      label: "Backend tests pass: `cd backend && pytest`",
+      area: "backend",
+    });
+  }
+
+  if (has("docs")) {
+    items.push({
+      id: "docs",
+      label: "Documentation updated (CONTENT_GUIDE / README / docs as needed)",
+      area: "docs",
+    });
+  }
+
+  if (has("migrations")) {
+    items.push({
+      id: "migrations",
+      label: "Noted migration steps / ran `python manage.py migrate` locally",
+      area: "migrations",
+    });
+  }
+
+  if (has("tests")) {
+    items.push({
+      id: "tests-added",
+      label: "Added or updated tests covering this change",
+      area: "tests",
+    });
+  }
+
+  if (has("ci")) {
+    items.push({
+      id: "ci",
+      label: "CI / workflow changes reviewed for breakage",
+      area: "ci",
+    });
+  }
+
+  if (has("infra")) {
+    items.push({
+      id: "infra",
+      label: "Deployment / Docker / env notes added if needed",
+      area: "infra",
+    });
+  }
+
+  items.push({
+    id: "git-diff",
+    label: "I have run `git diff` locally and verified my changes",
+    area: "general",
+  });
+
+  return items;
+}
+
+export type BuildPrBodyOptions = {
+  issueNumber?: string;
+  titleHint?: string;
+  summary?: DiffSummary;
+};
+
+/**
+ * Build a PR description inspired by `.github/pull_request_template.md`.
+ */
+export function buildPrDescription(
+  raw: string,
+  options: BuildPrBodyOptions = {},
+): string {
+  const summary = options.summary ?? summarizeDiff(raw);
+  const checklist = buildChecklist(summary);
+  const issue = options.issueNumber?.trim() || "<!-- issue number -->";
+  const titleHint =
+    options.titleHint?.trim() ||
+    (summary.files.length
+      ? `Update ${summary.areas.join(", ") || "project"} files`
+      : "Describe your changes");
+
+  const fileList =
+    summary.files.length > 0
+      ? summary.files.map((f) => `- \`${f.path}\` (${f.areas.join(", ")})`).join("\n")
+      : "- <!-- paste changed files after generating -->";
+
+  const typeChecks = [
+    summary.areas.includes("docs") && !summary.areas.some((a) => a !== "docs")
+      ? "- [x] 📝 Documentation update (no code changes)"
+      : "- [ ] 📝 Documentation update (no code changes)",
+    summary.areas.includes("frontend") || summary.areas.includes("backend")
+      ? "- [x] ✨ New feature (non-breaking change which adds functionality)"
+      : "- [ ] ✨ New feature (non-breaking change which adds functionality)",
+    "- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)",
+    "- [ ] 🛠️ Refactoring (no functional changes)",
+    summary.areas.includes("ci")
+      ? "- [x] ⚙️ CI/CD or build pipeline change"
+      : "- [ ] ⚙️ CI/CD or build pipeline change",
+  ].join("\n");
+
+  const howTested = checklist
+    .filter((i) => i.area === "frontend" || i.area === "backend")
+    .map((i) => `- [ ] ${i.label}`)
+    .join("\n");
+
+  const prePush = checklist.map((i) => `- [ ] ${i.label}`).join("\n");
+
+  return `## Description
+
+${titleHint}
+
+Fixes #${issue}
+
+### Changed files
+${fileList}
+
+## Type of Change
+
+${typeChecks}
+
+## How Has This Been Tested?
+
+### Automated Tests
+${howTested || "- [ ] Add relevant test commands based on changed areas"}
+
+### Manual Verification
+- [ ] Verified the user flow related to this change
+
+## Pre-Push Checklist
+
+${prePush}
+
+## Deployment Notes
+
+${
+  summary.areas.includes("migrations")
+    ? "- Requires running database migrations after deploy"
+    : "- <!-- Add deployment / env notes if needed -->"
+}
+`;
+}
+
+export const AREA_LABELS: Record<ChangeArea, string> = {
+  frontend: "Frontend",
+  backend: "Backend",
+  docs: "Docs",
+  migrations: "Migrations",
+  tests: "Tests",
+  ci: "CI",
+  infra: "Infra",
+  other: "Other",
+};

--- a/frontend/src/pages/ContributorSandboxPage.tsx
+++ b/frontend/src/pages/ContributorSandboxPage.tsx
@@ -11,6 +11,8 @@ import {
   CheckCircle,
 } from "lucide-react";
 import { SectionCard } from "../components/ui/SectionCard";
+import { CommitMessageCoach } from "../components/ui/CommitMessageCoach";
+import { validateCommitMessage } from "../lib/conventionalCommitCoach";
 
 type Step = "setup" | "fix" | "commit" | "pr" | "success";
 
@@ -121,13 +123,11 @@ export function ContributorSandboxPage() {
   const startLinterRun = () => {
     if (!commitMsg.trim()) return;
 
-    // Check for conventional commit structure
-    const isConventional = /^(feat|fix|docs|refactor|chore)(\(.+\))?:/.test(
-      commitMsg,
-    );
-    if (!isConventional) {
+    const validation = validateCommitMessage(commitMsg);
+    if (!validation.valid) {
       alert(
-        "Our project requires Conventional Commits! Format: 'feat: add feature' or 'fix: resolve issue'",
+        validation.issues[0]?.message ??
+          "Our project requires Conventional Commits! Format: 'feat: add feature' or 'fix: resolve issue'",
       );
       return;
     }
@@ -357,18 +357,12 @@ export function ContributorSandboxPage() {
               </div>
 
               <div className="space-y-4">
-                <div>
-                  <label className="block text-sm font-black mb-2">
-                    Commit Message
-                  </label>
-                  <input
-                    type="text"
-                    value={commitMsg}
-                    onChange={(e) => setCommitMsg(e.target.value)}
-                    className="w-full border-4 border-black px-4 py-3 rounded-xl font-mono text-sm bg-white text-black shadow-card dark:bg-[#151411] dark:border-[#2e2924] dark:text-[#f0ebe2]"
-                    placeholder="e.g. fix: handle unexpected errors in token decoding"
-                  />
-                </div>
+                <CommitMessageCoach
+                  value={commitMsg}
+                  onChange={setCommitMsg}
+                  compact
+                  defaultValue=""
+                />
 
                 {isLinterRunning && (
                   <div className="bg-surface-low dark:bg-[#151411] p-4 rounded-xl border-2 border-black flex items-center gap-3">

--- a/frontend/src/pages/ContributorSandboxPage.tsx
+++ b/frontend/src/pages/ContributorSandboxPage.tsx
@@ -12,7 +12,9 @@ import {
 } from "lucide-react";
 import { SectionCard } from "../components/ui/SectionCard";
 import { CommitMessageCoach } from "../components/ui/CommitMessageCoach";
+import { PrDiffSummarizer } from "../components/ui/PrDiffSummarizer";
 import { validateCommitMessage } from "../lib/conventionalCommitCoach";
+import { Link } from "react-router-dom";
 
 type Step = "setup" | "fix" | "commit" | "pr" | "success";
 
@@ -451,6 +453,27 @@ export function ContributorSandboxPage() {
                     credentials leaked
                   </div>
                 </div>
+              </div>
+
+              <div className="space-y-2">
+                <p className="text-sm font-black text-text dark:text-[#f0ebe2]">
+                  Practice writing your PR description
+                </p>
+                <p className="text-xs text-muted dark:text-[#c4bbae] font-bold">
+                  Paste changed files to generate a checklist-ready PR body. Full
+                  tool:{" "}
+                  <Link
+                    to="/pr-diff-summarizer"
+                    className="underline text-accent hover:opacity-80"
+                  >
+                    /pr-diff-summarizer
+                  </Link>
+                </p>
+                <PrDiffSummarizer
+                  compact
+                  defaultIssueNumber=""
+                  className="shadow-none"
+                />
               </div>
 
               <div className="flex justify-end gap-3 mt-6">

--- a/frontend/src/pages/LessonPage.tsx
+++ b/frontend/src/pages/LessonPage.tsx
@@ -65,6 +65,7 @@ const MarkdownRenderer = React.lazy(() =>
 import { LessonHistoryModal } from "../components/LessonHistoryModal";
 import { GitGraph } from "../components/ui/GitGraph";
 import { NotePanel } from "../components/ui/NotePanel";
+import { CommitMessageCoach } from "../components/ui/CommitMessageCoach";
 import { LessonFeedbackWidget } from "../components/ui/LessonFeedbackWidget";
 import { PythonSandbox } from "../components/ui/PythonSandbox";
 const CollabPythonSandbox = React.lazy(() =>
@@ -179,6 +180,7 @@ export function LessonPage() {
 
   // Note Panel
   const [isNotePanelOpen, setIsNotePanelOpen] = useState(false);
+  const [isCommitCoachOpen, setIsCommitCoachOpen] = useState(false);
 
   // Reading progress scroll ref
   const mainContentRef = useRef<HTMLDivElement>(null);
@@ -1329,9 +1331,21 @@ export function LessonPage() {
         </div>
 
         {/* Mentor Help Trigger Row */}
-        <div className="border-t-4 border-black p-4 bg-white dark:bg-[#151411] dark:border-[#2e2924] flex justify-end gap-4 flex-shrink-0">
+        <div className="border-t-4 border-black p-4 bg-white dark:bg-[#151411] dark:border-[#2e2924] flex justify-end gap-4 flex-shrink-0 flex-wrap">
           <button
-            onClick={() => setIsNotePanelOpen(!isNotePanelOpen)}
+            onClick={() => {
+              setIsCommitCoachOpen(!isCommitCoachOpen);
+              if (!isCommitCoachOpen) setIsNotePanelOpen(false);
+            }}
+            className="px-4 py-2 bg-white text-text dark:bg-[#151411] dark:text-[#f0ebe2] font-black text-xs rounded-lg border-4 border-black shadow-card-sm hover:-translate-y-0.5 cursor-pointer"
+          >
+            {isCommitCoachOpen ? "Close Commit Coach" : "Commit Coach"}
+          </button>
+          <button
+            onClick={() => {
+              setIsNotePanelOpen(!isNotePanelOpen);
+              if (!isNotePanelOpen) setIsCommitCoachOpen(false);
+            }}
             className="px-4 py-2 bg-white text-text dark:bg-[#151411] dark:text-[#f0ebe2] font-black text-xs rounded-lg border-4 border-black shadow-card-sm hover:-translate-y-0.5 cursor-pointer"
           >
             {isNotePanelOpen ? "Close Notes 📝" : "Notes 📝"}
@@ -1353,6 +1367,38 @@ export function LessonPage() {
           lessonSlug={lesson.slug}
           onClose={() => setIsNotePanelOpen(false)}
         />
+      )}
+
+      {isCommitCoachOpen && (
+        <div className="fixed inset-0 z-50 flex justify-end bg-black/40">
+          <button
+            type="button"
+            aria-label="Close commit message coach"
+            className="flex-1 cursor-default"
+            onClick={() => setIsCommitCoachOpen(false)}
+          />
+          <aside className="h-full w-full max-w-md overflow-y-auto bg-surface-lowest border-l-4 border-black p-6 shadow-card space-y-4 dark:bg-[#0f0e0c] dark:border-[#2e2924]">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <h2 className="text-2xl font-black text-text dark:text-[#f0ebe2]">
+                  Practice your commit
+                </h2>
+                <p className="text-xs text-muted mt-1 dark:text-[#c4bbae]">
+                  Draft a Conventional Commit while you learn — then copy it
+                  into your real PR.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setIsCommitCoachOpen(false)}
+                className="px-3 py-1 border-2 border-black rounded-lg font-black text-xs hover:bg-surface-low dark:border-[#2e2924] dark:text-[#f0ebe2]"
+              >
+                Close
+              </button>
+            </div>
+            <CommitMessageCoach />
+          </aside>
+        </div>
       )}
 
       {isHelpPanelOpen && (

--- a/frontend/src/pages/LessonPage.tsx
+++ b/frontend/src/pages/LessonPage.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { GitTerminal } from "../components/GitTerminal";
 import { useNavigate, useParams, Link } from "react-router-dom";
 import {
   ChevronLeft,
@@ -66,6 +65,8 @@ import { LessonHistoryModal } from "../components/LessonHistoryModal";
 import { GitGraph } from "../components/ui/GitGraph";
 import { NotePanel } from "../components/ui/NotePanel";
 import { CommitMessageCoach } from "../components/ui/CommitMessageCoach";
+import { ContextualGitCheatSheet } from "../components/ui/ContextualGitCheatSheet";
+import { moduleIdFromFilePath } from "../lib/contextualGitCheatSheet";
 import { LessonFeedbackWidget } from "../components/ui/LessonFeedbackWidget";
 import { PythonSandbox } from "../components/ui/PythonSandbox";
 const CollabPythonSandbox = React.lazy(() =>
@@ -1169,6 +1170,18 @@ export function LessonPage() {
                   >
                     <h3 className="text-xl font-black mb-4 flex items-center gap-2 text-text dark:text-[#f0ebe2]">
                       <span>💻</span> Sandbox terminal check
+                      <span className="ml-auto">
+                        <ContextualGitCheatSheet
+                          lessonSlug={lesson.slug}
+                          moduleId={
+                            moduleIdFromFilePath(lesson.filePath) ||
+                            (lesson.category?.startsWith("module-")
+                              ? lesson.category
+                              : undefined)
+                          }
+                          onInsertCommand={(command) => setInput(command)}
+                        />
+                      </span>
                     </h3>
 
                     <GitGraph state={repoState} />

--- a/frontend/src/pages/PrDiffSummarizerPage.tsx
+++ b/frontend/src/pages/PrDiffSummarizerPage.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { SectionCard } from "../components/ui/SectionCard";
+import { PrDiffSummarizer } from "../components/ui/PrDiffSummarizer";
+
+export function PrDiffSummarizerPage() {
+  return (
+    <div className="space-y-8 max-w-4xl mx-auto pb-16">
+      <SectionCard
+        eyebrow="Contribution Workflow"
+        title="PR Description Diff Summarizer"
+      >
+        <p className="max-w-3xl text-sm leading-6 text-muted dark:text-[#c4bbae] font-bold">
+          Paste your changed files (or{" "}
+          <code className="bg-surface-low dark:bg-black px-1.5 py-0.5 rounded font-mono">
+            git diff --name-only
+          </code>
+          ) and get a beginner-friendly PR checklist + description template —
+          no API keys, fully client-side.
+        </p>
+      </SectionCard>
+
+      <PrDiffSummarizer />
+    </div>
+  );
+}
+
+export default PrDiffSummarizerPage;

--- a/frontend/src/test/contextualGitCheatSheet.test.ts
+++ b/frontend/src/test/contextualGitCheatSheet.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveContextualCommands,
+  resolveModuleId,
+  moduleIdFromFilePath,
+  idsToCommands,
+  type GitCheatSheetMap,
+} from "../lib/contextualGitCheatSheet";
+
+const SAMPLE_MAP: GitCheatSheetMap = {
+  defaultCommandIds: ["git-status", "git-init"],
+  modules: {
+    "module-2": ["git-init", "git-status", "git-branch", "git-switch"],
+    "module-3": ["git-clone", "git-remote", "git-push"],
+  },
+  lessons: {
+    branches: ["git-branch", "git-switch", "git-status"],
+    remotes: ["git-remote", "git-push", "git-pull"],
+  },
+  slugToModule: {
+    branches: "module-2",
+    remotes: "module-2",
+    "github-repositories": "module-3",
+  },
+};
+
+describe("idsToCommands", () => {
+  it("maps known ids and skips unknown", () => {
+    const cmds = idsToCommands(["git-status", "nope", "git-init"]);
+    expect(cmds.map((c) => c.id)).toEqual(["git-status", "git-init"]);
+  });
+});
+
+describe("moduleIdFromFilePath", () => {
+  it("extracts module id from curriculum filePath", () => {
+    expect(moduleIdFromFilePath("module-2/branches.md")).toBe("module-2");
+    expect(moduleIdFromFilePath("module-3/forks.md")).toBe("module-3");
+  });
+});
+
+describe("resolveModuleId", () => {
+  it("prefers explicit moduleId", () => {
+    expect(resolveModuleId("branches", "module-3", SAMPLE_MAP)).toBe(
+      "module-3",
+    );
+  });
+
+  it("falls back to slugToModule", () => {
+    expect(resolveModuleId("github-repositories", undefined, SAMPLE_MAP)).toBe(
+      "module-3",
+    );
+  });
+});
+
+describe("resolveContextualCommands", () => {
+  it("uses lesson-specific commands when available", () => {
+    const result = resolveContextualCommands("branches", "module-2", SAMPLE_MAP);
+    expect(result.source).toBe("lesson");
+    expect(result.commands.map((c) => c.command)).toEqual([
+      "git branch",
+      "git switch <branch>",
+      "git status",
+    ]);
+  });
+
+  it("falls back to module commands", () => {
+    const result = resolveContextualCommands(
+      "github-repositories",
+      undefined,
+      SAMPLE_MAP,
+    );
+    expect(result.source).toBe("module");
+    expect(result.resolvedModuleId).toBe("module-3");
+    expect(result.commands.some((c) => c.id === "git-clone")).toBe(true);
+  });
+
+  it("falls back to defaults", () => {
+    const result = resolveContextualCommands("unknown-lesson", undefined, SAMPLE_MAP);
+    expect(result.source).toBe("default");
+    expect(result.commands.map((c) => c.id)).toEqual([
+      "git-status",
+      "git-init",
+    ]);
+  });
+
+  it("module-2 vs module-3 return different focused sets", () => {
+    const m2 = resolveContextualCommands(undefined, "module-2", SAMPLE_MAP);
+    const m3 = resolveContextualCommands(undefined, "module-3", SAMPLE_MAP);
+    expect(m2.commands.map((c) => c.id)).not.toEqual(
+      m3.commands.map((c) => c.id),
+    );
+    expect(m2.commands.some((c) => c.id === "git-branch")).toBe(true);
+    expect(m3.commands.some((c) => c.id === "git-remote")).toBe(true);
+  });
+});

--- a/frontend/src/test/conventionalCommitCoach.test.ts
+++ b/frontend/src/test/conventionalCommitCoach.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import {
+  validateCommitMessage,
+  suggestCommitRewrite,
+  buildPrChecklistTemplate,
+  ALLOWED_TYPES,
+} from "../lib/conventionalCommitCoach";
+
+describe("validateCommitMessage", () => {
+  it("rejects empty messages", () => {
+    const result = validateCommitMessage("   ");
+    expect(result.valid).toBe(false);
+    expect(result.issues[0]?.code).toBe("empty");
+  });
+
+  it("accepts a valid feat message", () => {
+    const result = validateCommitMessage("feat: add commit coach widget");
+    expect(result.valid).toBe(true);
+    expect(result.issues).toHaveLength(0);
+    expect(result.parsed.type).toBe("feat");
+    expect(result.parsed.subject).toBe("add commit coach widget");
+  });
+
+  it("accepts optional scope", () => {
+    const result = validateCommitMessage("fix(auth): handle expired tokens");
+    expect(result.valid).toBe(true);
+    expect(result.parsed.scope).toBe("auth");
+  });
+
+  it("rejects unknown types with plain-English help", () => {
+    const result = validateCommitMessage("update: bump deps");
+    expect(result.valid).toBe(false);
+    expect(result.issues.some((i) => i.code === "type")).toBe(true);
+    expect(result.issues[0]?.message).toMatch(/not a known type/i);
+  });
+
+  it("rejects uppercase subject start", () => {
+    const result = validateCommitMessage("feat: Add login form");
+    expect(result.valid).toBe(false);
+    expect(result.issues.some((i) => i.code === "subject_case")).toBe(true);
+  });
+
+  it("rejects trailing period on subject", () => {
+    const result = validateCommitMessage("docs: update readme.");
+    expect(result.valid).toBe(false);
+    expect(result.issues.some((i) => i.code === "subject_period")).toBe(true);
+  });
+
+  it("rejects empty scope parentheses", () => {
+    const result = validateCommitMessage("chore(): clean scripts");
+    expect(result.valid).toBe(false);
+    expect(result.issues.some((i) => i.code === "scope")).toBe(true);
+  });
+
+  it("rejects malformed format", () => {
+    const result = validateCommitMessage("just a random sentence");
+    expect(result.valid).toBe(false);
+    expect(result.issues.some((i) => i.code === "format")).toBe(true);
+  });
+
+  it("exposes the allowed type list", () => {
+    expect(ALLOWED_TYPES).toContain("feat");
+    expect(ALLOWED_TYPES).toContain("fix");
+    expect(ALLOWED_TYPES).toContain("docs");
+  });
+});
+
+describe("suggestCommitRewrite", () => {
+  it("returns a starter template for empty input", () => {
+    expect(suggestCommitRewrite("")).toBe("feat: describe your change here");
+  });
+
+  it("lowercases type and subject and strips trailing period", () => {
+    expect(suggestCommitRewrite("Feat: Add Login Form.")).toBe(
+      "feat: add Login Form",
+    );
+  });
+
+  it("maps unknown typed headers to chore", () => {
+    expect(suggestCommitRewrite("update: bump lodash")).toBe(
+      "chore: bump lodash",
+    );
+  });
+
+  it("prefixes bare subjects with feat", () => {
+    expect(suggestCommitRewrite("add heatmap widget")).toBe(
+      "feat: add heatmap widget",
+    );
+  });
+});
+
+describe("buildPrChecklistTemplate", () => {
+  it("includes the commit message and checklist items", () => {
+    const text = buildPrChecklistTemplate("feat: add coach");
+    expect(text).toContain("feat: add coach");
+    expect(text).toContain("## Summary");
+    expect(text).toContain("Conventional Commit message used");
+  });
+});

--- a/frontend/src/test/glossary.test.ts
+++ b/frontend/src/test/glossary.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import {
+  splitTextWithGlossary,
+  splitIgnoringInlineCode,
+  entryPhrases,
+  type GlossaryEntry,
+} from "../lib/glossary";
+
+const TERMS: GlossaryEntry[] = [
+  {
+    id: "fork",
+    term: "fork",
+    aliases: ["forks"],
+    short: "Your copy of a repo",
+    definition: "A fork is your copy.",
+  },
+  {
+    id: "pull-request",
+    term: "pull request",
+    aliases: ["PR", "PRs"],
+    short: "A change proposal",
+    definition: "A PR proposes merges.",
+  },
+  {
+    id: "good-first-issue",
+    term: "good first issue",
+    aliases: ["good first issues"],
+    short: "Beginner task",
+    definition: "Labeled for newcomers.",
+  },
+  {
+    id: "issue",
+    term: "issue",
+    aliases: ["issues"],
+    short: "A tracked ticket",
+    definition: "Issues track work.",
+  },
+  {
+    id: "commit",
+    term: "commit",
+    aliases: ["commits"],
+    short: "A snapshot",
+    definition: "Commits save changes.",
+  },
+];
+
+describe("entryPhrases", () => {
+  it("returns longest phrases first", () => {
+    const phrases = entryPhrases(TERMS.find((t) => t.id === "pull-request")!);
+    expect(phrases[0]).toBe("pull request");
+    expect(phrases).toContain("PR");
+  });
+});
+
+describe("splitTextWithGlossary", () => {
+  it("highlights known terms and preserves surrounding text", () => {
+    const segs = splitTextWithGlossary(
+      "Please open a pull request after you fork.",
+      TERMS,
+    );
+    const terms = segs.filter((s) => s.type === "term");
+    expect(terms.map((t) => (t.type === "term" ? t.entry.id : ""))).toEqual([
+      "pull-request",
+      "fork",
+    ]);
+  });
+
+  it("prefers longer phrase over shorter (good first issue vs issue)", () => {
+    const segs = splitTextWithGlossary("Pick a good first issue today.", TERMS);
+    const termSegs = segs.filter((s) => s.type === "term");
+    expect(termSegs).toHaveLength(1);
+    expect(termSegs[0].type === "term" && termSegs[0].entry.id).toBe(
+      "good-first-issue",
+    );
+  });
+
+  it("is case-insensitive but keeps original casing", () => {
+    const segs = splitTextWithGlossary("Submit a PR please.", TERMS);
+    const term = segs.find((s) => s.type === "term");
+    expect(term?.type === "term" && term.value).toBe("PR");
+    expect(term?.type === "term" && term.entry.id).toBe("pull-request");
+  });
+
+  it("does not match partial words (commit vs commitment)", () => {
+    const segs = splitTextWithGlossary(
+      "Show commitment to the project with a commit.",
+      TERMS,
+    );
+    const termSegs = segs.filter((s) => s.type === "term");
+    expect(termSegs).toHaveLength(1);
+    expect(termSegs[0].type === "term" && termSegs[0].value.toLowerCase()).toBe(
+      "commit",
+    );
+  });
+
+  it("returns plain text when no terms match", () => {
+    const segs = splitTextWithGlossary("Hello world", TERMS);
+    expect(segs).toEqual([{ type: "text", value: "Hello world" }]);
+  });
+});
+
+describe("splitIgnoringInlineCode", () => {
+  it("separates inline code from plain text for safe glossarizing", () => {
+    const parts = splitIgnoringInlineCode(
+      "Run `git fork` then open a fork on GitHub.",
+    );
+    expect(parts).toEqual([
+      { kind: "plain", value: "Run " },
+      { kind: "code", value: "`git fork`" },
+      { kind: "plain", value: " then open a fork on GitHub." },
+    ]);
+
+    const plain = parts
+      .filter((p) => p.kind === "plain")
+      .map((p) => p.value)
+      .join("");
+    const code = parts
+      .filter((p) => p.kind === "code")
+      .map((p) => p.value)
+      .join("");
+
+    const plainTerms = splitTextWithGlossary(plain, TERMS).filter(
+      (s) => s.type === "term",
+    );
+    const codeTerms = splitTextWithGlossary(code.replace(/`/g, ""), TERMS).filter(
+      (s) => s.type === "term",
+    );
+
+    // After skipping code spans, only the prose "fork" should be treated as glossary
+    expect(plainTerms.some((t) => t.type === "term" && t.entry.id === "fork")).toBe(
+      true,
+    );
+    // Document that callers must not glossarize code chunks (MarkdownRenderer skips them)
+    expect(code).toContain("fork");
+    expect(codeTerms.length).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/frontend/src/test/prDiffSummarizer.test.ts
+++ b/frontend/src/test/prDiffSummarizer.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseChangedFiles,
+  classifyPath,
+  summarizeDiff,
+  buildChecklist,
+  buildPrDescription,
+} from "../lib/prDiffSummarizer";
+
+describe("parseChangedFiles", () => {
+  it("parses plain paths", () => {
+    const paths = parseChangedFiles(
+      "frontend/src/App.tsx\nbackend/apps/content/models.py\n",
+    );
+    expect(paths).toEqual([
+      "frontend/src/App.tsx",
+      "backend/apps/content/models.py",
+    ]);
+  });
+
+  it("parses git status style lines", () => {
+    const paths = parseChangedFiles(`
+On branch feat/pr-tool
+Changes not staged for commit:
+  modified:   frontend/src/lib/prDiffSummarizer.ts
+  new file:   docs/CONTENT_GUIDE.md
+`);
+    expect(paths).toContain("frontend/src/lib/prDiffSummarizer.ts");
+    expect(paths).toContain("docs/CONTENT_GUIDE.md");
+  });
+
+  it("parses short status prefixes", () => {
+    const paths = parseChangedFiles("M  frontend/src/a.ts\n?? backend/b.py\n");
+    expect(paths).toEqual(["frontend/src/a.ts", "backend/b.py"]);
+  });
+
+  it("deduplicates paths", () => {
+    const paths = parseChangedFiles("a/b.ts\na/b.ts\n");
+    expect(paths).toEqual(["a/b.ts"]);
+  });
+});
+
+describe("classifyPath", () => {
+  it("detects frontend paths", () => {
+    expect(classifyPath("frontend/src/App.tsx")).toContain("frontend");
+  });
+
+  it("detects backend paths", () => {
+    expect(classifyPath("backend/apps/content/views.py")).toContain("backend");
+  });
+
+  it("detects docs and markdown", () => {
+    expect(classifyPath("docs/CONTENT_GUIDE.md")).toEqual(
+      expect.arrayContaining(["docs"]),
+    );
+    expect(classifyPath("README.md")).toContain("docs");
+  });
+
+  it("detects migrations", () => {
+    expect(
+      classifyPath("backend/apps/progress/migrations/0012_example.py"),
+    ).toEqual(expect.arrayContaining(["migrations", "backend"]));
+  });
+
+  it("detects tests", () => {
+    expect(classifyPath("frontend/src/test/prDiffSummarizer.test.ts")).toEqual(
+      expect.arrayContaining(["tests", "frontend"]),
+    );
+  });
+
+  it("detects ci workflows", () => {
+    expect(classifyPath(".github/workflows/ci.yml")).toEqual(
+      expect.arrayContaining(["ci"]),
+    );
+  });
+});
+
+describe("summarizeDiff + checklist", () => {
+  it("aggregates areas and builds relevant checklist items", () => {
+    const summary = summarizeDiff(`
+frontend/src/pages/PrDiffSummarizerPage.tsx
+backend/apps/accounts/models.py
+backend/apps/accounts/migrations/0003_foo.py
+docs/ARCHITECTURE.md
+`);
+    expect(summary.areas).toEqual(
+      expect.arrayContaining(["frontend", "backend", "migrations", "docs"]),
+    );
+
+    const checklist = buildChecklist(summary);
+    const labels = checklist.map((i) => i.label).join("\n");
+    expect(labels).toMatch(/npm run test/);
+    expect(labels).toMatch(/pytest/);
+    expect(labels).toMatch(/migrate/i);
+    expect(labels).toMatch(/Documentation/);
+  });
+});
+
+describe("buildPrDescription", () => {
+  it("includes issue number, files, and template sections", () => {
+    const body = buildPrDescription("frontend/src/App.tsx\ndocs/README.md", {
+      issueNumber: "1822",
+      titleHint: "Add PR summarizer",
+    });
+    expect(body).toContain("Fixes #1822");
+    expect(body).toContain("Add PR summarizer");
+    expect(body).toContain("frontend/src/App.tsx");
+    expect(body).toContain("## Pre-Push Checklist");
+    expect(body).toContain("## Type of Change");
+  });
+
+  it("handles empty input without crashing", () => {
+    const body = buildPrDescription("   ");
+    expect(body).toContain("## Description");
+  });
+});

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -38,9 +38,6 @@ export default defineConfig({
         type: "module",
       },
     }),
-    storybookTest({
-      configDir: path.join(dirname, ".storybook"),
-    }),
   ],
   resolve: {
     dedupe: ["react", "react-dom", "react-i18next"],
@@ -50,6 +47,7 @@ export default defineConfig({
       {
         extends: true,
         test: {
+          name: "unit",
           environment: "jsdom",
           setupFiles: "./src/test/setup.ts",
           include: ["src/**/*.test.{ts,tsx}"],
@@ -58,6 +56,11 @@ export default defineConfig({
       },
       {
         extends: true,
+        plugins: [
+          storybookTest({
+            configDir: path.join(dirname, ".storybook"),
+          }),
+        ],
         test: {
           name: "storybook",
           browser: {


### PR DESCRIPTION
# #1829 issue resolved
## Description
This PR adds a beginner-friendly “Explain Like I’m New” Glossary Drawer for lesson markdown (/lessons/:slug).

## Features

- Content-driven glossary.json with 20 starter OSS terms
- Clickable dotted-underline terms in lesson markdown
- Side drawer with plain-English short + full definitions
- Skips fenced code blocks and inline code (no false positives)
- Keyboard accessible triggers with aria-describedby
- Docs note in CONTENT_GUIDE for adding new terms
- Dark/light theme compatible UI with Vitest coverage for matching rules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a PR Summarizer that generates descriptions and checklists from changed file paths.
  * Added a Commit Message Coach with validation, rewrite suggestions, copy actions, and commit guidance.
  * Added contextual Git cheat sheets with copy and terminal insertion actions.
  * Added an interactive lesson glossary with definitions, aliases, and keyboard-accessible term details.
  * Added glossary and Git reference content for lessons.
* **Improvements**
  * Contributor practice now integrates commit coaching and PR description guidance.
  * Quiz submissions include improved security validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->