### PR TITLE
fix(gamification): use timezone.localdate() instead of naive date.today() for streak calculation

### DIFF
--- a/backend/apps/gamification/services.py
+++ b/backend/apps/gamification/services.py
@@ -1,4 +1,6 @@
-from datetime import date, timedelta
+from datetime import timedelta
+
+from django.utils import timezone
 
 from .models import Streak
 
@@ -7,7 +9,7 @@ class StreakService:
     @staticmethod
     def update_streak(user):
         streak, created = Streak.objects.get_or_create(user=user)
-        today = date.today()
+        today = timezone.localdate()
 
         if streak.last_activity_date == today:
             return streak  # Already updated today


### PR DESCRIPTION
## Description

`StreakService.update_streak()` used `datetime.date.today()`, which
reflects the server process's system timezone rather than Django's
configured `TIME_ZONE`/`USE_TZ`. Switched to
`django.utils.timezone.localdate()` so streak day boundaries are computed
in the timezone the project is actually configured for.

Fixes #1918

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update (no code changes)
- [ ] ⚙️ CI/CD or build pipeline change
- [ ] ⚡ Performance optimization
- [ ] 🛠️ Refactoring (no functional changes)

## How Has This Been Tested?

### Automated Tests
- [x] Backend tests pass: `cd backend && pytest`
- [ ] Frontend tests pass: `cd frontend && npm run test`
- [ ] Frontend builds successfully: `cd frontend && npm run build`

### Manual Verification
Verified `USE_TZ` setting value in this repo's Django settings (see PR
discussion); tested streak update behavior with a non-UTC `TIME_ZONE`
configured and frozen time near a UTC-vs-local day boundary.

## Pre-Push Checklist

> [!IMPORTANT]
> **All items below must be checked before requesting a review.** Our CI bot will automatically run the frontend build and backend tests on your PR. If CI fails, you will receive a comment explaining what went wrong.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or console errors
- [ ] I have run `npm run build` in `frontend/` and it completes with **0 errors**
- [x] I have run `pytest` in `backend/` and all tests pass
- [x] I have run `git diff` locally and verified my changes

Backend only.

## Deployment Notes

> [!NOTE]
> This project is deployed on **Vercel** (Frontend) and **Hugging Face** (Backend). The CI workflow simulates both deployment environments. If your PR passes CI, it is safe to merge.

<!-- Add any notes about deployment considerations, environment variables, or migration steps needed -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streak tracking by using the app’s local date when determining whether a streak was updated today or yesterday.
  * Prevented timezone differences from causing incorrect streak updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->