### PR TITLE
fix: add missing comma in frontend package.json

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -115,7 +115,7 @@
     "@types/emscripten": "^1.41.5",
     "@types/hast": "^3.0.5",
     "@types/junit-report-builder": "^3.0.2",
-    "@types/mdx": "^2.0.14"
+    "@types/mdx": "^2.0.14",
     "@types/node": "^20.11.0",
     "@types/prismjs": "^1.26.4",
     "@types/react": "^19.0.8",


### PR DESCRIPTION
## Summary

This PR fixes an invalid JSON syntax error in `frontend/package.json` caused by a missing comma in the `devDependencies` section.

## Changes Made

- Added the missing comma after `"@types/mdx": "^2.0.14"`.

## Testing

- Reproduced the issue by running `npm install` in the `frontend` directory, which failed with an `EJSONPARSE` error.
- Added the missing comma.
- Verified that `npm install` completes successfully without any JSON parsing errors.

Closes #2019


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the MDX type package declaration without changing its version range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->