### PR TITLE
fix(sandbox): add ReDoS validation on regex replace queries

### DIFF
--- a/backend/apps/sandbox/views.py
+++ b/backend/apps/sandbox/views.py
@@ -144,6 +144,14 @@ class ProjectViewSet(viewsets.ModelViewSet):
 
         import re
 
+        if is_regex:
+            if len(query) > 100:
+                return Response({"error": "Regex query too long (max 100 chars)"}, status=400)
+            # Basic validation to prevent catastrophic backtracking (nested quantifiers)
+            if re.search(r"(\(.*?[+*{].*?\)[+*{])", query):
+                return Response({"error": "Complex nested quantifiers are not allowed"}, status=400)
+
+
         flags = 0 if match_case else re.IGNORECASE
         try:
             pattern = re.compile(query if is_regex else re.escape(query), flags)


### PR DESCRIPTION
## Description
This PR addresses a Regular Expression Denial of Service (ReDoS) vulnerability in the `ProjectViewSet.replace` action of the Sandbox module.
Closes #2099 
Previously, authenticated users could submit arbitrarily complex regular expressions via the `query` field. Because Python's native `re` module utilizes a backtracking engine, a malicious nested quantifier payload (e.g. `(a+)+b`) could cause catastrophic backtracking, freezing the thread and spiking CPU usage indefinitely.

This fix implements preventative validation on incoming regex queries:
1. **Length constraint:** Queries are now strictly capped at 100 characters.
2. **Complexity validation:** Basic static analysis via regex now intercepts and blocks known dangerous patterns (nested quantifiers like `(.*)*` or `(a+)+`), returning a `400 Bad Request` before the pattern is compiled.

## Type of Change
- [x] Security Fix
- [x] Performance Improvement

## Verification
- Submitted excessively long regex queries and verified they are rejected.
- Submitted ReDoS-style payloads and verified they return a 400 error rather than hanging the server.