### PR TITLE
fix(dashboard): send tags as a list instead of a bare status string

### DIFF
--- a/backend/apps/dashboard/signals.py
+++ b/backend/apps/dashboard/signals.py
@@ -14,7 +14,7 @@ def publish_issue_indexed_event(sender, instance, **kwargs):
             "object_id": instance.pk,
             "title": instance.title,
             "description": instance.description,
-            "tags": instance.status,
+            "tags": [instance.status],
             "body_text": instance.description,
         },
     )


### PR DESCRIPTION
## Description

`tags` in the `SearchIndexRequested` event payload was a bare
`instance.status` string instead of a list — wrapped it in a list.
**Verified against the actual `SearchIndexRequested` consumer before
merging** (see PR discussion) since the issue itself was filed on a
plausible-but-unconfirmed reading of the code — no consumer read yet at
issue-filing time.

Fixes #2036 

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update (no code changes)
- [ ] ⚙️ CI/CD or build pipeline change
- [ ] ⚡ Performance optimization
- [ ] 🛠️ Refactoring (no functional changes)

## How Has This Been Tested?

### Automated Tests
- [x] Backend tests pass: `cd backend && pytest`
- [ ] Frontend tests pass: `cd frontend && npm run test`
- [ ] Frontend builds successfully: `cd frontend && npm run build`

### Manual Verification
Traced an Issue save through to the search index consumer and confirmed
correct tag handling post-fix.

## Pre-Push Checklist

> [!IMPORTANT]
> **All items below must be checked before requesting a review.** Our CI bot will automatically run the frontend build and backend tests on your PR. If CI fails, you will receive a comment explaining what went wrong.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or console errors
- [ ] I have run `npm run build` in `frontend/` and it completes with **0 errors**
- [x] I have run `pytest` in `backend/` and all tests pass
- [x] I have run `git diff` locally and verified my changes

Backend only.

# Note
Please Merge after 08:02 AM IST (GMT +5:30) 23 July. 
7 hours and 44 minutes after PR Creation.

## Deployment Notes

> [!NOTE]
> This project is deployed on **Vercel** (Frontend) and **Hugging Face** (Backend). The CI workflow simulates both deployment environments. If your PR passes CI, it is safe to merge.

<!-- Add any notes about deployment considerations, environment variables, or migration steps needed -->
