### PR TITLE
fix(github): use timezone-aware datetime.now() to compute token TTL

### DIFF
--- a/backend/github/auth.py
+++ b/backend/github/auth.py
@@ -3,7 +3,7 @@ import requests
 import time
 import os
 from typing import Optional
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from django.core.cache import cache
 
 
@@ -69,7 +69,7 @@ class GitHubAppAuth:
             # Cache token with 10 minute buffer
             if token and expires_at:
                 expires = datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
-                ttl = int((expires - datetime.now()).total_seconds()) - 600
+                ttl = int((expires - datetime.now(timezone.utc)).total_seconds()) - 600
                 if ttl > 0:
                     cache.set(self.cache_key, token, ttl)
 


### PR DESCRIPTION
## Description

`get_installation_token()` always crashed with `TypeError` on any cold-cache
fetch because it subtracted a timezone-aware `expires` datetime from a
naive `datetime.now()`. Fixed by using `datetime.now(timezone.utc)`.

Closes #1839 

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update (no code changes)
- [ ] ⚙️ CI/CD or build pipeline change
- [ ] ⚡ Performance optimization
- [ ] 🛠️ Refactoring (no functional changes)

## How Has This Been Tested?

### Automated Tests
- [x] Backend tests pass: `cd backend && pytest`
- [ ] Frontend tests pass: `cd frontend && npm run test`
- [ ] Frontend builds successfully: `cd frontend && npm run build`

### Manual Verification

Cleared the token cache and confirmed `get_installation_token()` no longer
raises TypeError and correctly caches/returns a token on repeat calls.

## Pre-Push Checklist

> [!IMPORTANT]
> **All items below must be checked before requesting a review.** Our CI bot will automatically run the frontend build and backend tests on your PR. If CI fails, you will receive a comment explaining what went wrong.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or console errors
- [ ] I have run `npm run build` in `frontend/` and it completes with **0 errors**
- [x] I have run `pytest` in `backend/` and all tests pass
- [x] I have run `git diff` locally and verified my changes

## Deployment Notes

> [!NOTE]
> This project is deployed on **Vercel** (Frontend) and **Hugging Face** (Backend). The CI workflow simulates both deployment environments. If your PR passes CI, it is safe to merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub authentication token expiration handling by using timezone-aware timestamps.
  * Prevented potential errors when comparing token expiration times across different time zones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->