### PR TITLE
Fix/license n plus one

### DIFF
--- a/backend/apps/sandbox/resource_manager.py
+++ b/backend/apps/sandbox/resource_manager.py
@@ -132,7 +132,7 @@ class ResourceManagementEngine:
                 cache_key, current - 1, timeout=cls.MAX_EXECUTION_TIME_SECONDS * 2
             )
 
-    class SandboxResourceManager:
+class SandboxResourceManager:
     """Atomic Redis-based distributed semaphore for sandbox execution."""
     
     MAX_CONCURRENT = 2

--- a/backend/apps/sandbox/resource_manager.py
+++ b/backend/apps/sandbox/resource_manager.py
@@ -6,7 +6,7 @@ import redis
 
 from django.contrib.auth import get_user_model
 from django.core.cache import cache
-from django.config import settings
+from django.conf import settings
 
 from apps.sandbox.models import ExecutionViolationLog
 

--- a/backend/apps/sandbox/views.py
+++ b/backend/apps/sandbox/views.py
@@ -734,7 +734,15 @@ from .serializers import LicenseScenarioSerializer, LicenseAttemptSerializer
 
 
 class LicenseScenarioViewSet(viewsets.ReadOnlyModelViewSet):
-    queryset = LicenseScenario.objects.all().order_by("-created_at")
+    """
+    Viewset for License Scenarios (Dependency Detective).
+    """
+
+    queryset = (
+        LicenseScenario.objects.all()
+        .prefetch_related("dependencies")
+        .order_by("-created_at")
+    )
     serializer_class = LicenseScenarioSerializer
     permission_classes = [permissions.AllowAny]
 


### PR DESCRIPTION
### Description
This PR addresses a critical N+1 query performance bottleneck identified in the `LicenseScenarioViewSet` (`backend/apps/sandbox/views.py`). Prior to this fix, fetching a list of license scenarios resulted in a separate database query for each scenario to fetch its dependencies, leading to severely degraded API response times as the dataset grew.
Closes #1991
### Changes Made
- Added a `.prefetch_related("dependencies")` clause to the `queryset` of `LicenseScenarioViewSet`.
- Fixed a minor indentation and module import error found in `backend/apps/sandbox/resource_manager.py` that occurred when using the sandbox resources.

### How to Test
1. Run the backend development server using `uv run python manage.py runserver`.
2. Hit the `/api/sandbox/license-scenarios/` endpoint (or use Django REST Framework UI).
3. Using a tool like Django Debug Toolbar or monitoring query logs, verify that the number of SQL queries executes in a constant number of queries instead of scaling linearly with the number of returned scenarios.
4. Verify that dependencies are properly included in the response payload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue that could prevent sandbox resource management from loading correctly.
  * Improved license scenario loading to reduce delays when displaying related dependency information.

* **Documentation**
  * Clarified the license scenarios view description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->