### PR TITLE
Offline Lesson Reading Indicator

### DIFF
--- a/frontend/src/components/ui/AvailableOfflineBadge.tsx
+++ b/frontend/src/components/ui/AvailableOfflineBadge.tsx
@@ -1,0 +1,28 @@
+/**
+ * AvailableOfflineBadge.tsx
+ * Compact badge for lesson list rows when content is cached for offline reading.
+ */
+import { HardDrive } from "lucide-react";
+
+interface AvailableOfflineBadgeProps {
+  /** Compact icon-only mode for dense sidebars */
+  compact?: boolean;
+  className?: string;
+}
+
+export function AvailableOfflineBadge({
+  compact = false,
+  className = "",
+}: AvailableOfflineBadgeProps) {
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full border border-teal-600/40 bg-teal-50 px-1.5 py-0.5 text-[9px] font-black uppercase tracking-wide text-teal-800 dark:bg-teal-900/30 dark:text-teal-200 dark:border-teal-600/50 ${className}`}
+      title="This lesson is cached and can be read offline"
+      aria-label="Available offline"
+    >
+      <HardDrive className="h-2.5 w-2.5 shrink-0" aria-hidden />
+      {!compact && <span>Available offline</span>}
+      {compact && <span className="sr-only">Available offline</span>}
+    </span>
+  );
+}

--- a/frontend/src/hooks/useOfflineReadyLessons.ts
+++ b/frontend/src/hooks/useOfflineReadyLessons.ts
@@ -1,0 +1,94 @@
+/**
+ * useOfflineReadyLessons.ts
+ * Tracks which curriculum lessons are available offline (SW cache + IndexedDB).
+ * Re-checks when network status changes or when the lesson list changes.
+ */
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useNetworkStatus } from "../context/useNetworkStatus";
+import {
+  getOfflineReadySlugs,
+  type OfflineLessonRef,
+} from "../lib/contentCacheCheck";
+
+export interface UseOfflineReadyLessonsResult {
+  /** Slugs that can be read without a network connection */
+  offlineReadySlugs: Set<string>;
+  isChecking: boolean;
+  isOnline: boolean;
+  isOfflineReady: (slug: string) => boolean;
+  refresh: () => void;
+}
+
+export function useOfflineReadyLessons(
+  lessons: OfflineLessonRef[],
+): UseOfflineReadyLessonsResult {
+  const { isOnline } = useNetworkStatus();
+  const [offlineReadySlugs, setOfflineReadySlugs] = useState<Set<string>>(
+    () => new Set(),
+  );
+  const [isChecking, setIsChecking] = useState(false);
+  const [refreshCount, setRefreshCount] = useState(0);
+
+  const lessonKey = useMemo(
+    () =>
+      lessons
+        .map((l) => `${l.slug}:${l.filePath ?? ""}`)
+        .sort()
+        .join("|"),
+    [lessons],
+  );
+
+  const refresh = useCallback(() => {
+    setRefreshCount((c) => c + 1);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function run() {
+      if (lessons.length === 0) {
+        if (!cancelled) setOfflineReadySlugs(new Set());
+        return;
+      }
+
+      if (!cancelled) setIsChecking(true);
+      try {
+        const ready = await getOfflineReadySlugs(lessons);
+        if (!cancelled) setOfflineReadySlugs(ready);
+      } catch {
+        if (!cancelled) setOfflineReadySlugs(new Set());
+      } finally {
+        if (!cancelled) setIsChecking(false);
+      }
+    }
+
+    void run();
+    return () => {
+      cancelled = true;
+    };
+    // lessonKey captures lesson identity; refreshCount forces re-scan
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [lessonKey, isOnline, refreshCount]);
+
+  // Re-scan when a lesson was just opened (IDB may have updated)
+  useEffect(() => {
+    const onVisibility = () => {
+      if (document.visibilityState === "visible") refresh();
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+    return () => document.removeEventListener("visibilitychange", onVisibility);
+  }, [refresh]);
+
+  const isOfflineReady = useCallback(
+    (slug: string) => offlineReadySlugs.has(slug),
+    [offlineReadySlugs],
+  );
+
+  return {
+    offlineReadySlugs,
+    isChecking,
+    isOnline,
+    isOfflineReady,
+    refresh,
+  };
+}

--- a/frontend/src/lib/contentCacheCheck.ts
+++ b/frontend/src/lib/contentCacheCheck.ts
@@ -1,0 +1,105 @@
+/**
+ * contentCacheCheck.ts
+ * Detect whether lesson Markdown under /content/ is available offline
+ * via the Cache API (service worker) and/or IndexedDB lesson cache.
+ */
+import { getAllCachedSlugs, getCachedLesson } from "./lessonCache";
+
+/** Workbox runtime cache name from src/sw.js */
+export const CONTENT_RUNTIME_CACHE = "content-runtime-cache";
+
+export interface OfflineLessonRef {
+  slug: string;
+  filePath?: string;
+}
+
+/** Build the absolute URL the SW would cache for a content file. */
+export function contentUrlForFilePath(filePath: string): string {
+  const normalized = filePath.replace(/^\/+/, "");
+  if (typeof window !== "undefined" && window.location?.origin) {
+    return new URL(`/content/${normalized}`, window.location.origin).href;
+  }
+  return `/content/${normalized}`;
+}
+
+/**
+ * Check whether a URL is present in any Cache Storage cache
+ * (runtime content cache first, then all caches as fallback).
+ */
+export async function isUrlInCacheStorage(url: string): Promise<boolean> {
+  if (typeof caches === "undefined") return false;
+
+  try {
+    const runtime = await caches.open(CONTENT_RUNTIME_CACHE);
+    if (await runtime.match(url, { ignoreSearch: true })) return true;
+
+    const names = await caches.keys();
+    for (const name of names) {
+      if (name === CONTENT_RUNTIME_CACHE) continue;
+      const cache = await caches.open(name);
+      if (await cache.match(url, { ignoreSearch: true })) return true;
+    }
+  } catch {
+    return false;
+  }
+
+  return false;
+}
+
+/** True if this lesson's /content/{filePath} asset is in the SW cache. */
+export async function isContentFileCached(
+  filePath: string | undefined,
+): Promise<boolean> {
+  if (!filePath) return false;
+  return isUrlInCacheStorage(contentUrlForFilePath(filePath));
+}
+
+/** True if IndexedDB has markdown for this slug. */
+export async function isLessonInIndexedDb(slug: string): Promise<boolean> {
+  const entry = await getCachedLesson(slug);
+  return !!entry?.markdown;
+}
+
+/**
+ * A lesson is offline-ready when either:
+ *  - IndexedDB has the lesson markdown (from prior online open), or
+ *  - the SW Cache API has /content/{filePath}
+ */
+export async function isLessonOfflineReady(
+  lesson: OfflineLessonRef,
+): Promise<boolean> {
+  if (await isLessonInIndexedDb(lesson.slug)) return true;
+  return isContentFileCached(lesson.filePath);
+}
+
+/**
+ * Batch-check which lessons are available offline.
+ * Returns a Set of offline-ready slugs.
+ */
+export async function getOfflineReadySlugs(
+  lessons: OfflineLessonRef[],
+): Promise<Set<string>> {
+  const ready = new Set<string>();
+  if (lessons.length === 0) return ready;
+
+  let idbSlugs: Set<string>;
+  try {
+    idbSlugs = new Set(await getAllCachedSlugs());
+  } catch {
+    idbSlugs = new Set();
+  }
+
+  await Promise.all(
+    lessons.map(async (lesson) => {
+      if (idbSlugs.has(lesson.slug)) {
+        ready.add(lesson.slug);
+        return;
+      }
+      if (await isContentFileCached(lesson.filePath)) {
+        ready.add(lesson.slug);
+      }
+    }),
+  );
+
+  return ready;
+}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -2,14 +2,23 @@ import { AdminDashboard } from "../components/dashboard/AdminDashboard";
 import { useAuth } from "../features/auth/AuthContext";
 import { useQuery } from "@tanstack/react-query";
 import { fetchApi } from "../lib/api";
-import { mockStudentStats, mockLessonQueue, getTipOfTheDay } from "../lib/dashboardMockData";
+import { mockStudentStats, getTipOfTheDay } from "../lib/dashboardMockData";
 import { Link } from "react-router-dom";
 import SkeletonAdminDashboard from "../components/ui/skeletons/SkeletonAdminDashboard";
-import { useState, useEffect, useMemo } from "react";
+import { useState, useMemo } from "react";
 import { useUserProgress } from "../hooks/useUserProgress";
 import { useBookmarks } from "../hooks/useBookmarks";
+import { useOfflineReadyLessons } from "../hooks/useOfflineReadyLessons";
 import { BADGES } from "../constants/badges";
 import { Flame, ArrowRight, Bookmark, Lock, BookOpen, Award, Sparkles } from "lucide-react";
+import { AvailableOfflineBadge } from "../components/ui/AvailableOfflineBadge";
+
+type CurriculumLesson = {
+  slug: string;
+  title: string;
+  description: string;
+  filePath?: string;
+};
 
 export function DashboardPage() {
   const { user } = useAuth();
@@ -21,12 +30,35 @@ export function DashboardPage() {
     queryFn: () =>
       fetch("/content/curriculum.json")
         .then((r) => r.json())
-        .then((json: { modules: { lessons: { slug: string; title: string; description: string }[] }[] }) =>
-          json.modules.flatMap((m) => m.lessons.map((l) => ({ ...l, filePath: "" }))),
+        .then(
+          (json: {
+            modules: { lessons: CurriculumLesson[] }[];
+          }) => json.modules.flatMap((m) => m.lessons),
         )
-        .catch(() => []),
+        .catch(() => [] as CurriculumLesson[]),
   });
   const lessons = lessonsData;
+
+  const lessonRefs = useMemo(
+    () =>
+      lessons.map((l) => ({
+        slug: l.slug,
+        filePath: l.filePath,
+      })),
+    [lessons],
+  );
+  const { isOfflineReady } = useOfflineReadyLessons(lessonRefs);
+
+  const lessonQueue = useMemo(() => {
+    const incomplete = lessons.filter((l) => !isLessonCompleted(l.slug));
+    return incomplete.slice(0, 3).map((l, index) => ({
+      number: index + 1,
+      title: l.title,
+      description: l.description,
+      slug: l.slug,
+      filePath: l.filePath,
+    }));
+  }, [lessons, isLessonCompleted]);
 
   const { isLoading: contributorLoading } = useQuery({
     queryKey: ["contributorStats"],
@@ -42,7 +74,6 @@ export function DashboardPage() {
   const [showProgressReport, setShowProgressReport] = useState(false);
 
   const stats = mockStudentStats;
-  const lessonQueue = mockLessonQueue;
 
   const completedLessonsCount = lessons.filter((l) => isLessonCompleted(l.slug)).length;
   const totalLessonsCount = lessons.length;
@@ -198,18 +229,30 @@ export function DashboardPage() {
               to={`/lessons/${lesson.slug}`}
               className="flex items-center justify-between p-5 rounded-lg border-4 border-black bg-gray-50 dark:bg-[#151411] dark:border-[#2e2924] shadow-card-sm hover:shadow-card hover:-translate-y-0.5 transition-all"
             >
-              <div className="flex items-center gap-4">
+              <div className="flex items-center gap-4 min-w-0">
                 <span className="w-8 h-8 rounded-full bg-black text-white font-black text-sm flex items-center justify-center flex-shrink-0 dark:bg-[#2e2924]">
                   {lesson.number}
                 </span>
-                <div>
-                  <h3 className="font-black text-lg dark:text-[#f0ebe2]">{lesson.title}</h3>
-                  <p className="text-sm font-bold text-gray-500 dark:text-[#c4bbae]">{lesson.description}</p>
+                <div className="min-w-0">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <h3 className="font-black text-lg dark:text-[#f0ebe2]">
+                      {lesson.title}
+                    </h3>
+                    {isOfflineReady(lesson.slug) && <AvailableOfflineBadge />}
+                  </div>
+                  <p className="text-sm font-bold text-gray-500 dark:text-[#c4bbae]">
+                    {lesson.description}
+                  </p>
                 </div>
               </div>
               <ArrowRight className="w-5 h-5 text-gray-400 flex-shrink-0" />
             </Link>
           ))}
+          {lessonQueue.length === 0 && (
+            <p className="text-sm font-bold text-gray-500 dark:text-[#c4bbae] text-center py-4">
+              All queued lessons complete — browse the full curriculum below.
+            </p>
+          )}
           <Link
             to="/content"
             className="block text-center rounded-lg border-4 border-black bg-gray-100 dark:bg-[#151411] dark:border-[#2e2924] py-3 font-black text-sm hover:-translate-y-0.5 transition-all dark:text-[#f0ebe2]"

--- a/frontend/src/pages/LessonPage.tsx
+++ b/frontend/src/pages/LessonPage.tsx
@@ -21,9 +21,15 @@ import { useTerminalAutocomplete } from "../hooks/useTerminalAutocomplete";
 import { ShellState } from "../hooks/useGitShell";
 import { useBookmarks } from "../hooks/useBookmarks";
 import { useNotifications } from "../features/notifications/NotificationContext";
+import { useOfflineLesson } from "../hooks/useOfflineLesson";
+import { useOfflineReadyLessons } from "../hooks/useOfflineReadyLessons";
+import { useNetworkStatus } from "../context/useNetworkStatus";
 import { fetchApi } from "../lib/api";
-import { Lesson, fetchLessonsApi, fetchLessonContent } from "../lib/lessons";
+import { Lesson, fetchLessonsApi } from "../lib/lessons";
 import { RecentlyViewedLessonsWidget } from "../components/ui/RecentlyViewedLessonsWidget";
+import { AvailableOfflineBadge } from "../components/ui/AvailableOfflineBadge";
+import { OfflineStatusBadge } from "../components/ui/OfflineStatusBadge";
+import { OfflineBanner } from "../components/ui/OfflineBanner";
 
 const SESSION_KEY_RECENT = "recentlyViewedLessonsV1";
 const MAX_RECENT_ITEMS = 3;
@@ -105,19 +111,51 @@ export function LessonPage() {
 
   const [lesson, setLesson] = useState<Lesson | undefined>(undefined);
   const [lessonsList, setLessonsList] = useState<Lesson[]>([]);
-  const [markdownContent, setMarkdownContent] = useState("");
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const { isOnline } = useNetworkStatus();
 
   // Curriculum modules list for sidebar
   const [modules, setModules] = useState<
     {
       id: string;
       title: string;
-      lessons: { slug: string; title: string; difficulty?: string }[];
+      lessons: {
+        slug: string;
+        title: string;
+        difficulty?: string;
+        filePath?: string;
+      }[];
     }[]
   >([]);
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+
+  const curriculumLessonRefs = useMemo(
+    () =>
+      modules.flatMap((mod) =>
+        mod.lessons.map((les) => ({
+          slug: les.slug,
+          filePath: les.filePath,
+        })),
+      ),
+    [modules],
+  );
+  const { isOfflineReady, refresh: refreshOfflineReady } =
+    useOfflineReadyLessons(curriculumLessonRefs);
+
+  const {
+    markdown: markdownContent,
+    source: contentSource,
+    isLoading: contentLoading,
+    refresh: refreshLessonContent,
+    isCached,
+  } = useOfflineLesson(lesson);
+
+  // After a lesson is cached (IDB), refresh list badges
+  useEffect(() => {
+    if (isCached) refreshOfflineReady();
+  }, [isCached, lesson?.slug, refreshOfflineReady]);
+
   const sidebarRef = useRef<HTMLElement>(null);
 
   const closeSidebar = useCallback(() => setIsSidebarOpen(false), []);
@@ -343,14 +381,9 @@ export function LessonPage() {
     setQuizNonce(null);
     setTimeLeft(null);
 
-    if (lesson.filePath) {
-      fetchLessonContent(lesson.filePath).then((content) => {
-        setMarkdownContent(content);
-      });
-    } else {
-      setMarkdownContent(`# ${lesson.title}\n\n${lesson.explanation}`);
-    }
-  }, [lesson]);
+    // Markdown is loaded via useOfflineLesson (network + IndexedDB / SW cache)
+    refreshOfflineReady();
+  }, [lesson, refreshOfflineReady]);
 
   // NEW: Fetch Cryptographic Nonce for the current quiz question
   useEffect(() => {
@@ -724,21 +757,23 @@ export function LessonPage() {
                     slug: string;
                     title: string;
                     difficulty?: string;
+                    filePath?: string;
                   }) => {
                     const active = les.slug === lesson.slug;
                     const completed = isLessonCompleted(les.slug);
+                    const offlineReady = isOfflineReady(les.slug);
                     return (
                       <Link
                         key={les.slug}
                         to={`/lessons/${les.slug}`}
                         onClick={closeSidebar}
-                        className={`w-full flex items-center justify-between p-2.5 rounded-lg border-2 transition-all text-xs font-bold ${
+                        className={`w-full flex items-center justify-between gap-1.5 p-2.5 rounded-lg border-2 transition-all text-xs font-bold ${
                           active
                             ? "bg-surface-low border-black shadow-card-sm text-text"
                             : "border-transparent hover:bg-surface-lowest hover:border-black/10 dark:text-[#c4bbae]"
                         }`}
                       >
-                        <div className="flex items-center gap-2 truncate">
+                        <div className="flex items-center gap-2 truncate min-w-0">
                           {completed ? (
                             <CheckCircle2
                               size={14}
@@ -749,11 +784,16 @@ export function LessonPage() {
                           )}
                           <span className="truncate">{les.title}</span>
                         </div>
-                        {les.difficulty === "advanced" && (
-                          <span className="text-[8px] bg-red-100 text-red-700 px-1 py-0.5 rounded border border-red-700">
-                            ADV
-                          </span>
-                        )}
+                        <div className="flex items-center gap-1 shrink-0">
+                          {offlineReady && (
+                            <AvailableOfflineBadge compact />
+                          )}
+                          {les.difficulty === "advanced" && (
+                            <span className="text-[8px] bg-red-100 text-red-700 px-1 py-0.5 rounded border border-red-700">
+                              ADV
+                            </span>
+                          )}
+                        </div>
                       </Link>
                     );
                   },
@@ -793,6 +833,15 @@ export function LessonPage() {
                   <span className="text-[10px] font-mono font-black bg-surface-low text-muted px-3 py-1 rounded-full border-2 border-black rotate-[-0.5deg] inline-block shadow-card-sm uppercase dark:bg-[#1f1c18] dark:border-[#2e2924] dark:text-[#c4bbae]">
                     📅 Updated: {new Date((lesson as any).updatedAt || (lesson as any).updated_at || new Date()).toLocaleDateString()}
                   </span>
+                  {isCached && <AvailableOfflineBadge />}
+                  <OfflineStatusBadge
+                    source={contentSource}
+                    onRefresh={() => {
+                      refreshLessonContent();
+                      refreshOfflineReady();
+                    }}
+                    isRefreshing={contentLoading}
+                  />
                 </div>
                 <h1 className="text-4xl sm:text-5xl font-black text-text dark:text-[#f0ebe2] drop-shadow-[2.5px_2.5px_0_#FF3B30] mt-3">
                   {lesson.title}
@@ -845,15 +894,24 @@ export function LessonPage() {
 
             <TextToSpeechControls content={markdownContent} />
 
-            <article className="prose max-w-none">
-              <React.Suspense
-                fallback={
-                  <div className="w-full h-64 animate-pulse rounded-2xl border-4 border-black/20 bg-surface-low dark:border-[#2e2924]/50 dark:bg-[#151411]" />
-                }
-              >
-                <MarkdownRenderer content={markdownContent} />
-              </React.Suspense>
-            </article>
+            {!isOnline && !isCached ? (
+              <OfflineBanner lessonTitle={lesson.title} isCached={false} />
+            ) : (
+              <>
+                {!isOnline && isCached && (
+                  <OfflineBanner lessonTitle={lesson.title} isCached />
+                )}
+                <article className="prose max-w-none">
+                  <React.Suspense
+                    fallback={
+                      <div className="w-full h-64 animate-pulse rounded-2xl border-4 border-black/20 bg-surface-low dark:border-[#2e2924]/50 dark:bg-[#151411]" />
+                    }
+                  >
+                    <MarkdownRenderer content={markdownContent} />
+                  </React.Suspense>
+                </article>
+              </>
+            )}
             <div className="mt-4 flex justify-end">
               <button
                 onClick={() => alert("Thanks for reporting the typo")}

--- a/frontend/src/test/contentCacheCheck.test.ts
+++ b/frontend/src/test/contentCacheCheck.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  contentUrlForFilePath,
+  CONTENT_RUNTIME_CACHE,
+  getOfflineReadySlugs,
+  isContentFileCached,
+  isUrlInCacheStorage,
+} from "../lib/contentCacheCheck";
+
+vi.mock("../lib/lessonCache", () => ({
+  getAllCachedSlugs: vi.fn(async () => ["cached-in-idb"]),
+  getCachedLesson: vi.fn(async (slug: string) =>
+    slug === "cached-in-idb"
+      ? { slug, markdown: "# hi", metaJson: "{}", fetchedAt: Date.now() }
+      : undefined,
+  ),
+}));
+
+describe("contentCacheCheck", () => {
+  const matchMock = vi.fn();
+  const openMock = vi.fn();
+  const keysMock = vi.fn();
+
+  beforeEach(() => {
+    matchMock.mockReset();
+    openMock.mockReset();
+    keysMock.mockReset();
+
+    openMock.mockImplementation(async () => ({
+      match: matchMock,
+    }));
+    keysMock.mockResolvedValue([CONTENT_RUNTIME_CACHE]);
+
+    vi.stubGlobal("caches", {
+      open: openMock,
+      keys: keysMock,
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("builds a /content/ URL for a file path", () => {
+    expect(contentUrlForFilePath("module-1/what-is-open-source.md")).toContain(
+      "/content/module-1/what-is-open-source.md",
+    );
+    expect(contentUrlForFilePath("/module-1/x.md")).toContain(
+      "/content/module-1/x.md",
+    );
+  });
+
+  it("detects SW-cached content files", async () => {
+    matchMock.mockResolvedValueOnce({ ok: true });
+    await expect(
+      isContentFileCached("module-1/what-is-open-source.md"),
+    ).resolves.toBe(true);
+    expect(openMock).toHaveBeenCalledWith(CONTENT_RUNTIME_CACHE);
+  });
+
+  it("returns false when Cache API has no match", async () => {
+    matchMock.mockResolvedValue(undefined);
+    await expect(isContentFileCached("module-1/missing.md")).resolves.toBe(
+      false,
+    );
+  });
+
+  it("returns false when caches API is unavailable", async () => {
+    vi.unstubAllGlobals();
+    // @ts-expect-error intentional
+    delete globalThis.caches;
+    await expect(isUrlInCacheStorage("http://localhost/content/x.md")).resolves.toBe(
+      false,
+    );
+  });
+
+  it("marks lessons offline-ready from IndexedDB or SW cache", async () => {
+    matchMock.mockImplementation(async (url: string) =>
+      String(url).includes("sw-cached.md") ? { ok: true } : undefined,
+    );
+
+    const ready = await getOfflineReadySlugs([
+      { slug: "cached-in-idb", filePath: "module-1/a.md" },
+      { slug: "sw-only", filePath: "module-1/sw-cached.md" },
+      { slug: "nowhere", filePath: "module-1/missing.md" },
+    ]);
+
+    expect(ready.has("cached-in-idb")).toBe(true);
+    expect(ready.has("sw-only")).toBe(true);
+    expect(ready.has("nowhere")).toBe(false);
+  });
+});


### PR DESCRIPTION
# #1881 issue resolved

## Description

This PR adds an Offline Lesson Reading Indicator so learners can see which lessons are available without a network connection.

## Features

- “Available offline” badge on lesson list items (curriculum sidebar + dashboard queue)
- Detects cached `/content/` assets via Service Worker Cache API and IndexedDB
- Uses existing NetworkStatus context for online/offline awareness
- Clear offline empty-state UX when a lesson has not been cached yet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added offline availability indicators to dashboard queues and lesson lists.
  * Lessons can now be viewed offline when cached, with clear offline status messaging.
  * Dashboard learning queues now reflect current curriculum content and exclude completed lessons.
  * Added improved offline detection across cached lesson content and saved lessons.
  * Enhanced quiz security with protected submissions, timeout handling, and replay-attack alerts.
* **Tests**
  * Added coverage for offline content detection and cache handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->