### PR TITLE
fix(monitoring): compute per-queue size from Redis instead of misused inspect.reserved()

### DIFF
--- a/backend/monitoring/celery_monitor.py
+++ b/backend/monitoring/celery_monitor.py
@@ -2,6 +2,7 @@ from prometheus_client import Counter, Gauge, Histogram, start_http_server
 import time
 from celery import Celery
 import os
+import redis
 
 app = Celery("config")
 
@@ -23,6 +24,9 @@ class CeleryMonitor:
     def __init__(self):
         self.queues = ["default", "high_priority", "low_priority"]
         self.workers = 0
+        self.redis_client = redis.Redis.from_url(
+            os.getenv("CELERY_BROKER_URL", "redis://localhost:6379/0")
+        )
 
     def update_metrics(self):
         """Update all metrics"""
@@ -30,19 +34,11 @@ class CeleryMonitor:
         self.update_worker_count()
 
     def update_queue_sizes(self):
-        """Update queue size metrics"""
+        """Update queue size metrics using the true per-queue Redis list length"""
         for queue in self.queues:
             try:
-                from celery import current_app
-                from celery.utils import term
-
-                inspect = current_app.control.inspect()
-                reserved = inspect.reserved()
-                if reserved:
-                    count = sum(1 for v in reserved.values() if v)
-                    queue_size.labels(queue_name=queue).set(count)
-                else:
-                    queue_size.labels(queue_name=queue).set(0)
+                count = self.redis_client.llen(queue)
+                queue_size.labels(queue_name=queue).set(count)
             except Exception as e:
                 print(f"Failed to get queue size for {queue}: {e}")
 


### PR DESCRIPTION
## Description

Fixes per-queue Celery metrics: all three `celery_queue_size` gauge labels
previously reported the identical (wrong) number because `update_queue_sizes()`
misused `inspect.reserved()`, which is keyed by worker, not queue. Now reads
the true per-queue backlog directly from Redis via `LLEN`. Also removes an
unused `celery.utils.term` import.

Closes #1836 

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update (no code changes)
- [ ] ⚙️ CI/CD or build pipeline change
- [ ] ⚡ Performance optimization
- [ ] 🛠️ Refactoring (no functional changes)

## How Has This Been Tested?

### Automated Tests
- [x] Backend tests pass: `cd backend && pytest`
- [ ] Frontend tests pass: `cd frontend && npm run test`
- [ ] Frontend builds successfully: `cd frontend && npm run build`

### Manual Verification
Pushed items into a single queue's Redis list key, confirmed only that
queue's gauge reflects the count and the other two report 0 (see testing
checklist in linked issue).

## Pre-Push Checklist

> [!IMPORTANT]
> **All items below must be checked before requesting a review.** Our CI bot will automatically run the frontend build and backend tests on your PR. If CI fails, you will receive a comment explaining what went wrong.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or console errors
- [ ] I have run `npm run build` in `frontend/` and it completes with **0 errors**
- [x] I have run `pytest` in `backend/` and all tests pass
- [x] I have run `git diff` locally and verified my changes

Backend only.

## Deployment Notes

> [!NOTE]
> This project is deployed on **Vercel** (Frontend) and **Hugging Face** (Backend). The CI workflow simulates both deployment environments. If your PR passes CI, it is safe to merge.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Celery queue size monitoring for more accurate task counts.
  * Monitoring now reads queue lengths directly and continues operating if a queue check fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->