### PR TITLE
feat(#1931): add webhook delivery attempt logs and health-check API

### DIFF
--- a/backend/apps/billing/serializers.py
+++ b/backend/apps/billing/serializers.py
@@ -5,6 +5,7 @@ from .models import (
     OrganizationSponsor,
     Bounty,
     BountyClaim,
+    Invoice,
 )
 
 

--- a/backend/apps/webhooks/management/commands/replay_dead_webhooks.py
+++ b/backend/apps/webhooks/management/commands/replay_dead_webhooks.py
@@ -37,7 +37,9 @@ class Command(BaseCommand):
         if dlq_id:
             self.stdout.write(f"Replaying DLQ entry {dlq_id}...")
             replay_delivery(dlq_id)
-            self.stdout.write(self.style.SUCCESS(f"Queued replay for DLQ entry {dlq_id}."))
+            self.stdout.write(
+                self.style.SUCCESS(f"Queued replay for DLQ entry {dlq_id}.")
+            )
             return
 
         qs = DeadLetterWebhook.objects.all()

--- a/backend/apps/webhooks/migrations/0003_add_encrypted_secrets.py
+++ b/backend/apps/webhooks/migrations/0003_add_encrypted_secrets.py
@@ -5,50 +5,68 @@ from django.db import migrations, models
 
 
 def encrypt_existing_secrets(apps, schema_editor):
-    WebhookEndpoint = apps.get_model('webhooks', 'WebhookEndpoint')
+    WebhookEndpoint = apps.get_model("webhooks", "WebhookEndpoint")
     from apps.webhooks.security import encrypt_secret
-    
+
     for endpoint in WebhookEndpoint.objects.all():
         if endpoint.secret_plain and not endpoint.encrypted_secret:
             endpoint.encrypted_secret = encrypt_secret(endpoint.secret_plain)
-            endpoint.save(update_fields=['encrypted_secret'])
+            endpoint.save(update_fields=["encrypted_secret"])
 
 
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('webhooks', '0002_webhookdelivery_retry_dlq'),
+        ("webhooks", "0002_webhookdelivery_retry_dlq"),
     ]
 
     operations = [
         migrations.RenameField(
-            model_name='webhookendpoint',
-            old_name='secret',
-            new_name='secret_plain',
+            model_name="webhookendpoint",
+            old_name="secret",
+            new_name="secret_plain",
         ),
         migrations.AlterField(
-            model_name='webhookendpoint',
-            name='secret_plain',
-            field=models.CharField(blank=True, db_column='secret', default=apps.webhooks.models.generate_secret, help_text='Legacy plaintext secret column, to be removed after data migration.', max_length=64, null=True),
+            model_name="webhookendpoint",
+            name="secret_plain",
+            field=models.CharField(
+                blank=True,
+                db_column="secret",
+                default=apps.webhooks.models.generate_secret,
+                help_text="Legacy plaintext secret column, to be removed after data migration.",
+                max_length=64,
+                null=True,
+            ),
         ),
         migrations.AddField(
-            model_name='webhookendpoint',
-            name='encrypted_old_secret',
-            field=models.TextField(blank=True, help_text='Encrypted previous shared secret (for rotation grace period).', null=True),
+            model_name="webhookendpoint",
+            name="encrypted_old_secret",
+            field=models.TextField(
+                blank=True,
+                help_text="Encrypted previous shared secret (for rotation grace period).",
+                null=True,
+            ),
         ),
         migrations.AddField(
-            model_name='webhookendpoint',
-            name='encrypted_secret',
-            field=models.TextField(blank=True, help_text='Encrypted shared secret used to sign the webhook payloads.', null=True),
+            model_name="webhookendpoint",
+            name="encrypted_secret",
+            field=models.TextField(
+                blank=True,
+                help_text="Encrypted shared secret used to sign the webhook payloads.",
+                null=True,
+            ),
         ),
         migrations.AddField(
-            model_name='webhookendpoint',
-            name='old_secret_expires_at',
-            field=models.DateTimeField(blank=True, help_text='Expiration timestamp for the old secret.', null=True),
+            model_name="webhookendpoint",
+            name="old_secret_expires_at",
+            field=models.DateTimeField(
+                blank=True,
+                help_text="Expiration timestamp for the old secret.",
+                null=True,
+            ),
         ),
         migrations.RunPython(
             encrypt_existing_secrets,
             reverse_code=migrations.RunPython.noop,
         ),
     ]
-

--- a/backend/apps/webhooks/migrations/0004_remove_secret_plain.py
+++ b/backend/apps/webhooks/migrations/0004_remove_secret_plain.py
@@ -6,12 +6,12 @@ from django.db import migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('webhooks', '0003_add_encrypted_secrets'),
+        ("webhooks", "0003_add_encrypted_secrets"),
     ]
 
     operations = [
         migrations.RemoveField(
-            model_name='webhookendpoint',
-            name='secret_plain',
+            model_name="webhookendpoint",
+            name="secret_plain",
         ),
     ]

--- a/backend/apps/webhooks/models.py
+++ b/backend/apps/webhooks/models.py
@@ -50,6 +50,7 @@ class WebhookEndpoint(models.Model):
         # 1. Return decrypted active secret if present
         if self.encrypted_secret:
             from apps.cache.audit_logger import AuditLogger
+
             AuditLogger.log(
                 user_id=str(self.user.id) if self.user else "system",
                 action="secret_accessed",
@@ -60,11 +61,13 @@ class WebhookEndpoint(models.Model):
                 status_code=200,
             )
             from .security import decrypt_secret
+
             return decrypt_secret(self.encrypted_secret)
 
         # 2. Fall back to legacy plaintext secret_plain if present in database (for transition/migration)
         if hasattr(self, "secret_plain") and self.secret_plain:
             from apps.cache.audit_logger import AuditLogger
+
             AuditLogger.log(
                 user_id=str(self.user.id) if self.user else "system",
                 action="secret_accessed",
@@ -82,6 +85,7 @@ class WebhookEndpoint(models.Model):
     def secret(self, value):
         if value:
             from .security import encrypt_secret
+
             self.encrypted_secret = encrypt_secret(value)
             self._raw_secret = value
             if hasattr(self, "secret_plain"):
@@ -101,6 +105,7 @@ class WebhookEndpoint(models.Model):
         if self.encrypted_old_secret and self.old_secret_expires_at:
             if timezone.now() < self.old_secret_expires_at:
                 from .security import decrypt_secret
+
                 old_sec = decrypt_secret(self.encrypted_old_secret)
                 if old_sec:
                     valid_list.append(old_sec)
@@ -110,9 +115,12 @@ class WebhookEndpoint(models.Model):
     def save(self, *args, **kwargs):
         is_new = self.pk is None
         # If no active secret is set (neither encrypted nor plain)
-        if not self.encrypted_secret and (not hasattr(self, "secret_plain") or not self.secret_plain):
+        if not self.encrypted_secret and (
+            not hasattr(self, "secret_plain") or not self.secret_plain
+        ):
             raw_val = generate_secret()
             from .security import encrypt_secret
+
             self.encrypted_secret = encrypt_secret(raw_val)
             self._raw_secret = raw_val
             if hasattr(self, "secret_plain"):
@@ -120,6 +128,7 @@ class WebhookEndpoint(models.Model):
 
             # Log secret creation
             from apps.cache.audit_logger import AuditLogger
+
             AuditLogger.log(
                 user_id=str(self.user.id) if self.user else "system",
                 action="secret_created",
@@ -199,3 +208,26 @@ class DeadLetterWebhook(models.Model):
 
     def __str__(self):
         return f"DLQ entry for delivery {self.delivery_id}"
+
+
+class WebhookDeliveryLog(models.Model):
+    """
+    Persists immutable logs of individual webhook delivery attempts.
+    """
+
+    delivery = models.ForeignKey(
+        WebhookDelivery,
+        on_delete=models.CASCADE,
+        related_name="logs",
+        help_text="The delivery this attempt is associated with.",
+    )
+    status_code = models.IntegerField(
+        null=True, blank=True, help_text="HTTP status code returned, if any."
+    )
+    response_body = models.TextField(
+        blank=True, help_text="Response body or error details."
+    )
+    attempted_at = models.DateTimeField(auto_now_add=True)
+
+    def __str__(self):
+        return f"Log for Delivery {self.delivery_id} - Status {self.status_code}"

--- a/backend/apps/webhooks/security.py
+++ b/backend/apps/webhooks/security.py
@@ -105,4 +105,3 @@ def require_webhook_signature(secret, header_name="HTTP_X_SIGNATURE"):
         return _wrapped_view
 
     return decorator
-

--- a/backend/apps/webhooks/serializers.py
+++ b/backend/apps/webhooks/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-from .models import WebhookDelivery, WebhookEndpoint
+from .models import WebhookDelivery, WebhookEndpoint, WebhookDeliveryLog
 
 
 class WebhookEndpointSerializer(serializers.ModelSerializer):
@@ -36,8 +36,16 @@ class WebhookEndpointSerializer(serializers.ModelSerializer):
         return instance
 
 
+class WebhookDeliveryLogSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = WebhookDeliveryLog
+        fields = ["id", "status_code", "response_body", "attempted_at"]
+        read_only_fields = ["id", "status_code", "response_body", "attempted_at"]
+
 
 class WebhookDeliverySerializer(serializers.ModelSerializer):
+    logs = WebhookDeliveryLogSerializer(many=True, read_only=True)
+
     class Meta:
         model = WebhookDelivery
         fields = [
@@ -48,6 +56,7 @@ class WebhookDeliverySerializer(serializers.ModelSerializer):
             "status_code",
             "response_body",
             "created_at",
+            "logs",
         ]
         read_only_fields = [
             "id",
@@ -57,4 +66,5 @@ class WebhookDeliverySerializer(serializers.ModelSerializer):
             "status_code",
             "response_body",
             "created_at",
+            "logs",
         ]

--- a/backend/apps/webhooks/tasks.py
+++ b/backend/apps/webhooks/tasks.py
@@ -7,7 +7,12 @@ import requests
 from django.utils import timezone
 from django_q.tasks import async_task
 
-from .models import DeadLetterWebhook, WebhookDelivery, WebhookEndpoint
+from .models import (
+    DeadLetterWebhook,
+    WebhookDelivery,
+    WebhookEndpoint,
+    WebhookDeliveryLog,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -109,6 +114,12 @@ def deliver_webhook(delivery_id, attempt=1):
             delivery.status_code = response.status_code
             delivery.response_body = response.text[:2000]
 
+            WebhookDeliveryLog.objects.create(
+                delivery=delivery,
+                status_code=delivery.status_code,
+                response_body=delivery.response_body,
+            )
+
             if 200 <= response.status_code < 300:
                 delivery.status = "success"
                 delivery.next_retry_at = None
@@ -123,11 +134,19 @@ def deliver_webhook(delivery_id, attempt=1):
         is_retryable = True
         failure_reason = f"Circuit open: {str(exc)}"
         delivery.response_body = failure_reason
+        delivery.status_code = None
+        WebhookDeliveryLog.objects.create(
+            delivery=delivery, status_code=None, response_body=failure_reason
+        )
 
     except requests.exceptions.RequestException as exc:
         is_retryable = True
         failure_reason = str(exc)[:1000]
         delivery.response_body = failure_reason
+        delivery.status_code = None
+        WebhookDeliveryLog.objects.create(
+            delivery=delivery, status_code=None, response_body=failure_reason
+        )
 
     # --- Schedule retry or move to DLQ ---
     if is_retryable and attempt < MAX_RETRIES:

--- a/backend/apps/webhooks/tests.py
+++ b/backend/apps/webhooks/tests.py
@@ -191,10 +191,11 @@ class TestWebhookSecretSecurity:
     def test_secret_encryption_at_rest(self, endpoint):
         # Retrieve raw database value to ensure encryption-at-rest
         from django.db import connection
+
         with connection.cursor() as cursor:
             cursor.execute(
                 "SELECT encrypted_secret FROM webhooks_webhookendpoint WHERE id = %s",
-                [endpoint.id]
+                [endpoint.id],
             )
             row = cursor.fetchone()
             encrypted_val = row[0]
@@ -219,7 +220,7 @@ class TestWebhookSecretSecurity:
         res = api_client.patch(
             f"/api/webhooks/endpoints/{endpoint.id}/",
             {"is_active": False},
-            format="json"
+            format="json",
         )
         assert res.status_code == 200
         assert "secret" not in res.data
@@ -239,6 +240,7 @@ class TestWebhookSecretSecurity:
         endpoint.refresh_from_db()
         assert endpoint.secret == new_secret
         from apps.webhooks.security import decrypt_secret
+
         assert decrypt_secret(endpoint.encrypted_old_secret) == old_secret
         assert endpoint.old_secret_expires_at is not None
 
@@ -294,7 +296,8 @@ class TestWebhookSecretSecurity:
         assert res.status_code == 201
 
         created_calls = [
-            c for c in mock_audit_log.mock_calls
+            c
+            for c in mock_audit_log.mock_calls
             if c[2].get("action") == "secret_created"
         ]
         assert len(created_calls) > 0
@@ -305,10 +308,10 @@ class TestWebhookSecretSecurity:
         assert res.status_code == 200
 
         rotated_calls = [
-            c for c in mock_audit_log.mock_calls
+            c
+            for c in mock_audit_log.mock_calls
             if c[2].get("action") == "secret_rotated"
         ]
         assert len(rotated_calls) > 0
         assert rotated_calls[0][2].get("user_id") == str(user.id)
         assert rotated_calls[0][2].get("resource_id") == str(endpoint.id)
-

--- a/backend/apps/webhooks/tests_security.py
+++ b/backend/apps/webhooks/tests_security.py
@@ -39,7 +39,6 @@ def test_verify_signature_multiple_secrets():
     assert verify_signature(secrets, PAYLOAD, VALID_SIGNATURE) is True
 
 
-
 def test_verify_signature_invalid():
     assert verify_signature(SECRET, PAYLOAD, "invalid_signature") is False
 

--- a/backend/apps/webhooks/views.py
+++ b/backend/apps/webhooks/views.py
@@ -71,3 +71,23 @@ class WebhookDeliveryViewSet(viewsets.ReadOnlyModelViewSet):
 
     def get_queryset(self):
         return WebhookDelivery.objects.filter(endpoint__user=self.request.user)
+
+    @action(detail=False, methods=["get"])
+    def health(self, request):
+        """
+        Returns the failed delivery ratio over the last 24 hours.
+        """
+        twenty_four_hours_ago = timezone.now() - timezone.timedelta(hours=24)
+        
+        # Consider the base WebhookDelivery to compute ratio
+        # Failed implies status is "failed" or "dead". Or we can just look at deliveries.
+        recent_deliveries = self.get_queryset().filter(created_at__gte=twenty_four_hours_ago)
+        total = recent_deliveries.count()
+        
+        if total == 0:
+            return Response({"failed_ratio": 0.0, "total": 0, "failed": 0})
+            
+        failed = recent_deliveries.filter(status__in=["failed", "dead", "retrying"]).count()
+        ratio = round((failed / total) * 100, 2)
+        
+        return Response({"failed_ratio": ratio, "total": total, "failed": failed})


### PR DESCRIPTION
## Description

Fixes #1931

This PR completes the webhook reliability and observability improvements by persisting an immutable log of every delivery attempt and introducing a health-check endpoint. 

- Added `WebhookDeliveryLog` model to track `status_code` and `response_body` for each retry attempt.
- Refactored `tasks.deliver_webhook` to log every individual attempt rather than simply overwriting the parent `WebhookDelivery` status.
- Added `/api/webhooks/deliveries/health/` action to calculate the 24-hour failure ratio.
- Nested the `logs` into `WebhookDeliverySerializer` for UI surface visibility.
- *Also includes a minor fix for a broken `Invoice` import in `billing` that was crashing the app locally.*

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

### Automated Tests
- [x] Backend tests pass: `cd backend && pytest` (Note: requires Redis running locally for Kombu/Celery fixtures)

### Manual Verification
- Verified Django migrations generated successfully and applied.
- Verified `/health/` endpoint handles 0-deliveries edge case without dividing by zero.

## Pre-Push Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have run `git diff` locally and verified my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added webhook delivery attempt logs, including status, response details, errors, and timestamps.
  - Webhook delivery responses now include read-only delivery logs.
  - Added a health endpoint reporting delivery totals and failure rates from the past 24 hours.
  - Existing webhook secrets are encrypted and rotation data is preserved.

- **Bug Fixes**
  - Corrected invoice serializer model loading.
  - Improved webhook replay success output and failure logging.
  - Ensured webhook signature protection is properly applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->