### PR TITLE
fix: log GitHub API failures instead of silently ignoring them

### DIFF
--- a/backend/apps/project_health/services.py
+++ b/backend/apps/project_health/services.py
@@ -4,10 +4,14 @@ Uses the public GitHub REST API (no authentication required for public repos).
 """
 
 import re
+import logging
 from datetime import datetime, timezone
 from urllib.parse import urlparse
+from typing import Any
 
 import requests
+
+logger = logging.getLogger(__name__)
 
 GITHUB_API = "https://api.github.com"
 
@@ -21,12 +25,17 @@ def _parse_repo_url(repo_url: str) -> tuple[str, str]:
     return parts[0], parts[1]
 
 
-def _github_get(path: str, token: str = None) -> dict | list:
+def _github_get(path: str, token: str | None = None) -> Any:
     """Make a GET request to the GitHub API."""
     headers = {"Accept": "application/vnd.github+json"}
     if token:
         headers["Authorization"] = f"Bearer {token}"
-    response = requests.get(f"{GITHUB_API}{path}", headers=headers, timeout=10)
+
+    response = requests.get(
+        f"{GITHUB_API}{path}",
+        headers=headers,
+        timeout=10,
+    )
     response.raise_for_status()
     return response.json()
 
@@ -44,11 +53,10 @@ def _compute_health_score(data: dict) -> tuple[int, list, list]:
     Compute a health score (0-100) from raw metrics.
     Returns (score, red_flags, green_flags).
     """
-    score = 50  # Baseline
+    score = 50
     red_flags = []
     green_flags = []
 
-    # Recency
     last_commit_days = data.get("last_commit_days_ago")
     if last_commit_days is not None:
         if last_commit_days > 365:
@@ -58,30 +66,38 @@ def _compute_health_score(data: dict) -> tuple[int, list, list]:
             )
         elif last_commit_days > 90:
             score -= 10
-            red_flags.append("🟡 Low activity (last commit was over 3 months ago).")
+            red_flags.append(
+                "🟡 Low activity (last commit was over 3 months ago)."
+            )
         else:
             score += 15
             green_flags.append("✅ Actively maintained (recent commits).")
 
-    # PR responsiveness
     avg_pr_days = data.get("avg_pr_close_days")
     if avg_pr_days is not None:
         if avg_pr_days < 7:
             score += 15
-            green_flags.append("✅ Excellent PR response time (< 1 week).")
+            green_flags.append(
+                "✅ Excellent PR response time (< 1 week)."
+            )
         elif avg_pr_days < 30:
             score += 5
-            green_flags.append("✅ Reasonable PR response time (< 1 month).")
+            green_flags.append(
+                "✅ Reasonable PR response time (< 1 month)."
+            )
         else:
             score -= 10
-            red_flags.append("🟡 Slow PR response time (> 30 days on average).")
+            red_flags.append(
+                "🟡 Slow PR response time (> 30 days on average)."
+            )
 
-    # Issue ratio
     open_issues = data.get("open_issues", 0)
     closed_issues = data.get("closed_issues", 0)
     total_issues = open_issues + closed_issues
+
     if total_issues > 0:
         close_ratio = closed_issues / total_issues
+
         if close_ratio > 0.7:
             score += 10
             green_flags.append(
@@ -93,8 +109,8 @@ def _compute_health_score(data: dict) -> tuple[int, list, list]:
                 f"🔴 Low issue resolution rate ({int(close_ratio * 100)}% closed)."
             )
 
-    # Contributor diversity
     contributors = data.get("contributor_count", 0)
+
     if contributors > 50:
         score += 10
         green_flags.append(
@@ -102,10 +118,12 @@ def _compute_health_score(data: dict) -> tuple[int, list, list]:
         )
     elif contributors < 5:
         score -= 5
-        red_flags.append("🟡 Low contributor count – bus-factor risk.")
+        red_flags.append(
+            "🟡 Low contributor count – bus-factor risk."
+        )
 
-    # Sentiment
     sentiment = data.get("sentiment_score")
+
     if sentiment is not None:
         if sentiment > 0.2:
             score += 10
@@ -114,45 +132,78 @@ def _compute_health_score(data: dict) -> tuple[int, list, list]:
             )
         elif sentiment < -0.1:
             score -= 15
-            red_flags.append("🔴 Community communications appear negative or toxic.")
+            red_flags.append(
+                "🔴 Community communications appear negative or toxic."
+            )
 
     return max(0, min(score, 100)), red_flags, green_flags
 
 
-def analyze_repository(repo_url: str, token: str = None) -> dict:
+def analyze_repository(
+    repo_url: str,
+    token: str | None = None,
+) -> dict:
     """
     Fetch GitHub data, run sentiment analysis, compute health score.
     Returns a dict of all metrics ready to store in RepoHealthScore.
     """
+
     owner, repo_name = _parse_repo_url(repo_url)
+    warnings = []
 
-    # Fetch basic repo info
     try:
-        repo_data = _github_get(f"/repos/{owner}/{repo_name}", token=token)
-    except requests.HTTPError as e:
-        raise ValueError(f"Repository not found or inaccessible: {e}")
+        repo_data = _github_get(
+            f"/repos/{owner}/{repo_name}",
+            token=token,
+        )
+    except requests.HTTPError as exc:
+        raise ValueError(
+            f"Repository not found or inaccessible: {exc}"
+        ) from exc
 
-    # Last commit date
     last_commit_days = None
+
     try:
         commits = _github_get(
-            f"/repos/{owner}/{repo_name}/commits?per_page=1", token=token
+            f"/repos/{owner}/{repo_name}/commits?per_page=1",
+            token=token,
         )
+
         if commits:
             date_str = commits[0]["commit"]["committer"]["date"]
-            last_commit_dt = datetime.fromisoformat(date_str.replace("Z", "+00:00"))
-            last_commit_days = (datetime.now(tz=timezone.utc) - last_commit_dt).days
-    except Exception:
-        pass
+            last_commit_dt = datetime.fromisoformat(
+                date_str.replace("Z", "+00:00")
+            )
+            last_commit_days = (
+                datetime.now(tz=timezone.utc) - last_commit_dt
+            ).days
 
-    # PR stats (closed, last 30)
+    except (
+        requests.RequestException,
+        KeyError,
+        IndexError,
+        TypeError,
+    ) as exc:
+        logger.warning(
+            "Failed to fetch last commit information: %s",
+            exc,
+        )
+        warnings.append(
+            "Last commit information could not be retrieved."
+        )
+
     avg_pr_close_days = None
+    closed_prs = []
+
     try:
         closed_prs = _github_get(
-            f"/repos/{owner}/{repo_name}/pulls?state=closed&per_page=30", token=token
+            f"/repos/{owner}/{repo_name}/pulls?state=closed&per_page=30",
+            token=token,
         )
+
         if closed_prs:
             durations = []
+
             for pr in closed_prs:
                 if pr.get("merged_at") and pr.get("created_at"):
                     created = datetime.fromisoformat(
@@ -162,41 +213,86 @@ def analyze_repository(repo_url: str, token: str = None) -> dict:
                         pr["merged_at"].replace("Z", "+00:00")
                     )
                     durations.append((merged - created).days)
-            if durations:
-                avg_pr_close_days = sum(durations) / len(durations)
-    except Exception:
-        pass
 
-    # Open PR count
+            if durations:
+                avg_pr_close_days = (
+                    sum(durations) / len(durations)
+                )
+
+    except (
+        requests.RequestException,
+        KeyError,
+        IndexError,
+        TypeError,
+    ) as exc:
+        logger.warning(
+            "Failed to fetch pull request statistics: %s",
+            exc,
+        )
+        warnings.append(
+            "Pull request statistics could not be retrieved."
+        )
+
     open_pr_count = 0
+
     try:
         open_prs = _github_get(
-            f"/repos/{owner}/{repo_name}/pulls?state=open&per_page=1", token=token
+            f"/repos/{owner}/{repo_name}/pulls?state=open&per_page=1",
+            token=token,
         )
         open_pr_count = len(open_prs)
-    except Exception:
-        pass
 
-    # Contributor count
+    except (
+        requests.RequestException,
+        KeyError,
+        IndexError,
+        TypeError,
+    ) as exc:
+        logger.warning(
+            "Failed to fetch open pull request count: %s",
+            exc,
+        )
+        warnings.append(
+            "Open pull request count could not be retrieved."
+        )
+
     contributor_count = 0
+
     try:
         contributors = _github_get(
-            f"/repos/{owner}/{repo_name}/contributors?per_page=100", token=token
+            f"/repos/{owner}/{repo_name}/contributors?per_page=100",
+            token=token,
         )
         contributor_count = len(contributors)
-    except Exception:
-        pass
 
-    # Sentiment from recent PR comments (lightweight approach without TextBlob)
+    except (
+        requests.RequestException,
+        KeyError,
+        IndexError,
+        TypeError,
+    ) as exc:
+        logger.warning(
+            "Failed to fetch contributor count: %s",
+            exc,
+        )
+        warnings.append(
+            "Contributor statistics could not be retrieved."
+        )
+
     sentiment_score = None
     sentiment_lbl = ""
+
     try:
         comments_data = _github_get(
             f"/repos/{owner}/{repo_name}/issues/comments?per_page=50&sort=created&direction=desc",
             token=token,
         )
+
         if comments_data:
+
             # Simple keyword-based sentiment (no external dependency needed)
+
+
             positive_words = {
                 "great",
                 "thanks",
@@ -207,6 +303,9 @@ def analyze_repository(repo_url: str, token: str = None) -> dict:
                 "love",
                 "perfect",
             }
+
+
+
             negative_words = {
                 "terrible",
                 "broken",
@@ -218,25 +317,42 @@ def analyze_repository(repo_url: str, token: str = None) -> dict:
                 "useless",
                 "toxic",
             }
+
+
             polarity_sum = 0
+
             for comment in comments_data:
                 body = comment.get("body", "").lower()
                 words = set(re.findall(r"\w+", body))
+
                 polarity_sum += len(words & positive_words) - len(
                     words & negative_words
                 )
             sentiment_score = polarity_sum / len(comments_data) if comments_data else 0
+
             sentiment_lbl = _sentiment_label(sentiment_score)
-    except Exception:
-        pass
+
+    except (
+        requests.RequestException,
+        KeyError,
+        IndexError,
+        TypeError,
+    ) as exc:
+        logger.warning(
+            "Failed to fetch issue comments for sentiment analysis: %s",
+            exc,
+        )
+        warnings.append(
+            "Sentiment analysis could not be completed."
+        )
 
     data = {
         "repo_owner": owner,
         "repo_name": repo_name,
         "open_issues": repo_data.get("open_issues_count", 0),
-        "closed_issues": 0,  # Not directly available without search API
+        "closed_issues": 0,
         "open_prs": open_pr_count,
-        "closed_prs": len(closed_prs) if avg_pr_close_days is not None else 0,
+        "closed_prs": len(closed_prs),
         "avg_pr_close_days": avg_pr_close_days,
         "contributor_count": contributor_count,
         "last_commit_days_ago": last_commit_days,
@@ -245,9 +361,13 @@ def analyze_repository(repo_url: str, token: str = None) -> dict:
     }
 
     score, red_flags, green_flags = _compute_health_score(data)
+
     data["health_score"] = score
     data["red_flags"] = red_flags
     data["green_flags"] = green_flags
+    data["warnings"] = warnings
+    data["partial_analysis"] = bool(warnings)
+
 
     return data
 


### PR DESCRIPTION
## Summary

This PR replaces silent exception handling in the GitHub repository analysis service with proper logging and user-visible warnings.

### Changes
- Added logging using Python's `logging` module.
- Replaced silent `except` blocks with logged warnings.
- Added a `warnings` list to collect partial analysis failures.
- Added a `partial_analysis` flag to indicate when analysis could not be fully completed.
- Preserved existing functionality by allowing analysis to continue even if individual GitHub API requests fail.

### Why

Previously, several GitHub API failures were silently ignored, making debugging difficult and hiding partial failures from users. This change improves observability while maintaining graceful degradation when some API endpoints are unavailable.

## Testing

- Verified that the code continues to return repository analysis when optional GitHub API requests fail.
- Confirmed that warnings are logged instead of being silently ignored.

closes #2041

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Repository health reports now include warnings when some information cannot be retrieved.
  * Reports indicate when analysis is partial and identify the affected metrics.
  * Health scoring now accounts for contributor activity alongside sentiment.

* **Bug Fixes**
  * Improved handling of GitHub and sentiment-analysis errors.
  * Analysis continues with available data instead of failing silently or stopping entirely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->