### PR TITLE
feat(feature_flags): cache flag/switch lookups for 30s to cut per-request DB load

### DIFF
--- a/backend/apps/feature_flags/context_processors.py
+++ b/backend/apps/feature_flags/context_processors.py
@@ -1,29 +1,39 @@
 import waffle
+from django.core.cache import cache
 
 
 def feature_flags(request):
     """
-    Exposes all waffle flags and switches to templates and the frontend.
-    Flags and switches are namespaced separately (rather than merged into
-    one dict keyed by name) since Waffle allows a Flag and a Switch to
-    share the same name — merging them would silently drop one's state
-    on a collision.
+    Exposes all waffle flags and switches to templates/frontend.
+    Cached for 30s to avoid two full-table queries on every request —
+    flag/switch state changes are infrequent (admin toggles), so a short
+    staleness window is an acceptable tradeoff for the reduced DB load.
     """
-    Flag = waffle.get_waffle_flag_model()
-    Switch = waffle.get_waffle_switch_model()
+    if not hasattr(request, 'user'):
+        return {"feature_flags": {"flags": {}, "switches": {}}}
 
-    flags_dict = {}
-    switches_dict = {}
+    cache_key = "waffle_flags_switches_v1"
+    cached = cache.get(cache_key)
 
-    if hasattr(request, 'user'):
-        for flag in Flag.objects.all():
-            flags_dict[flag.name] = {
-                "enabled": waffle.flag_is_active(request, flag.name)
-            }
-
-    for switch in Switch.objects.all():
-        switches_dict[switch.name] = {
-            "enabled": waffle.switch_is_active(switch.name)
+    if cached is None:
+        Flag = waffle.get_waffle_flag_model()
+        Switch = waffle.get_waffle_switch_model()
+        cached = {
+            "flag_names": list(Flag.objects.values_list("name", flat=True)),
+            "switch_states": {
+                s.name: waffle.switch_is_active(s.name)
+                for s in Switch.objects.all()
+            },
         }
+        cache.set(cache_key, cached, timeout=30)
+
+    flags_dict = {
+        name: {"enabled": waffle.flag_is_active(request, name)}
+        for name in cached["flag_names"]
+    }
+    switches_dict = {
+        name: {"enabled": enabled}
+        for name, enabled in cached["switch_states"].items()
+    }
 
     return {"feature_flags": {"flags": flags_dict, "switches": switches_dict}}


### PR DESCRIPTION
## Description

Caches the Flag name list / Switch states for 30s instead of querying
both tables fully on every request. Per-user flag targeting (`flag_is_active`)
still evaluates fresh each request — only the underlying flag/switch
existence and switch on/off state is cached.

Fixes #1976 

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update (no code changes)
- [ ] ⚙️ CI/CD or build pipeline change
- [x] ⚡ Performance optimization
- [ ] 🛠️ Refactoring (no functional changes)

## How Has This Been Tested?

### Automated Tests
- [x] Backend tests pass: `cd backend && pytest`
- [ ] Frontend tests pass: `cd frontend && npm run test`
- [ ] Frontend builds successfully: `cd frontend && npm run build`

### Manual Verification
Confirmed reduced query count within the cache window and correct
pickup of changes after expiry.

## Pre-Push Checklist

> [!IMPORTANT]
> **All items below must be checked before requesting a review.** Our CI bot will automatically run the frontend build and backend tests on your PR. If CI fails, you will receive a comment explaining what went wrong.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or console errors
- [ ] I have run `npm run build` in `frontend/` and it completes with **0 errors**
- [x] I have run `pytest` in `backend/` and all tests pass
- [x] I have run `git diff` locally and verified my changes

Backend only.

# Note
Please Merge after 12:06 AM IST (GMT +5:30) 22 July. 
2 hours and 33 minutes after PR Creation.

## Deployment Notes

> [!NOTE]
> This project is deployed on **Vercel** (Frontend) and **Hugging Face** (Backend). The CI workflow simulates both deployment environments. If your PR passes CI, it is safe to merge.

<!-- Add any notes about deployment considerations, environment variables, or migration steps needed -->
