### PR TITLE
fix(scripts): derive skeletons dir from repo structure instead of hardcoded personal path

### DIFF
--- a/backend/refactor_skeletons.py
+++ b/backend/refactor_skeletons.py
@@ -1,32 +1,69 @@
-import os
+# backend/refactor_skeletons.py
+import argparse
 import glob
+import os
 import re
+from pathlib import Path
 
-skeletons_dir = r"c:\Users\LENOVO\OneDrive\Desktop\SSOC\Open-Source-Contribution-Atelier\frontend\src\components\ui\skeletons"
-files = glob.glob(os.path.join(skeletons_dir, "*.tsx"))
 
-target_str = "bg-gradient-to-r from-surface-high via-surface-highest to-surface-high bg-[length:200%_100%] animate-shimmer"
+def get_default_skeletons_dir() -> Path:
+    """Resolve frontend/src/components/ui/skeletons relative to this script,
+    since backend/ and frontend/ are sibling directories at the repo root."""
+    repo_root = Path(__file__).resolve().parent.parent
+    return repo_root / "frontend" / "src" / "components" / "ui" / "skeletons"
 
-for file in files:
-    with open(file, "r", encoding="utf-8") as f:
-        content = f.read()
 
-    if target_str in content:
-        if "import { Skeleton }" not in content:
-            content = 'import { Skeleton } from "../Skeleton";\n' + content
+def main():
+    parser = argparse.ArgumentParser(
+        description="Convert shimmer <div> skeletons to <Skeleton> components."
+    )
+    parser.add_argument(
+        "--skeletons-dir",
+        type=str,
+        default=None,
+        help="Override path to the skeletons directory (defaults to "
+        "frontend/src/components/ui/skeletons relative to the repo root).",
+    )
+    args = parser.parse_args()
 
-        def repl(match):
-            full_match = match.group(0)
-            new_match = (
-                full_match.replace("<div", "<Skeleton")
-                .replace(target_str, "")
-                .replace("  ", " ")
+    skeletons_dir = Path(args.skeletons_dir) if args.skeletons_dir else get_default_skeletons_dir()
+
+    if not skeletons_dir.is_dir():
+        print(f"⚠️ Skeletons directory not found: {skeletons_dir}")
+        return
+
+    files = glob.glob(os.path.join(str(skeletons_dir), "*.tsx"))
+    if not files:
+        print(f"⚠️ No .tsx files found in {skeletons_dir}")
+        return
+
+    target_str = "bg-gradient-to-r from-surface-high via-surface-highest to-surface-high bg-[length:200%_100%] animate-shimmer"
+
+    for file in files:
+        with open(file, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        if target_str in content:
+            if 'import { Skeleton }' not in content:
+                content = 'import { Skeleton } from "../Skeleton";\n' + content
+
+            def repl(match):
+                full_match = match.group(0)
+                new_match = (
+                    full_match.replace("<div", "<Skeleton")
+                    .replace(target_str, "")
+                    .replace("  ", " ")
+                )
+                return new_match
+
+            content = re.sub(
+                r'<div\s+className="[^"]*animate-shimmer[^"]*"\s*/>', repl, content
             )
-            return new_match
 
-        content = re.sub(
-            r'<div\s+className="[^"]*animate-shimmer[^"]*"\s*/>', repl, content
-        )
+            with open(file, "w", encoding="utf-8") as f:
+                f.write(content)
+            print(f"✅ Updated: {file}")
 
-        with open(file, "w", encoding="utf-8") as f:
-            f.write(content)
+
+if __name__ == "__main__":
+    main()

--- a/backend/refactor_skeletons2.py
+++ b/backend/refactor_skeletons2.py
@@ -1,55 +1,92 @@
-import os
+# backend/refactor_skeletons2.py
+import argparse
 import glob
+import os
 import re
+from pathlib import Path
 
-skeletons_dir = r"c:\Users\LENOVO\OneDrive\Desktop\SSOC\Open-Source-Contribution-Atelier\frontend\src\components\ui\skeletons"
-files = glob.glob(os.path.join(skeletons_dir, "*.tsx"))
 
-target_str = "bg-gradient-to-r from-surface-high via-surface-highest to-surface-high bg-[length:200%_100%] animate-shimmer"
+def get_default_skeletons_dir() -> Path:
+    """Resolve frontend/src/components/ui/skeletons relative to this script,
+    since backend/ and frontend/ are sibling directories at the repo root."""
+    repo_root = Path(__file__).resolve().parent.parent
+    return repo_root / "frontend" / "src" / "components" / "ui" / "skeletons"
 
-for file in files:
-    with open(file, "r", encoding="utf-8") as f:
-        content = f.read()
 
-    if target_str in content:
-        if "import { Skeleton }" not in content:
-            content = 'import { Skeleton } from "../Skeleton";\n' + content
+def main():
+    parser = argparse.ArgumentParser(
+        description="Convert shimmer <div> skeletons (self-closing and open/close) to <Skeleton> components."
+    )
+    parser.add_argument(
+        "--skeletons-dir",
+        type=str,
+        default=None,
+        help="Override path to the skeletons directory (defaults to "
+        "frontend/src/components/ui/skeletons relative to the repo root).",
+    )
+    args = parser.parse_args()
 
-        # We handle self closing: <div className="..." /> -> <Skeleton className="..." />
-        # and standard closing: <div className="..."></div> -> <Skeleton className="..."></Skeleton>
+    skeletons_dir = Path(args.skeletons_dir) if args.skeletons_dir else get_default_skeletons_dir()
 
-        # 1. Self closing
-        def repl_self_closing(match):
-            full = match.group(0)
-            return (
-                full.replace("<div", "<Skeleton")
-                .replace(target_str, "")
-                .replace("  ", " ")
+    if not skeletons_dir.is_dir():
+        print(f"⚠️ Skeletons directory not found: {skeletons_dir}")
+        return
+
+    files = glob.glob(os.path.join(str(skeletons_dir), "*.tsx"))
+    if not files:
+        print(f"⚠️ No .tsx files found in {skeletons_dir}")
+        return
+
+    target_str = "bg-gradient-to-r from-surface-high via-surface-highest to-surface-high bg-[length:200%_100%] animate-shimmer"
+
+    for file in files:
+        with open(file, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        if target_str in content:
+            if 'import { Skeleton }' not in content:
+                content = 'import { Skeleton } from "../Skeleton";\n' + content
+
+            # We handle self closing: <div className="..." /> -> <Skeleton className="..." />
+            # and standard closing: <div className="...">...</div> -> <Skeleton className="...">...</Skeleton>
+
+            # 1. Self closing
+            def repl_self_closing(match):
+                full = match.group(0)
+                return (
+                    full.replace("<div", "<Skeleton")
+                    .replace(target_str, "")
+                    .replace("  ", " ")
+                )
+
+            content = re.sub(
+                r'<div\s+className="[^"]*animate-shimmer[^"]*"\s*/>',
+                repl_self_closing,
+                content,
             )
 
-        content = re.sub(
-            r'<div\s+className="[^"]*animate-shimmer[^"]*"\s*/>',
-            repl_self_closing,
-            content,
-        )
+            # 2. Open/Close tags
+            def repl_open_close(match):
+                # match.group(1) is the inner part of <div ...>
+                # match.group(0) is the entire `<div ...>...</div>`
+                full = match.group(0)
+                new_full = full.replace("<div", "<Skeleton").replace(
+                    "</div>", "</Skeleton>"
+                )
+                new_full = new_full.replace(target_str, "").replace("  ", " ")
+                return new_full
 
-        # 2. Open/Close tags
-        def repl_open_close(match):
-            # match.group(1) is the inner part of <div ...>
-            # match.group(0) is the entire `<div ...></div>`
-            full = match.group(0)
-            new_full = full.replace("<div", "<Skeleton").replace(
-                "</div>", "</Skeleton>"
+            content = re.sub(
+                r'<div\s+className="[^"]*animate-shimmer[^"]*"\s*>.*?</div>',
+                repl_open_close,
+                content,
+                flags=re.DOTALL,
             )
-            new_full = new_full.replace(target_str, "").replace("  ", " ")
-            return new_full
 
-        content = re.sub(
-            r'<div\s+className="[^"]*animate-shimmer[^"]*"\s*>.*?</div>',
-            repl_open_close,
-            content,
-            flags=re.DOTALL,
-        )
+            with open(file, "w", encoding="utf-8") as f:
+                f.write(content)
+            print(f"✅ Updated: {file}")
 
-        with open(file, "w", encoding="utf-8") as f:
-            f.write(content)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description

Both `refactor_skeletons.py` and `refactor_skeletons2.py` hardcoded a
personal Windows absolute path (`c:\Users\LENOVO\OneDrive\...`), so they
silently did nothing for any contributor other than the original author.
Now resolves the skeletons directory relative to the repo root via
`Path(__file__)`, with an optional `--skeletons-dir` CLI override and a
warning when no `.tsx` files are found instead of silent no-op success.

Closes #1853

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update (no code changes)
- [ ] ⚙️ CI/CD or build pipeline change
- [ ] ⚡ Performance optimization
- [ ] 🛠️ Refactoring (no functional changes)

## How Has This Been Tested?

### Automated Tests
- [x] Backend tests pass: `cd backend && pytest`
- [ ] Frontend tests pass: `cd frontend && npm run test`
- [ ] Frontend builds successfully: `cd frontend && npm run build`

### Manual Verification
Ran both scripts from a non-author machine/Codespace, confirmed correct
path resolution, the `--skeletons-dir` override, and the new not-found
warning; verified the actual `<div>`→`<Skeleton>` conversion regex logic
is unchanged from before this fix.

## Pre-Push Checklist

> [!IMPORTANT]
> **All items below must be checked before requesting a review.** Our CI bot will automatically run the frontend build and backend tests on your PR. If CI fails, you will receive a comment explaining what went wrong.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or console errors
- [ ] I have run `npm run build` in `frontend/` and it completes with **0 errors**
- [x] I have run `pytest` in `backend/` and all tests pass
- [x] I have run `git diff` locally and verified my changes

Backend Only.

## Deployment Notes

> [!NOTE]
> This project is deployed on **Vercel** (Frontend) and **Hugging Face** (Backend). The CI workflow simulates both deployment environments. If your PR passes CI, it is safe to merge.

`refactor_skeletons2.py` looks like a
strict superset of `refactor_skeletons.py` (handles open/close tags too) —
flagging for the maintainer in case they'd rather consolidate into one
script; left both as separate files here to keep this PR scoped to the
actual bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the skeleton migration tools to support command-line execution with configurable source directories.
  * Added automatic discovery of matching component files and safer handling when directories or files are unavailable.
  * Expanded shimmer conversion support to include both self-closing and nested component markup.
  * Added safeguards to avoid duplicate imports and provided clearer per-file completion feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->