### PR TITLE
feat(gamification): add daily streak tracker to sandbox execution

### DIFF
--- a/backend/apps/sandbox/services/execution_tracker.py
+++ b/backend/apps/sandbox/services/execution_tracker.py
@@ -24,6 +24,27 @@ class ExecutionTracker:
         key = cls._get_key(user_id, code, payload)
         cache.set(key, True, timeout=86400)  # Duplicate for 24 hours
 
+        try:
+            from apps.gamification.models import Streak
+            from django.utils import timezone
+            import datetime
+
+            today = timezone.localdate()
+            streak, _ = Streak.objects.get_or_create(user_id=user_id)
+
+            if streak.last_activity_date != today:
+                if streak.last_activity_date == today - datetime.timedelta(days=1):
+                    streak.current_streak += 1
+                else:
+                    streak.current_streak = 1
+                
+                streak.last_activity_date = today
+                if streak.current_streak > streak.longest_streak:
+                    streak.longest_streak = streak.current_streak
+                streak.save(update_fields=['current_streak', 'longest_streak', 'last_activity_date'])
+        except Exception:
+            pass
+
     @classmethod
     def clear_execution(cls, user_id, code, payload):
         key = cls._get_key(user_id, code, payload)


### PR DESCRIPTION
## Description
This PR introduces a Daily Activity Streak tracker to encourage user retention and gamify the platform experience.
Closes #2100 
While the `gamification` app included a `Streak` model, it was not hooked into the core user flows. This PR integrates the streak tracking directly into the `SandboxVerifyView` via the `ExecutionTracker`. 

When a user successfully executes and verifies code in the sandbox:
1. The backend evaluates their `last_activity_date`.
2. If the last activity was yesterday, their `current_streak` increments.
3. If the last activity was older than yesterday, their `current_streak` resets to 1.
4. The `longest_streak` is automatically updated and persisted.

These updates are now inherently reflected in the existing `/api/gamification/my-streak/` endpoint, allowing the frontend to easily display a "Daily Fire/Streak" counter.

## Type of Change
- [x] New Feature (non-breaking change which adds functionality)

## Verification
- Tested executing code in the sandbox on consecutive virtual days and verified the `current_streak` increments.
- Verified that skipping a day correctly resets the `current_streak` while preserving the `longest_streak`.