### PR TITLE
fix(github): don't reference unbound response on connection-level RequestException

### DIFF
--- a/backend/github/service.py
+++ b/backend/github/service.py
@@ -33,7 +33,7 @@ class GithubService:
             raise ValueError("Invalid endpoint: Must be a relative path")
 
         url = f"{self.base_url}/{endpoint.lstrip('/')}"
-        
+
         parsed_url = urlparse(url)
         if parsed_url.netloc != "api.github.com" and not parsed_url.netloc.endswith(".github.com"):
             raise ValueError("Invalid endpoint: Domain must be a github.com domain")
@@ -46,8 +46,11 @@ class GithubService:
             response.raise_for_status()
             return response.json()
         except requests.exceptions.RequestException as e:
-            # If token expired, refresh and retry once
-            if response.status_code == 401:
+            # Only attempt the 401-refresh-and-retry path if we actually got
+            # a response back (connection-level failures like ConnectionError
+            # or Timeout never produce a response object).
+            resp = getattr(e, "response", None)
+            if resp is not None and resp.status_code == 401:
                 self._refresh_token()
                 headers = self._get_headers()
                 response = requests.request(method, url, headers=headers, **kwargs)


### PR DESCRIPTION
## Description

`make_request()` referenced an unbound `response` variable whenever
`requests.request()` itself raised before returning a response (e.g.
`ConnectionError`, `Timeout`), crashing with `UnboundLocalError` and hiding
the real network error. Now only accesses `response` when the exception
actually carries one.

Closes #1837  

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update (no code changes)
- [ ] ⚙️ CI/CD or build pipeline change
- [ ] ⚡ Performance optimization
- [ ] 🛠️ Refactoring (no functional changes)

## How Has This Been Tested?

### Automated Tests
- [x] Backend tests pass: `cd backend && pytest`
- [ ] Frontend tests pass: `cd frontend && npm run test`
- [ ] Frontend builds successfully: `cd frontend && npm run build`

### Manual Verification
Simulated a connection-level failure and confirmed the original exception
now propagates correctly instead of UnboundLocalError; confirmed the
401-refresh-and-retry path is unchanged.

## Pre-Push Checklist

> [!IMPORTANT]
> **All items below must be checked before requesting a review.** Our CI bot will automatically run the frontend build and backend tests on your PR. If CI fails, you will receive a comment explaining what went wrong.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or console errors
- [ ] I have run `npm run build` in `frontend/` and it completes with **0 errors**
- [x] I have run `pytest` in `backend/` and all tests pass
- [x] I have run `git diff` locally and verified my changes

## Deployment Notes

> [!NOTE]
> This project is deployed on **Vercel** (Frontend) and **Hugging Face** (Backend). The CI workflow simulates both deployment environments. If your PR passes CI, it is safe to merge.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of GitHub connection failures.
  * Token refresh and retry now occur only for confirmed authentication errors.
  * Other request failures are reported without triggering unnecessary retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->