### PR TITLE
fix(localization): key resolve_locale cache on settings state, not just the header

### DIFF
--- a/backend/apps/localization/middleware.py
+++ b/backend/apps/localization/middleware.py
@@ -80,16 +80,15 @@ def resolve_tag_with_fallback(tag: str, supported: set[str]) -> str | None:
 
 
 @lru_cache(maxsize=1024)
-def resolve_locale(accept_language_header: str) -> str:
+def _resolve_locale_cached(
+    accept_language_header: str, default_lang_normalized: str, supported_tuple: tuple
+) -> str:
     """
-    Resolves the best supported locale for the Accept-Language header.
-    Falls back to settings.LANGUAGE_CODE if no match is found.
+    Internal cached resolver. Cache key includes the settings-derived state
+    (default language, supported locales) so a settings change produces a
+    different key instead of returning a stale result.
     """
-    default_lang = getattr(settings, "LANGUAGE_CODE", "en-us").lower()
-    supported = get_supported_locales()
-
-    # Normalize default_lang for set comparison
-    default_lang_normalized = default_lang.replace("_", "-")
+    supported = set(supported_tuple)
     supported.add(default_lang_normalized)
 
     try:
@@ -103,6 +102,22 @@ def resolve_locale(accept_language_header: str) -> str:
         pass
 
     return default_lang_normalized
+
+
+def resolve_locale(accept_language_header: str) -> str:
+    """
+    Resolves the best supported locale for the Accept-Language header.
+    Falls back to settings.LANGUAGE_CODE if no match is found.
+    Cache key includes current settings state so changes to LANGUAGE_CODE/LANGUAGES
+    are picked up instead of returning a stale cached result.
+    """
+    default_lang = getattr(settings, "LANGUAGE_CODE", "en-us").lower()
+    default_lang_normalized = default_lang.replace("_", "-")
+    supported_tuple = tuple(sorted(get_supported_locales()))
+
+    return _resolve_locale_cached(
+        accept_language_header, default_lang_normalized, supported_tuple
+    )
 
 
 def check_locale_switch_rate_limit(request, resolved_lang: str) -> bool:


### PR DESCRIPTION
## Description

`resolve_locale()` used `functools.lru_cache` keyed only on the
`Accept-Language` header string, but its result also depends on
`settings.LANGUAGE_CODE`/`LANGUAGES`. A settings change (per-tenant
config, `@override_settings` in tests) after a header was already cached
produced a stale, wrong locale. Cache key now includes the settings state.

Fixes #1854 

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update (no code changes)
- [ ] ⚙️ CI/CD or build pipeline change
- [ ] ⚡ Performance optimization
- [ ] 🛠️ Refactoring (no functional changes)

## How Has This Been Tested?

### Automated Tests
- [x] Backend tests pass: `cd backend && pytest`
- [ ] Frontend tests pass: `cd frontend && npm run test`
- [ ] Frontend builds successfully: `cd frontend && npm run build`

### Manual Verification
Ran the settings-drift repro from the linked issue — confirmed the second
call now returns the correct locale instead of the stale cached one;
confirmed unchanged behavior when settings don't change between calls.

## Pre-Push Checklist

> [!IMPORTANT]
> **All items below must be checked before requesting a review.** Our CI bot will automatically run the frontend build and backend tests on your PR. If CI fails, you will receive a comment explaining what went wrong.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or console errors
- [ ] I have run `npm run build` in `frontend/` and it completes with **0 errors**
- [x] I have run `pytest` in `backend/` and all tests pass
- [x] I have run `git diff` locally and verified my changes

Backend only.

## Deployment Notes

> [!NOTE]
> This project is deployed on **Vercel** (Frontend) and **Hugging Face** (Backend). The CI workflow simulates both deployment environments. If your PR passes CI, it is safe to merge.

<!-- Add any notes about deployment considerations, environment variables, or migration steps needed -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved locale resolution speed through caching while preserving accurate language matching.

* **Bug Fixes**
  * Locale selection now reflects changes to default and supported language settings without returning stale results.
  * Preserved fallback behavior for partially matching language preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->