### PR TITLE
fix(billing): resolve Stripe webhook signature bypass vulnerability

### DIFF
--- a/backend/apps/billing/webhooks.py
+++ b/backend/apps/billing/webhooks.py
@@ -21,8 +21,11 @@ def stripe_webhook(request):
     is_mock = (
         getattr(settings, "TESTING", False)
         or stripe.api_key == "sk_test_mock"
-        or sig_header is None
     )
+
+    if not is_mock and sig_header is None:
+        return HttpResponse("Missing Stripe-Signature header", status=400)
+
 
     if is_mock:
         try:


### PR DESCRIPTION
## Description
This PR resolves a critical security vulnerability in the Stripe webhook handling logic (`backend/apps/billing/webhooks.py`). 
Closes #2098 
Previously, the `is_mock` boolean fallback evaluated to true if the `Stripe-Signature` header was missing (`sig_header is None`). This logic allowed potential attackers to bypass signature verification entirely by omitting the header, forcing the server to evaluate payloads as mock events in production.

This fix explicitly removes the `sig_header is None` check from the mock allowance and introduces a strict `400 Bad Request` rejection if the signature header is missing outside of a valid `settings.TESTING` environment.

## Type of Change
- [x] Security Fix
- [x] Bug Fix

## Verification
- Verified that missing signature headers in non-test environments correctly return a `400 Bad Request`.
- Verified that local mock testing remains functional when `TESTING = True`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stripe webhook requests without a valid signature header now return a clear 400 error instead of bypassing signature verification.
  * Mock and test environments continue to support unsigned webhook requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->