### PR TITLE
feat(monitoring): log warnings when queue backlog or worker count crosses configurable thresholds

### DIFF
--- a/backend/monitoring/celery_monitor.py
+++ b/backend/monitoring/celery_monitor.py
@@ -32,6 +32,19 @@ class CeleryMonitor:
         """Update all metrics"""
         self.update_queue_sizes()
         self.update_worker_count()
+        self._check_alert_thresholds()
+
+    def _check_alert_thresholds(self):
+        """Log a warning if queue backlog or worker count crosses configured thresholds."""
+        queue_threshold = int(os.getenv("CELERY_QUEUE_ALERT_THRESHOLD", 1000))
+
+        for queue in self.queues:
+            current = queue_size.labels(queue_name=queue)._value.get()
+            if current is not None and current > queue_threshold:
+                print(f"🚨 Queue backlog alert: '{queue}' has {current} pending tasks (threshold: {queue_threshold})")
+
+        if self.workers == 0:
+            print("🚨 No active Celery workers detected")
 
     def update_queue_sizes(self):
         """Update queue size metrics using the true per-queue Redis list length"""


### PR DESCRIPTION
## Description

`CeleryMonitor` now logs a warning when a queue's backlog exceeds a
configurable threshold (`CELERY_QUEUE_ALERT_THRESHOLD`, default 1000) or
when zero active workers are detected — a cheap in-process safety net
alongside the existing Prometheus metrics.

Fixes #1920 

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update (no code changes)
- [ ] ⚙️ CI/CD or build pipeline change
- [ ] ⚡ Performance optimization
- [ ] 🛠️ Refactoring (no functional changes)

## How Has This Been Tested?

### Automated Tests
- [x] Backend tests pass: `cd backend && pytest`
- [ ] Frontend tests pass: `cd frontend && npm run test`
- [ ] Frontend builds successfully: `cd frontend && npm run build`

### Manual Verification
Verified alert log lines print when thresholds are crossed and stay
silent otherwise (see testing checklist in linked issue).

## Pre-Push Checklist

> [!IMPORTANT]
> **All items below must be checked before requesting a review.** Our CI bot will automatically run the frontend build and backend tests on your PR. If CI fails, you will receive a comment explaining what went wrong.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or console errors
- [ ] I have run `npm run build` in `frontend/` and it completes with **0 errors**
- [x] I have run `pytest` in `backend/` and all tests pass
- [x] I have run `git diff` locally and verified my changes

Backend only.

## Deployment Notes

> [!NOTE]
> This project is deployed on **Vercel** (Frontend) and **Hugging Face** (Backend). The CI workflow simulates both deployment environments. If your PR passes CI, it is safe to merge.

Builds on top of the earlier `bug/celery-queue-size-per-queue`
fix in this same file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added monitoring alerts when task queue backlogs exceed the configured threshold.
  * Added warnings when no active workers are detected.
  * Alert thresholds can be configured through the queue monitoring settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->