### PR TITLE
feat(localization): make locale switch rate-limit configurable via settings

### DIFF
--- a/backend/apps/localization/middleware.py
+++ b/backend/apps/localization/middleware.py
@@ -123,9 +123,13 @@ def resolve_locale(accept_language_header: str) -> str:
 def check_locale_switch_rate_limit(request, resolved_lang: str) -> bool:
     """
     Checks if the user/IP is switching locales too rapidly.
-    Allows up to 10 locale switches per 60 seconds.
+    Limits are configurable via settings.LOCALE_SWITCH_RATE_LIMIT (default 10)
+    and settings.LOCALE_SWITCH_RATE_WINDOW_SECONDS (default 60).
     Returns True if switch is allowed, False if rate-limited.
     """
+    max_switches = getattr(settings, "LOCALE_SWITCH_RATE_LIMIT", 10)
+    window_seconds = getattr(settings, "LOCALE_SWITCH_RATE_WINDOW_SECONDS", 60)
+
     # Try to identify client via session key or IP address
     client_id = None
     if hasattr(request, "session"):
@@ -151,14 +155,13 @@ def check_locale_switch_rate_limit(request, resolved_lang: str) -> bool:
     now = int(time.time())
     cache_key = f"{client_id}_switches"
     switches = cache.get(cache_key, [])
-    # Keep only switches from the last 60 seconds
-    switches = [t for t in switches if now - t < 60]
+    switches = [t for t in switches if now - t < window_seconds]
 
-    if len(switches) >= 10:
+    if len(switches) >= max_switches:
         return False
 
     switches.append(now)
-    cache.set(cache_key, switches, timeout=60)
+    cache.set(cache_key, switches, timeout=window_seconds)
     return True
 
 


### PR DESCRIPTION
## Description

Locale switch rate-limit threshold and window are now configurable via
`settings.LOCALE_SWITCH_RATE_LIMIT` / `LOCALE_SWITCH_RATE_WINDOW_SECONDS`,
defaulting to the previous hardcoded values (10, 60) for no behavior
change unless explicitly overridden.

Fixes #1977 

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update (no code changes)
- [ ] ⚙️ CI/CD or build pipeline change
- [ ] ⚡ Performance optimization
- [ ] 🛠️ Refactoring (no functional changes)

## How Has This Been Tested?

### Automated Tests
- [x] Backend tests pass: `cd backend && pytest`
- [ ] Frontend tests pass: `cd frontend && npm run test`
- [ ] Frontend builds successfully: `cd frontend && npm run build`

### Manual Verification
Confirmed default behavior unchanged, and both settings overrides take effect.

## Pre-Push Checklist

> [!IMPORTANT]
> **All items below must be checked before requesting a review.** Our CI bot will automatically run the frontend build and backend tests on your PR. If CI fails, you will receive a comment explaining what went wrong.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or console errors
- [ ] I have run `npm run build` in `frontend/` and it completes with **0 errors**
- [x] I have run `pytest` in `backend/` and all tests pass
- [x] I have run `git diff` locally and verified my changes

Backend only.

# Note
Please Merge after 12:06 AM IST (GMT +5:30) 22 July. 
2 hours and 23 minutes after PR Creation.

## Deployment Notes

> [!NOTE]
> This project is deployed on **Vercel** (Frontend) and **Hugging Face** (Backend). The CI workflow simulates both deployment environments. If your PR passes CI, it is safe to merge.

<!-- Add any notes about deployment considerations, environment variables, or migration steps needed -->
