### PR TITLE
Good First Issue Finder

### DIFF
--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -158,6 +158,12 @@ const BountiesPage = lazy(() =>
   })),
 );
 
+const GoodFirstIssueFinderPage = lazy(() =>
+  import("../pages/GoodFirstIssueFinderPage").then((module) => ({
+    default: module.GoodFirstIssueFinderPage,
+  })),
+);
+
 /*
  * These pages use default exports, so they can be passed directly
  * to React.lazy().
@@ -339,6 +345,15 @@ export function AppRouter() {
             element={
               <ProtectedRoute>
                 <BountiesPage />
+              </ProtectedRoute>
+            }
+          />
+
+          <Route
+            path="/good-first-issues"
+            element={
+              <ProtectedRoute>
+                <GoodFirstIssueFinderPage />
               </ProtectedRoute>
             }
           />

--- a/frontend/src/components/layout/Navigation.tsx
+++ b/frontend/src/components/layout/Navigation.tsx
@@ -18,6 +18,7 @@ import {
   FileText,
   Target,
   FileDiff,
+  SearchCode,
 } from "lucide-react";
 import { Link, NavLink, useNavigate } from "react-router-dom";
 import { useTheme } from "../../hooks/useTheme";
@@ -44,6 +45,11 @@ const navGroups = [
       { to: "/a11y-sandbox", label: "A11y Sandbox", icon: Eye },
       { to: "/pr-diff-summarizer", label: "PR Summarizer", icon: FileDiff },
       { to: "/bounties", label: "Bounties", icon: Target },
+      {
+        to: "/good-first-issues",
+        label: "Good First Issues",
+        icon: SearchCode,
+      },
     ],
   },
   {

--- a/frontend/src/components/ui/AvailableOfflineBadge.tsx
+++ b/frontend/src/components/ui/AvailableOfflineBadge.tsx
@@ -1,0 +1,28 @@
+/**
+ * AvailableOfflineBadge.tsx
+ * Compact badge for lesson list rows when content is cached for offline reading.
+ */
+import { HardDrive } from "lucide-react";
+
+interface AvailableOfflineBadgeProps {
+  /** Compact icon-only mode for dense sidebars */
+  compact?: boolean;
+  className?: string;
+}
+
+export function AvailableOfflineBadge({
+  compact = false,
+  className = "",
+}: AvailableOfflineBadgeProps) {
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full border border-teal-600/40 bg-teal-50 px-1.5 py-0.5 text-[9px] font-black uppercase tracking-wide text-teal-800 dark:bg-teal-900/30 dark:text-teal-200 dark:border-teal-600/50 ${className}`}
+      title="This lesson is cached and can be read offline"
+      aria-label="Available offline"
+    >
+      <HardDrive className="h-2.5 w-2.5 shrink-0" aria-hidden />
+      {!compact && <span>Available offline</span>}
+      {compact && <span className="sr-only">Available offline</span>}
+    </span>
+  );
+}

--- a/frontend/src/hooks/useGoodFirstIssues.ts
+++ b/frontend/src/hooks/useGoodFirstIssues.ts
@@ -1,0 +1,76 @@
+/**
+ * useGoodFirstIssues.ts
+ * Debounced GitHub issue search with client cache + AbortController.
+ */
+import { useEffect, useState } from "react";
+import {
+  GoodFirstIssueFilters,
+  RankedIssue,
+  normalizeFilters,
+  rankAndFilterIssues,
+  searchGitHubIssues,
+} from "../lib/goodFirstIssueFinder";
+
+const DEBOUNCE_MS = 450;
+
+export interface UseGoodFirstIssuesResult {
+  issues: RankedIssue[];
+  isLoading: boolean;
+  error: string | null;
+  fromCache: boolean;
+  totalCount: number;
+}
+
+export function useGoodFirstIssues(
+  filters: GoodFirstIssueFilters,
+): UseGoodFirstIssuesResult {
+  const [issues, setIssues] = useState<RankedIssue[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [fromCache, setFromCache] = useState(false);
+  const [totalCount, setTotalCount] = useState(0);
+  const [debounced, setDebounced] = useState(() => normalizeFilters(filters));
+
+  useEffect(() => {
+    const id = window.setTimeout(() => {
+      setDebounced(normalizeFilters(filters));
+    }, DEBOUNCE_MS);
+    return () => window.clearTimeout(id);
+  }, [filters]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    let cancelled = false;
+
+    async function run() {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const result = await searchGitHubIssues(debounced, controller.signal);
+        if (cancelled) return;
+        const ranked = rankAndFilterIssues(result.items, debounced);
+        setIssues(ranked);
+        setFromCache(result.fromCache);
+        setTotalCount(result.totalCount);
+      } catch (err) {
+        if (cancelled || (err instanceof DOMException && err.name === "AbortError")) {
+          return;
+        }
+        if (!cancelled) {
+          setIssues([]);
+          setError(err instanceof Error ? err.message : "Failed to search GitHub");
+        }
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    }
+
+    void run();
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [debounced]);
+
+  return { issues, isLoading, error, fromCache, totalCount };
+}

--- a/frontend/src/hooks/useOfflineReadyLessons.ts
+++ b/frontend/src/hooks/useOfflineReadyLessons.ts
@@ -1,0 +1,94 @@
+/**
+ * useOfflineReadyLessons.ts
+ * Tracks which curriculum lessons are available offline (SW cache + IndexedDB).
+ * Re-checks when network status changes or when the lesson list changes.
+ */
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useNetworkStatus } from "../context/useNetworkStatus";
+import {
+  getOfflineReadySlugs,
+  type OfflineLessonRef,
+} from "../lib/contentCacheCheck";
+
+export interface UseOfflineReadyLessonsResult {
+  /** Slugs that can be read without a network connection */
+  offlineReadySlugs: Set<string>;
+  isChecking: boolean;
+  isOnline: boolean;
+  isOfflineReady: (slug: string) => boolean;
+  refresh: () => void;
+}
+
+export function useOfflineReadyLessons(
+  lessons: OfflineLessonRef[],
+): UseOfflineReadyLessonsResult {
+  const { isOnline } = useNetworkStatus();
+  const [offlineReadySlugs, setOfflineReadySlugs] = useState<Set<string>>(
+    () => new Set(),
+  );
+  const [isChecking, setIsChecking] = useState(false);
+  const [refreshCount, setRefreshCount] = useState(0);
+
+  const lessonKey = useMemo(
+    () =>
+      lessons
+        .map((l) => `${l.slug}:${l.filePath ?? ""}`)
+        .sort()
+        .join("|"),
+    [lessons],
+  );
+
+  const refresh = useCallback(() => {
+    setRefreshCount((c) => c + 1);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function run() {
+      if (lessons.length === 0) {
+        if (!cancelled) setOfflineReadySlugs(new Set());
+        return;
+      }
+
+      if (!cancelled) setIsChecking(true);
+      try {
+        const ready = await getOfflineReadySlugs(lessons);
+        if (!cancelled) setOfflineReadySlugs(ready);
+      } catch {
+        if (!cancelled) setOfflineReadySlugs(new Set());
+      } finally {
+        if (!cancelled) setIsChecking(false);
+      }
+    }
+
+    void run();
+    return () => {
+      cancelled = true;
+    };
+    // lessonKey captures lesson identity; refreshCount forces re-scan
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [lessonKey, isOnline, refreshCount]);
+
+  // Re-scan when a lesson was just opened (IDB may have updated)
+  useEffect(() => {
+    const onVisibility = () => {
+      if (document.visibilityState === "visible") refresh();
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+    return () => document.removeEventListener("visibilitychange", onVisibility);
+  }, [refresh]);
+
+  const isOfflineReady = useCallback(
+    (slug: string) => offlineReadySlugs.has(slug),
+    [offlineReadySlugs],
+  );
+
+  return {
+    offlineReadySlugs,
+    isChecking,
+    isOnline,
+    isOfflineReady,
+    refresh,
+  };
+}

--- a/frontend/src/lib/contentCacheCheck.ts
+++ b/frontend/src/lib/contentCacheCheck.ts
@@ -1,0 +1,105 @@
+/**
+ * contentCacheCheck.ts
+ * Detect whether lesson Markdown under /content/ is available offline
+ * via the Cache API (service worker) and/or IndexedDB lesson cache.
+ */
+import { getAllCachedSlugs, getCachedLesson } from "./lessonCache";
+
+/** Workbox runtime cache name from src/sw.js */
+export const CONTENT_RUNTIME_CACHE = "content-runtime-cache";
+
+export interface OfflineLessonRef {
+  slug: string;
+  filePath?: string;
+}
+
+/** Build the absolute URL the SW would cache for a content file. */
+export function contentUrlForFilePath(filePath: string): string {
+  const normalized = filePath.replace(/^\/+/, "");
+  if (typeof window !== "undefined" && window.location?.origin) {
+    return new URL(`/content/${normalized}`, window.location.origin).href;
+  }
+  return `/content/${normalized}`;
+}
+
+/**
+ * Check whether a URL is present in any Cache Storage cache
+ * (runtime content cache first, then all caches as fallback).
+ */
+export async function isUrlInCacheStorage(url: string): Promise<boolean> {
+  if (typeof caches === "undefined") return false;
+
+  try {
+    const runtime = await caches.open(CONTENT_RUNTIME_CACHE);
+    if (await runtime.match(url, { ignoreSearch: true })) return true;
+
+    const names = await caches.keys();
+    for (const name of names) {
+      if (name === CONTENT_RUNTIME_CACHE) continue;
+      const cache = await caches.open(name);
+      if (await cache.match(url, { ignoreSearch: true })) return true;
+    }
+  } catch {
+    return false;
+  }
+
+  return false;
+}
+
+/** True if this lesson's /content/{filePath} asset is in the SW cache. */
+export async function isContentFileCached(
+  filePath: string | undefined,
+): Promise<boolean> {
+  if (!filePath) return false;
+  return isUrlInCacheStorage(contentUrlForFilePath(filePath));
+}
+
+/** True if IndexedDB has markdown for this slug. */
+export async function isLessonInIndexedDb(slug: string): Promise<boolean> {
+  const entry = await getCachedLesson(slug);
+  return !!entry?.markdown;
+}
+
+/**
+ * A lesson is offline-ready when either:
+ *  - IndexedDB has the lesson markdown (from prior online open), or
+ *  - the SW Cache API has /content/{filePath}
+ */
+export async function isLessonOfflineReady(
+  lesson: OfflineLessonRef,
+): Promise<boolean> {
+  if (await isLessonInIndexedDb(lesson.slug)) return true;
+  return isContentFileCached(lesson.filePath);
+}
+
+/**
+ * Batch-check which lessons are available offline.
+ * Returns a Set of offline-ready slugs.
+ */
+export async function getOfflineReadySlugs(
+  lessons: OfflineLessonRef[],
+): Promise<Set<string>> {
+  const ready = new Set<string>();
+  if (lessons.length === 0) return ready;
+
+  let idbSlugs: Set<string>;
+  try {
+    idbSlugs = new Set(await getAllCachedSlugs());
+  } catch {
+    idbSlugs = new Set();
+  }
+
+  await Promise.all(
+    lessons.map(async (lesson) => {
+      if (idbSlugs.has(lesson.slug)) {
+        ready.add(lesson.slug);
+        return;
+      }
+      if (await isContentFileCached(lesson.filePath)) {
+        ready.add(lesson.slug);
+      }
+    }),
+  );
+
+  return ready;
+}

--- a/frontend/src/lib/goodFirstIssueFinder.ts
+++ b/frontend/src/lib/goodFirstIssueFinder.ts
@@ -1,0 +1,306 @@
+/**
+ * goodFirstIssueFinder.ts
+ * Pure helpers for the Good First Issue Finder (GitHub issue discovery).
+ * Keeps query building, scoring, cache, and localStorage out of the UI.
+ */
+
+export const FILTERS_STORAGE_KEY = "atelier_gfi_filters_v1";
+export const SEARCH_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+export const DEFAULT_LABELS = ["good first issue", "help wanted"] as const;
+
+export const LANGUAGE_OPTIONS = [
+  "",
+  "JavaScript",
+  "TypeScript",
+  "Python",
+  "Go",
+  "Rust",
+  "Java",
+  "HTML",
+  "CSS",
+  "Shell",
+  "C++",
+  "Ruby",
+] as const;
+
+export interface GoodFirstIssueFilters {
+  language: string;
+  labels: string[];
+  minStars: number;
+  minBeginnerScore: number;
+}
+
+export const DEFAULT_FILTERS: GoodFirstIssueFilters = {
+  language: "TypeScript",
+  labels: ["good first issue"],
+  minStars: 50,
+  minBeginnerScore: 40,
+};
+
+export interface GitHubIssueLabel {
+  name: string;
+}
+
+export interface GitHubSearchIssue {
+  id: number;
+  html_url: string;
+  title: string;
+  body: string | null;
+  comments: number;
+  state: string;
+  labels: GitHubIssueLabel[];
+  repository_url: string;
+  created_at: string;
+  user?: { login: string };
+}
+
+export interface RankedIssue extends GitHubSearchIssue {
+  beginnerScore: number;
+  repoFullName: string;
+}
+
+/** Normalize and clamp filters for safe use. */
+export function normalizeFilters(
+  input: Partial<GoodFirstIssueFilters> | null | undefined,
+): GoodFirstIssueFilters {
+  if (input == null) {
+    return { ...DEFAULT_FILTERS, labels: [...DEFAULT_FILTERS.labels] };
+  }
+
+  const language =
+    typeof input.language === "string"
+      ? input.language.trim()
+      : DEFAULT_FILTERS.language;
+  const labels = Array.isArray(input.labels)
+    ? input.labels
+        .filter((l): l is string => typeof l === "string" && l.trim().length > 0)
+        .map((l) => l.trim())
+    : [...DEFAULT_FILTERS.labels];
+
+  const minStars = clampInt(
+    input.minStars,
+    0,
+    100_000,
+    DEFAULT_FILTERS.minStars,
+  );
+  const minBeginnerScore = clampInt(
+    input.minBeginnerScore,
+    0,
+    100,
+    DEFAULT_FILTERS.minBeginnerScore,
+  );
+
+  return {
+    language,
+    labels: labels.length > 0 ? labels : [...DEFAULT_FILTERS.labels],
+    minStars,
+    minBeginnerScore,
+  };
+}
+
+function clampInt(
+  value: unknown,
+  min: number,
+  max: number,
+  fallback: number,
+): number {
+  const n = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.min(max, Math.max(min, Math.round(n)));
+}
+
+/**
+ * Build a GitHub Search API `q` string for open issues.
+ * Multiple labels are OR'd so beginners get broader discovery results.
+ */
+export function buildGitHubIssueQuery(filters: GoodFirstIssueFilters): string {
+  const f = normalizeFilters(filters);
+  const parts: string[] = ["is:issue", "is:open", "no:assignee"];
+
+  if (f.labels.length === 1) {
+    parts.push(`label:"${f.labels[0]}"`);
+  } else if (f.labels.length > 1) {
+    const labelClause = f.labels
+      .map((label) => `label:"${label}"`)
+      .join(" OR ");
+    parts.push(`(${labelClause})`);
+  }
+
+  if (f.language) {
+    parts.push(`language:${f.language}`);
+  }
+
+  if (f.minStars > 0) {
+    parts.push(`stars:>=${f.minStars}`);
+  }
+
+  return parts.join(" ");
+}
+
+/** Extract owner/repo from repository_url. */
+export function repoFullNameFromUrl(repositoryUrl: string): string {
+  const match = repositoryUrl.match(/repos\/([^/]+\/[^/]+)\/?$/i);
+  return match ? match[1] : repositoryUrl;
+}
+
+/**
+ * Heuristic beginner-friendly score (0–100).
+ * Favors good-first-issue / help-wanted / docs labels and quieter threads.
+ */
+export function computeBeginnerScore(issue: GitHubSearchIssue): number {
+  const labelNames = issue.labels.map((l) => l.name.toLowerCase());
+  let score = 20;
+
+  if (labelNames.some((n) => n.includes("good first issue") || n === "good-first-issue")) {
+    score += 40;
+  }
+  if (labelNames.some((n) => n.includes("help wanted") || n === "help-wanted")) {
+    score += 20;
+  }
+  if (
+    labelNames.some(
+      (n) =>
+        n.includes("documentation") ||
+        n === "docs" ||
+        n.includes("beginner") ||
+        n.includes("easy") ||
+        n.includes("starter"),
+    )
+  ) {
+    score += 15;
+  }
+
+  if (issue.comments <= 2) score += 10;
+  else if (issue.comments <= 5) score += 5;
+  else if (issue.comments > 20) score -= 10;
+
+  return Math.min(100, Math.max(0, score));
+}
+
+/** Rank + filter issues by beginner-friendly score threshold. */
+export function rankAndFilterIssues(
+  issues: GitHubSearchIssue[],
+  filters: GoodFirstIssueFilters,
+): RankedIssue[] {
+  const f = normalizeFilters(filters);
+
+  return issues
+    .map((issue) => ({
+      ...issue,
+      beginnerScore: computeBeginnerScore(issue),
+      repoFullName: repoFullNameFromUrl(issue.repository_url),
+    }))
+    .filter((issue) => issue.beginnerScore >= f.minBeginnerScore)
+    .sort(
+      (a, b) =>
+        b.beginnerScore - a.beginnerScore || a.comments - b.comments,
+    );
+}
+
+export function loadFiltersFromStorage(): GoodFirstIssueFilters {
+  try {
+    const raw = localStorage.getItem(FILTERS_STORAGE_KEY);
+    if (!raw) return { ...DEFAULT_FILTERS };
+    return normalizeFilters(JSON.parse(raw) as Partial<GoodFirstIssueFilters>);
+  } catch {
+    return { ...DEFAULT_FILTERS };
+  }
+}
+
+export function saveFiltersToStorage(filters: GoodFirstIssueFilters): void {
+  try {
+    localStorage.setItem(
+      FILTERS_STORAGE_KEY,
+      JSON.stringify(normalizeFilters(filters)),
+    );
+  } catch {
+    /* ignore quota / private mode */
+  }
+}
+
+/** Simple in-memory search cache keyed by query string. */
+const searchCache = new Map<
+  string,
+  { fetchedAt: number; items: GitHubSearchIssue[] }
+>();
+
+export function getCachedSearch(query: string): GitHubSearchIssue[] | null {
+  const hit = searchCache.get(query);
+  if (!hit) return null;
+  if (Date.now() - hit.fetchedAt > SEARCH_CACHE_TTL_MS) {
+    searchCache.delete(query);
+    return null;
+  }
+  return hit.items;
+}
+
+export function setCachedSearch(
+  query: string,
+  items: GitHubSearchIssue[],
+): void {
+  searchCache.set(query, { fetchedAt: Date.now(), items });
+}
+
+/** Test helper — clears the module cache. */
+export function clearSearchCache(): void {
+  searchCache.clear();
+}
+
+export interface SearchIssuesResult {
+  items: GitHubSearchIssue[];
+  totalCount: number;
+  fromCache: boolean;
+}
+
+/**
+ * Fetch open issues from GitHub Search API.
+ * Uses Accept header; no token required (subject to unauthenticated rate limits).
+ */
+export async function searchGitHubIssues(
+  filters: GoodFirstIssueFilters,
+  signal?: AbortSignal,
+): Promise<SearchIssuesResult> {
+  const q = buildGitHubIssueQuery(filters);
+  const cached = getCachedSearch(q);
+  if (cached) {
+    return { items: cached, totalCount: cached.length, fromCache: true };
+  }
+
+  const url = new URL("https://api.github.com/search/issues");
+  url.searchParams.set("q", q);
+  url.searchParams.set("sort", "created");
+  url.searchParams.set("order", "desc");
+  url.searchParams.set("per_page", "30");
+
+  const res = await fetch(url.toString(), {
+    signal,
+    headers: {
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
+
+  if (res.status === 403 || res.status === 429) {
+    throw new Error(
+      "GitHub rate limit reached. Wait a minute and try again, or browse results from cache if available.",
+    );
+  }
+
+  if (!res.ok) {
+    throw new Error(`GitHub search failed (${res.status}). Try adjusting filters.`);
+  }
+
+  const data = (await res.json()) as {
+    total_count?: number;
+    items?: GitHubSearchIssue[];
+  };
+  const items = Array.isArray(data.items) ? data.items : [];
+  setCachedSearch(q, items);
+
+  return {
+    items,
+    totalCount: typeof data.total_count === "number" ? data.total_count : items.length,
+    fromCache: false,
+  };
+}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -2,14 +2,23 @@ import { AdminDashboard } from "../components/dashboard/AdminDashboard";
 import { useAuth } from "../features/auth/AuthContext";
 import { useQuery } from "@tanstack/react-query";
 import { fetchApi } from "../lib/api";
-import { mockStudentStats, mockLessonQueue, getTipOfTheDay } from "../lib/dashboardMockData";
+import { mockStudentStats, getTipOfTheDay } from "../lib/dashboardMockData";
 import { Link } from "react-router-dom";
 import SkeletonAdminDashboard from "../components/ui/skeletons/SkeletonAdminDashboard";
-import { useState, useEffect, useMemo } from "react";
+import { useState, useMemo } from "react";
 import { useUserProgress } from "../hooks/useUserProgress";
 import { useBookmarks } from "../hooks/useBookmarks";
+import { useOfflineReadyLessons } from "../hooks/useOfflineReadyLessons";
 import { BADGES } from "../constants/badges";
 import { Flame, ArrowRight, Bookmark, Lock, BookOpen, Award, Sparkles } from "lucide-react";
+import { AvailableOfflineBadge } from "../components/ui/AvailableOfflineBadge";
+
+type CurriculumLesson = {
+  slug: string;
+  title: string;
+  description: string;
+  filePath?: string;
+};
 
 export function DashboardPage() {
   const { user } = useAuth();
@@ -21,12 +30,35 @@ export function DashboardPage() {
     queryFn: () =>
       fetch("/content/curriculum.json")
         .then((r) => r.json())
-        .then((json: { modules: { lessons: { slug: string; title: string; description: string }[] }[] }) =>
-          json.modules.flatMap((m) => m.lessons.map((l) => ({ ...l, filePath: "" }))),
+        .then(
+          (json: {
+            modules: { lessons: CurriculumLesson[] }[];
+          }) => json.modules.flatMap((m) => m.lessons),
         )
-        .catch(() => []),
+        .catch(() => [] as CurriculumLesson[]),
   });
   const lessons = lessonsData;
+
+  const lessonRefs = useMemo(
+    () =>
+      lessons.map((l) => ({
+        slug: l.slug,
+        filePath: l.filePath,
+      })),
+    [lessons],
+  );
+  const { isOfflineReady } = useOfflineReadyLessons(lessonRefs);
+
+  const lessonQueue = useMemo(() => {
+    const incomplete = lessons.filter((l) => !isLessonCompleted(l.slug));
+    return incomplete.slice(0, 3).map((l, index) => ({
+      number: index + 1,
+      title: l.title,
+      description: l.description,
+      slug: l.slug,
+      filePath: l.filePath,
+    }));
+  }, [lessons, isLessonCompleted]);
 
   const { isLoading: contributorLoading } = useQuery({
     queryKey: ["contributorStats"],
@@ -42,7 +74,6 @@ export function DashboardPage() {
   const [showProgressReport, setShowProgressReport] = useState(false);
 
   const stats = mockStudentStats;
-  const lessonQueue = mockLessonQueue;
 
   const completedLessonsCount = lessons.filter((l) => isLessonCompleted(l.slug)).length;
   const totalLessonsCount = lessons.length;
@@ -198,18 +229,30 @@ export function DashboardPage() {
               to={`/lessons/${lesson.slug}`}
               className="flex items-center justify-between p-5 rounded-lg border-4 border-black bg-gray-50 dark:bg-[#151411] dark:border-[#2e2924] shadow-card-sm hover:shadow-card hover:-translate-y-0.5 transition-all"
             >
-              <div className="flex items-center gap-4">
+              <div className="flex items-center gap-4 min-w-0">
                 <span className="w-8 h-8 rounded-full bg-black text-white font-black text-sm flex items-center justify-center flex-shrink-0 dark:bg-[#2e2924]">
                   {lesson.number}
                 </span>
-                <div>
-                  <h3 className="font-black text-lg dark:text-[#f0ebe2]">{lesson.title}</h3>
-                  <p className="text-sm font-bold text-gray-500 dark:text-[#c4bbae]">{lesson.description}</p>
+                <div className="min-w-0">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <h3 className="font-black text-lg dark:text-[#f0ebe2]">
+                      {lesson.title}
+                    </h3>
+                    {isOfflineReady(lesson.slug) && <AvailableOfflineBadge />}
+                  </div>
+                  <p className="text-sm font-bold text-gray-500 dark:text-[#c4bbae]">
+                    {lesson.description}
+                  </p>
                 </div>
               </div>
               <ArrowRight className="w-5 h-5 text-gray-400 flex-shrink-0" />
             </Link>
           ))}
+          {lessonQueue.length === 0 && (
+            <p className="text-sm font-bold text-gray-500 dark:text-[#c4bbae] text-center py-4">
+              All queued lessons complete — browse the full curriculum below.
+            </p>
+          )}
           <Link
             to="/content"
             className="block text-center rounded-lg border-4 border-black bg-gray-100 dark:bg-[#151411] dark:border-[#2e2924] py-3 font-black text-sm hover:-translate-y-0.5 transition-all dark:text-[#f0ebe2]"

--- a/frontend/src/pages/GoodFirstIssueFinderPage.tsx
+++ b/frontend/src/pages/GoodFirstIssueFinderPage.tsx
@@ -1,0 +1,295 @@
+import { useEffect, useState } from "react";
+import {
+  DEFAULT_FILTERS,
+  DEFAULT_LABELS,
+  LANGUAGE_OPTIONS,
+  GoodFirstIssueFilters,
+  loadFiltersFromStorage,
+  saveFiltersToStorage,
+} from "../lib/goodFirstIssueFinder";
+import { useGoodFirstIssues } from "../hooks/useGoodFirstIssues";
+import { ExternalLink, Filter, Search, Sparkles, Star, AlertCircle } from "lucide-react";
+import { Link } from "react-router-dom";
+
+function ScorePill({ score }: { score: number }) {
+  const tone =
+    score >= 70
+      ? "bg-green-100 text-green-800 border-green-600 dark:bg-green-900/30 dark:text-green-200"
+      : score >= 45
+        ? "bg-amber-100 text-amber-900 border-amber-600 dark:bg-amber-900/30 dark:text-amber-200"
+        : "bg-gray-100 text-gray-700 border-gray-500 dark:bg-gray-800 dark:text-gray-300";
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full border-2 px-2 py-0.5 text-[10px] font-black uppercase ${tone}`}
+      title="Beginner-friendly score (higher is easier to start)"
+    >
+      <Sparkles className="h-3 w-3" aria-hidden />
+      {score}
+    </span>
+  );
+}
+
+function IssueSkeleton() {
+  return (
+    <div
+      className="animate-pulse rounded-2xl border-4 border-black bg-white p-5 dark:bg-[#1f1c18] dark:border-[#2e2924]"
+      aria-hidden
+    >
+      <div className="mb-3 h-4 w-1/3 rounded bg-gray-200 dark:bg-gray-700" />
+      <div className="mb-2 h-6 w-3/4 rounded bg-gray-200 dark:bg-gray-700" />
+      <div className="h-3 w-full rounded bg-gray-200 dark:bg-gray-700" />
+      <div className="mt-2 h-3 w-2/3 rounded bg-gray-200 dark:bg-gray-700" />
+    </div>
+  );
+}
+
+export function GoodFirstIssueFinderPage() {
+  const [filters, setFilters] = useState<GoodFirstIssueFilters>(DEFAULT_FILTERS);
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    setFilters(loadFiltersFromStorage());
+    setHydrated(true);
+  }, []);
+
+  useEffect(() => {
+    if (!hydrated) return;
+    saveFiltersToStorage(filters);
+  }, [filters, hydrated]);
+
+  const { issues, isLoading, error, fromCache, totalCount } =
+    useGoodFirstIssues(filters);
+
+  const toggleLabel = (label: string) => {
+    setFilters((prev) => {
+      const has = prev.labels.includes(label);
+      const labels = has
+        ? prev.labels.filter((l) => l !== label)
+        : [...prev.labels, label];
+      return {
+        ...prev,
+        labels: labels.length > 0 ? labels : ["good first issue"],
+      };
+    });
+  };
+
+  return (
+    <div className="container mx-auto max-w-5xl px-4 py-8">
+      <div className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="mb-2 inline-flex items-center gap-2 rounded-full border-2 border-black bg-teal-100 px-3 py-1 text-[10px] font-black uppercase tracking-wider dark:bg-teal-900/40 dark:border-[#2e2924]">
+            <Search className="h-3.5 w-3.5" aria-hidden />
+            External GitHub discovery
+          </p>
+          <h1 className="text-3xl font-black tracking-tight text-text dark:text-[#fff8ef]">
+            Good First Issue Finder
+          </h1>
+          <p className="mt-2 max-w-2xl text-sm font-bold text-muted dark:text-[#d7cec0]">
+            Find beginner-friendly issues on GitHub for Git/GitHub learning tracks.
+            This is separate from internal{" "}
+            <Link
+              to="/bounties"
+              className="underline decoration-2 underline-offset-2 hover:text-primary"
+            >
+              Bounties
+            </Link>
+            .
+          </p>
+        </div>
+      </div>
+
+      {/* Filters */}
+      <section className="mb-8 rounded-[2rem] border-4 border-black bg-white p-5 shadow-card dark:bg-[#1f1c18] dark:border-[#2e2924]">
+        <div className="mb-4 flex items-center gap-2">
+          <Filter className="h-5 w-5" aria-hidden />
+          <h2 className="text-lg font-black">Filters</h2>
+          <span className="text-xs font-bold text-muted dark:text-[#c4bbae]">
+            Saved in this browser
+          </span>
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <label className="flex flex-col gap-1.5 text-xs font-black uppercase tracking-wide">
+            Language
+            <select
+              value={filters.language}
+              onChange={(e) =>
+                setFilters((f) => ({ ...f, language: e.target.value }))
+              }
+              className="rounded-xl border-2 border-black bg-surface-low px-3 py-2 text-sm font-bold normal-case dark:bg-[#151411] dark:border-[#2e2924]"
+            >
+              {LANGUAGE_OPTIONS.map((lang) => (
+                <option key={lang || "any"} value={lang}>
+                  {lang || "Any language"}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="flex flex-col gap-1.5 text-xs font-black uppercase tracking-wide">
+            Min repo stars
+            <input
+              type="number"
+              min={0}
+              max={100000}
+              value={filters.minStars}
+              onChange={(e) =>
+                setFilters((f) => ({
+                  ...f,
+                  minStars: Number(e.target.value) || 0,
+                }))
+              }
+              className="rounded-xl border-2 border-black bg-surface-low px-3 py-2 text-sm font-bold normal-case dark:bg-[#151411] dark:border-[#2e2924]"
+            />
+          </label>
+
+          <label className="flex flex-col gap-1.5 text-xs font-black uppercase tracking-wide">
+            Min beginner score
+            <input
+              type="range"
+              min={0}
+              max={100}
+              step={5}
+              value={filters.minBeginnerScore}
+              onChange={(e) =>
+                setFilters((f) => ({
+                  ...f,
+                  minBeginnerScore: Number(e.target.value),
+                }))
+              }
+              className="mt-2"
+            />
+            <span className="text-[11px] font-bold normal-case text-muted">
+              {filters.minBeginnerScore}+ recommended
+            </span>
+          </label>
+
+          <div className="flex flex-col gap-1.5 text-xs font-black uppercase tracking-wide">
+            Labels
+            <div className="flex flex-wrap gap-2 pt-1">
+              {DEFAULT_LABELS.map((label) => {
+                const active = filters.labels.includes(label);
+                return (
+                  <button
+                    key={label}
+                    type="button"
+                    onClick={() => toggleLabel(label)}
+                    aria-pressed={active}
+                    className={`rounded-full border-2 border-black px-3 py-1.5 text-[11px] font-black normal-case transition ${
+                      active
+                        ? "bg-primary text-black shadow-card-sm"
+                        : "bg-surface-low dark:bg-[#151411] dark:border-[#2e2924]"
+                    }`}
+                  >
+                    {label}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Status */}
+      <div className="mb-4 flex flex-wrap items-center gap-3 text-xs font-bold text-muted dark:text-[#c4bbae]">
+        {!isLoading && !error && (
+          <span>
+            Showing {issues.length} ranked issue
+            {issues.length === 1 ? "" : "s"}
+            {totalCount > issues.length ? ` (from ${totalCount} matches)` : ""}
+          </span>
+        )}
+        {fromCache && !isLoading && (
+          <span className="rounded-full border border-teal-600/40 bg-teal-50 px-2 py-0.5 text-teal-800 dark:bg-teal-900/30 dark:text-teal-200">
+            Served from cache
+          </span>
+        )}
+      </div>
+
+      {/* Results */}
+      {isLoading && (
+        <div className="grid gap-4 md:grid-cols-2" role="status" aria-busy="true">
+          <span className="sr-only">Searching GitHub issues…</span>
+          <IssueSkeleton />
+          <IssueSkeleton />
+          <IssueSkeleton />
+          <IssueSkeleton />
+        </div>
+      )}
+
+      {!isLoading && error && (
+        <div
+          role="alert"
+          className="flex flex-col items-center gap-3 rounded-[2rem] border-4 border-dashed border-red-400 bg-red-50 p-10 text-center dark:bg-red-950/20 dark:border-red-700"
+        >
+          <AlertCircle className="h-10 w-10 text-red-500" aria-hidden />
+          <h3 className="text-lg font-black text-red-800 dark:text-red-200">
+            Couldn’t load issues
+          </h3>
+          <p className="max-w-md text-sm font-bold text-red-700/90 dark:text-red-300">
+            {error}
+          </p>
+        </div>
+      )}
+
+      {!isLoading && !error && issues.length === 0 && (
+        <div className="rounded-[2rem] border-4 border-dashed border-black/30 bg-surface-low p-12 text-center dark:bg-[#151411] dark:border-[#2e2924]">
+          <h3 className="mb-2 text-xl font-black dark:text-[#f0ebe2]">
+            No matching issues
+          </h3>
+          <p className="mx-auto max-w-md text-sm font-bold text-muted dark:text-[#c4bbae]">
+            Try lowering the beginner score, reducing min stars, or switching
+            language. Internal practice stays on{" "}
+            <Link to="/bounties" className="underline underline-offset-2">
+              Bounties
+            </Link>
+            .
+          </p>
+        </div>
+      )}
+
+      {!isLoading && !error && issues.length > 0 && (
+        <div className="grid gap-4 md:grid-cols-2">
+          {issues.map((issue) => (
+            <a
+              key={issue.id}
+              href={issue.html_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group flex flex-col rounded-2xl border-4 border-black bg-white p-5 shadow-card-sm transition hover:-translate-y-0.5 hover:shadow-card dark:bg-[#1f1c18] dark:border-[#2e2924]"
+            >
+              <div className="mb-3 flex flex-wrap items-center gap-2">
+                <ScorePill score={issue.beginnerScore} />
+                <span className="inline-flex items-center gap-1 text-[10px] font-black uppercase text-muted dark:text-[#c4bbae]">
+                  <Star className="h-3 w-3" aria-hidden />
+                  {issue.repoFullName}
+                </span>
+              </div>
+              <h3 className="mb-2 text-lg font-black leading-snug text-text group-hover:text-primary dark:text-[#f0ebe2]">
+                {issue.title}
+              </h3>
+              <p className="mb-4 line-clamp-3 flex-1 text-sm font-bold text-muted dark:text-[#c4bbae]">
+                {issue.body?.trim() || "No description provided."}
+              </p>
+              <div className="flex flex-wrap gap-1.5 mb-4">
+                {issue.labels.slice(0, 4).map((label) => (
+                  <span
+                    key={label.name}
+                    className="rounded-md border border-black/20 bg-surface-low px-1.5 py-0.5 text-[10px] font-bold dark:bg-[#151411] dark:border-[#2e2924]"
+                  >
+                    {label.name}
+                  </span>
+                ))}
+              </div>
+              <span className="inline-flex items-center gap-1 text-xs font-black text-primary">
+                Open on GitHub
+                <ExternalLink className="h-3.5 w-3.5" aria-hidden />
+              </span>
+            </a>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/LessonPage.tsx
+++ b/frontend/src/pages/LessonPage.tsx
@@ -21,9 +21,15 @@ import { useTerminalAutocomplete } from "../hooks/useTerminalAutocomplete";
 import { ShellState } from "../hooks/useGitShell";
 import { useBookmarks } from "../hooks/useBookmarks";
 import { useNotifications } from "../features/notifications/NotificationContext";
+import { useOfflineLesson } from "../hooks/useOfflineLesson";
+import { useOfflineReadyLessons } from "../hooks/useOfflineReadyLessons";
+import { useNetworkStatus } from "../context/useNetworkStatus";
 import { fetchApi } from "../lib/api";
-import { Lesson, fetchLessonsApi, fetchLessonContent } from "../lib/lessons";
+import { Lesson, fetchLessonsApi } from "../lib/lessons";
 import { RecentlyViewedLessonsWidget } from "../components/ui/RecentlyViewedLessonsWidget";
+import { AvailableOfflineBadge } from "../components/ui/AvailableOfflineBadge";
+import { OfflineStatusBadge } from "../components/ui/OfflineStatusBadge";
+import { OfflineBanner } from "../components/ui/OfflineBanner";
 
 const SESSION_KEY_RECENT = "recentlyViewedLessonsV1";
 const MAX_RECENT_ITEMS = 3;
@@ -105,19 +111,51 @@ export function LessonPage() {
 
   const [lesson, setLesson] = useState<Lesson | undefined>(undefined);
   const [lessonsList, setLessonsList] = useState<Lesson[]>([]);
-  const [markdownContent, setMarkdownContent] = useState("");
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const { isOnline } = useNetworkStatus();
 
   // Curriculum modules list for sidebar
   const [modules, setModules] = useState<
     {
       id: string;
       title: string;
-      lessons: { slug: string; title: string; difficulty?: string }[];
+      lessons: {
+        slug: string;
+        title: string;
+        difficulty?: string;
+        filePath?: string;
+      }[];
     }[]
   >([]);
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+
+  const curriculumLessonRefs = useMemo(
+    () =>
+      modules.flatMap((mod) =>
+        mod.lessons.map((les) => ({
+          slug: les.slug,
+          filePath: les.filePath,
+        })),
+      ),
+    [modules],
+  );
+  const { isOfflineReady, refresh: refreshOfflineReady } =
+    useOfflineReadyLessons(curriculumLessonRefs);
+
+  const {
+    markdown: markdownContent,
+    source: contentSource,
+    isLoading: contentLoading,
+    refresh: refreshLessonContent,
+    isCached,
+  } = useOfflineLesson(lesson);
+
+  // After a lesson is cached (IDB), refresh list badges
+  useEffect(() => {
+    if (isCached) refreshOfflineReady();
+  }, [isCached, lesson?.slug, refreshOfflineReady]);
+
   const sidebarRef = useRef<HTMLElement>(null);
 
   const closeSidebar = useCallback(() => setIsSidebarOpen(false), []);
@@ -343,14 +381,9 @@ export function LessonPage() {
     setQuizNonce(null);
     setTimeLeft(null);
 
-    if (lesson.filePath) {
-      fetchLessonContent(lesson.filePath).then((content) => {
-        setMarkdownContent(content);
-      });
-    } else {
-      setMarkdownContent(`# ${lesson.title}\n\n${lesson.explanation}`);
-    }
-  }, [lesson]);
+    // Markdown is loaded via useOfflineLesson (network + IndexedDB / SW cache)
+    refreshOfflineReady();
+  }, [lesson, refreshOfflineReady]);
 
   // NEW: Fetch Cryptographic Nonce for the current quiz question
   useEffect(() => {
@@ -724,21 +757,23 @@ export function LessonPage() {
                     slug: string;
                     title: string;
                     difficulty?: string;
+                    filePath?: string;
                   }) => {
                     const active = les.slug === lesson.slug;
                     const completed = isLessonCompleted(les.slug);
+                    const offlineReady = isOfflineReady(les.slug);
                     return (
                       <Link
                         key={les.slug}
                         to={`/lessons/${les.slug}`}
                         onClick={closeSidebar}
-                        className={`w-full flex items-center justify-between p-2.5 rounded-lg border-2 transition-all text-xs font-bold ${
+                        className={`w-full flex items-center justify-between gap-1.5 p-2.5 rounded-lg border-2 transition-all text-xs font-bold ${
                           active
                             ? "bg-surface-low border-black shadow-card-sm text-text"
                             : "border-transparent hover:bg-surface-lowest hover:border-black/10 dark:text-[#c4bbae]"
                         }`}
                       >
-                        <div className="flex items-center gap-2 truncate">
+                        <div className="flex items-center gap-2 truncate min-w-0">
                           {completed ? (
                             <CheckCircle2
                               size={14}
@@ -749,11 +784,16 @@ export function LessonPage() {
                           )}
                           <span className="truncate">{les.title}</span>
                         </div>
-                        {les.difficulty === "advanced" && (
-                          <span className="text-[8px] bg-red-100 text-red-700 px-1 py-0.5 rounded border border-red-700">
-                            ADV
-                          </span>
-                        )}
+                        <div className="flex items-center gap-1 shrink-0">
+                          {offlineReady && (
+                            <AvailableOfflineBadge compact />
+                          )}
+                          {les.difficulty === "advanced" && (
+                            <span className="text-[8px] bg-red-100 text-red-700 px-1 py-0.5 rounded border border-red-700">
+                              ADV
+                            </span>
+                          )}
+                        </div>
                       </Link>
                     );
                   },
@@ -793,6 +833,15 @@ export function LessonPage() {
                   <span className="text-[10px] font-mono font-black bg-surface-low text-muted px-3 py-1 rounded-full border-2 border-black rotate-[-0.5deg] inline-block shadow-card-sm uppercase dark:bg-[#1f1c18] dark:border-[#2e2924] dark:text-[#c4bbae]">
                     📅 Updated: {new Date((lesson as any).updatedAt || (lesson as any).updated_at || new Date()).toLocaleDateString()}
                   </span>
+                  {isCached && <AvailableOfflineBadge />}
+                  <OfflineStatusBadge
+                    source={contentSource}
+                    onRefresh={() => {
+                      refreshLessonContent();
+                      refreshOfflineReady();
+                    }}
+                    isRefreshing={contentLoading}
+                  />
                 </div>
                 <h1 className="text-4xl sm:text-5xl font-black text-text dark:text-[#f0ebe2] drop-shadow-[2.5px_2.5px_0_#FF3B30] mt-3">
                   {lesson.title}
@@ -845,15 +894,24 @@ export function LessonPage() {
 
             <TextToSpeechControls content={markdownContent} />
 
-            <article className="prose max-w-none">
-              <React.Suspense
-                fallback={
-                  <div className="w-full h-64 animate-pulse rounded-2xl border-4 border-black/20 bg-surface-low dark:border-[#2e2924]/50 dark:bg-[#151411]" />
-                }
-              >
-                <MarkdownRenderer content={markdownContent} />
-              </React.Suspense>
-            </article>
+            {!isOnline && !isCached ? (
+              <OfflineBanner lessonTitle={lesson.title} isCached={false} />
+            ) : (
+              <>
+                {!isOnline && isCached && (
+                  <OfflineBanner lessonTitle={lesson.title} isCached />
+                )}
+                <article className="prose max-w-none">
+                  <React.Suspense
+                    fallback={
+                      <div className="w-full h-64 animate-pulse rounded-2xl border-4 border-black/20 bg-surface-low dark:border-[#2e2924]/50 dark:bg-[#151411]" />
+                    }
+                  >
+                    <MarkdownRenderer content={markdownContent} />
+                  </React.Suspense>
+                </article>
+              </>
+            )}
             <div className="mt-4 flex justify-end">
               <button
                 onClick={() => alert("Thanks for reporting the typo")}

--- a/frontend/src/test/contentCacheCheck.test.ts
+++ b/frontend/src/test/contentCacheCheck.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  contentUrlForFilePath,
+  CONTENT_RUNTIME_CACHE,
+  getOfflineReadySlugs,
+  isContentFileCached,
+  isUrlInCacheStorage,
+} from "../lib/contentCacheCheck";
+
+vi.mock("../lib/lessonCache", () => ({
+  getAllCachedSlugs: vi.fn(async () => ["cached-in-idb"]),
+  getCachedLesson: vi.fn(async (slug: string) =>
+    slug === "cached-in-idb"
+      ? { slug, markdown: "# hi", metaJson: "{}", fetchedAt: Date.now() }
+      : undefined,
+  ),
+}));
+
+describe("contentCacheCheck", () => {
+  const matchMock = vi.fn();
+  const openMock = vi.fn();
+  const keysMock = vi.fn();
+
+  beforeEach(() => {
+    matchMock.mockReset();
+    openMock.mockReset();
+    keysMock.mockReset();
+
+    openMock.mockImplementation(async () => ({
+      match: matchMock,
+    }));
+    keysMock.mockResolvedValue([CONTENT_RUNTIME_CACHE]);
+
+    vi.stubGlobal("caches", {
+      open: openMock,
+      keys: keysMock,
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("builds a /content/ URL for a file path", () => {
+    expect(contentUrlForFilePath("module-1/what-is-open-source.md")).toContain(
+      "/content/module-1/what-is-open-source.md",
+    );
+    expect(contentUrlForFilePath("/module-1/x.md")).toContain(
+      "/content/module-1/x.md",
+    );
+  });
+
+  it("detects SW-cached content files", async () => {
+    matchMock.mockResolvedValueOnce({ ok: true });
+    await expect(
+      isContentFileCached("module-1/what-is-open-source.md"),
+    ).resolves.toBe(true);
+    expect(openMock).toHaveBeenCalledWith(CONTENT_RUNTIME_CACHE);
+  });
+
+  it("returns false when Cache API has no match", async () => {
+    matchMock.mockResolvedValue(undefined);
+    await expect(isContentFileCached("module-1/missing.md")).resolves.toBe(
+      false,
+    );
+  });
+
+  it("returns false when caches API is unavailable", async () => {
+    vi.unstubAllGlobals();
+    // @ts-expect-error intentional
+    delete globalThis.caches;
+    await expect(isUrlInCacheStorage("http://localhost/content/x.md")).resolves.toBe(
+      false,
+    );
+  });
+
+  it("marks lessons offline-ready from IndexedDB or SW cache", async () => {
+    matchMock.mockImplementation(async (url: string) =>
+      String(url).includes("sw-cached.md") ? { ok: true } : undefined,
+    );
+
+    const ready = await getOfflineReadySlugs([
+      { slug: "cached-in-idb", filePath: "module-1/a.md" },
+      { slug: "sw-only", filePath: "module-1/sw-cached.md" },
+      { slug: "nowhere", filePath: "module-1/missing.md" },
+    ]);
+
+    expect(ready.has("cached-in-idb")).toBe(true);
+    expect(ready.has("sw-only")).toBe(true);
+    expect(ready.has("nowhere")).toBe(false);
+  });
+});

--- a/frontend/src/test/goodFirstIssueFinder.test.ts
+++ b/frontend/src/test/goodFirstIssueFinder.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  buildGitHubIssueQuery,
+  clearSearchCache,
+  computeBeginnerScore,
+  DEFAULT_FILTERS,
+  getCachedSearch,
+  normalizeFilters,
+  rankAndFilterIssues,
+  repoFullNameFromUrl,
+  setCachedSearch,
+  type GitHubSearchIssue,
+} from "../lib/goodFirstIssueFinder";
+
+function makeIssue(
+  overrides: Partial<GitHubSearchIssue> & { labels?: { name: string }[] },
+): GitHubSearchIssue {
+  return {
+    id: 1,
+    html_url: "https://github.com/org/repo/issues/1",
+    title: "Fix typo",
+    body: "Small docs fix",
+    comments: 1,
+    state: "open",
+    labels: overrides.labels ?? [{ name: "good first issue" }],
+    repository_url: "https://api.github.com/repos/org/repo",
+    created_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("goodFirstIssueFinder helpers", () => {
+  beforeEach(() => {
+    clearSearchCache();
+  });
+
+  it("normalizes filters with safe defaults and clamps", () => {
+    expect(normalizeFilters(null)).toEqual(DEFAULT_FILTERS);
+    expect(
+      normalizeFilters({
+        language: "  Python ",
+        labels: [],
+        minStars: -5,
+        minBeginnerScore: 999,
+      }),
+    ).toEqual({
+      language: "Python",
+      labels: [...DEFAULT_FILTERS.labels],
+      minStars: 0,
+      minBeginnerScore: 100,
+    });
+  });
+
+  it("builds a GitHub search query with language, stars, and label OR", () => {
+    const q = buildGitHubIssueQuery({
+      language: "TypeScript",
+      labels: ["good first issue", "help wanted"],
+      minStars: 100,
+      minBeginnerScore: 40,
+    });
+
+    expect(q).toContain("is:issue");
+    expect(q).toContain("is:open");
+    expect(q).toContain("no:assignee");
+    expect(q).toContain('label:"good first issue" OR label:"help wanted"');
+    expect(q).toContain("language:TypeScript");
+    expect(q).toContain("stars:>=100");
+  });
+
+  it("extracts owner/repo from repository_url", () => {
+    expect(
+      repoFullNameFromUrl("https://api.github.com/repos/facebook/react"),
+    ).toBe("facebook/react");
+  });
+
+  it("scores beginner-friendly labels higher", () => {
+    const gfi = computeBeginnerScore(
+      makeIssue({ labels: [{ name: "good first issue" }], comments: 1 }),
+    );
+    const plain = computeBeginnerScore(
+      makeIssue({ labels: [{ name: "bug" }], comments: 30 }),
+    );
+    expect(gfi).toBeGreaterThan(plain);
+    expect(gfi).toBeGreaterThanOrEqual(60);
+  });
+
+  it("ranks and filters by min beginner score", () => {
+    const ranked = rankAndFilterIssues(
+      [
+        makeIssue({
+          id: 1,
+          labels: [{ name: "bug" }],
+          comments: 40,
+        }),
+        makeIssue({
+          id: 2,
+          labels: [{ name: "good first issue" }, { name: "help wanted" }],
+          comments: 0,
+        }),
+      ],
+      { ...DEFAULT_FILTERS, minBeginnerScore: 50 },
+    );
+
+    expect(ranked.every((i) => i.beginnerScore >= 50)).toBe(true);
+    expect(ranked[0]?.id).toBe(2);
+    expect(ranked[0]?.repoFullName).toBe("org/repo");
+  });
+
+  it("caches search results by query key", () => {
+    expect(getCachedSearch("q1")).toBeNull();
+    setCachedSearch("q1", [makeIssue({ id: 9 })]);
+    expect(getCachedSearch("q1")?.[0]?.id).toBe(9);
+  });
+});


### PR DESCRIPTION
# #1882 issue resolved

## Description

This PR adds a Good First Issue Finder dashboard for external GitHub discovery (separate from internal Bounties).

## Features

- Filters for language, labels, min stars, and beginner-friendly score
- Saves filters to localStorage
- Debounced GitHub search with client-side cache
- Loading skeletons plus error/empty states
- Practice nav route at `/good-first-issues` with Vitest coverage for filter helpers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Good First Issue Finder with filters for language, repository stars, beginner score, and issue labels.
  * Added ranked GitHub issue results with loading, error, empty, and cached-result states.
  * Added navigation access through the Practice menu.
  * Improved offline lesson support with availability indicators across dashboards and lesson pages.
  * Lesson content now supports offline viewing with network-aware status messaging.

* **Tests**
  * Added coverage for issue discovery, filtering, caching, and offline content detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->