### PR TITLE
fix: Service Worker Auto-Update

### DIFF
--- a/frontend/e2e/pwa-update.spec.ts
+++ b/frontend/e2e/pwa-update.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Service Worker Prompt-Based Update Flow", () => {
+  test("displays UpdateAvailableBanner on update detection and does not auto-reload", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    // Dispatch custom PWA update event simulating update detection
+    await page.evaluate(() => {
+      window.dispatchEvent(
+        new CustomEvent("pwa-need-refresh", {
+          detail: {
+            updateSW: (reload?: boolean) => {
+              (window as any).__pwaUpdateTriggered = reload;
+            },
+          },
+        }),
+      );
+    });
+
+    // Verify banner appears
+    const banner = page.locator('[data-testid="pwa-update-banner"]');
+    await expect(banner).toBeVisible();
+    await expect(banner).toContainText("New Version Available");
+
+    // Verify page did not reload automatically without user interaction
+    const isReloaded = await page.evaluate(
+      () => (window as any).__pwaUpdateTriggered,
+    );
+    expect(isReloaded).toBeUndefined();
+
+    // Click "Update Now"
+    await banner.getByRole("button", { name: /Update Now/i }).click();
+
+    // Verify update handler was triggered
+    const wasUpdated = await page.evaluate(
+      () => (window as any).__pwaUpdateTriggered,
+    );
+    expect(wasUpdated).toBe(true);
+  });
+
+  test("dismisses banner when Later is clicked", async ({ page }) => {
+    await page.goto("/");
+
+    await page.evaluate(() => {
+      window.dispatchEvent(
+        new CustomEvent("pwa-need-refresh", {
+          detail: { updateSW: () => {} },
+        }),
+      );
+    });
+
+    const banner = page.locator('[data-testid="pwa-update-banner"]');
+    await expect(banner).toBeVisible();
+
+    await banner.getByRole("button", { name: /Later/i }).click();
+    await expect(banner).not.toBeVisible();
+  });
+});

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -12,6 +12,7 @@ import { WebSocketStatusIndicator } from "../components/WebSocketStatus/WebSocke
 import { CustomCursor } from "../components/CustomCursor";
 import { OfflineBanner } from "../components/ui/OfflineBanner";
 import { InstallAppBanner } from "../components/ui/InstallAppBanner";
+import { UpdateAvailableBanner } from "../components/ui/UpdateAvailableBanner";
 import { ConflictResolutionModal } from "../components/ui/ConflictResolutionModal";
 // Pure React Onboarding Tour Step Definition Type Map
 interface TourStep {
@@ -125,6 +126,7 @@ export function App({ children }: { children?: React.ReactNode }) {
           <div className="min-h-screen bg-white dark:bg-slate-900 text-gray-900 dark:text-gray-100 transition-colors duration-300">
             <OfflineBanner />
             <InstallAppBanner />
+            <UpdateAvailableBanner />
             <ConflictResolutionModal />
             {/* Global Toast Configuration */}
             <Toaster

--- a/frontend/src/components/ui/UpdateAvailableBanner.tsx
+++ b/frontend/src/components/ui/UpdateAvailableBanner.tsx
@@ -1,0 +1,103 @@
+import React, { useState, useEffect } from "react";
+
+interface UpdateAvailableBannerProps {
+  needRefresh?: boolean;
+  onUpdate?: () => void;
+  onDismiss?: () => void;
+}
+
+export const UpdateAvailableBanner: React.FC<UpdateAvailableBannerProps> = ({
+  needRefresh: propNeedRefresh,
+  onUpdate: propOnUpdate,
+  onDismiss: propOnDismiss,
+}) => {
+  const [isVisible, setIsVisible] = useState(false);
+  const [updateHandler, setUpdateHandler] = useState<(() => void) | null>(null);
+
+  useEffect(() => {
+    if (propNeedRefresh) {
+      setIsVisible(true);
+    }
+  }, [propNeedRefresh]);
+
+  useEffect(() => {
+    const handlePwaRefresh = (event: CustomEvent<{ updateSW: (reload?: boolean) => void }>) => {
+      setIsVisible(true);
+      if (event.detail && typeof event.detail.updateSW === "function") {
+        setUpdateHandler(() => () => event.detail.updateSW(true));
+      }
+    };
+
+    window.addEventListener(
+      "pwa-need-refresh" as any,
+      handlePwaRefresh as EventListener,
+    );
+
+    return () => {
+      window.removeEventListener(
+        "pwa-need-refresh" as any,
+        handlePwaRefresh as EventListener,
+      );
+    };
+  }, []);
+
+  const handleUpdate = () => {
+    if (propOnUpdate) {
+      propOnUpdate();
+    } else if (updateHandler) {
+      updateHandler();
+    } else {
+      window.location.reload();
+    }
+    setIsVisible(false);
+  };
+
+  const handleDismiss = () => {
+    setIsVisible(false);
+    if (propOnDismiss) {
+      propOnDismiss();
+    }
+  };
+
+  if (!isVisible) return null;
+
+  return (
+    <div
+      data-testid="pwa-update-banner"
+      role="region"
+      aria-label="Application update available"
+      className="fixed bottom-4 right-4 z-50 max-w-md w-full p-4 bg-surface dark:bg-slate-900 border-4 border-black dark:border-slate-700 rounded-2xl shadow-card-lg animate-in slide-in-from-bottom-5"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <span className="text-2xl p-2 bg-[#ffebc2] border-2 border-black rounded-xl">
+            🚀
+          </span>
+          <div>
+            <h4 className="font-extrabold text-black dark:text-slate-100 text-sm">
+              New Version Available
+            </h4>
+            <p className="text-xs text-muted dark:text-slate-300 mt-0.5 leading-snug">
+              A new version of Atelier is ready. Update now to load the latest features.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex items-center justify-end gap-2 mt-3 pt-2 border-t border-black/10 dark:border-slate-800">
+        <button
+          onClick={handleDismiss}
+          className="px-3 py-1.5 text-xs font-bold text-black dark:text-slate-300 bg-transparent hover:bg-black/5 dark:hover:bg-slate-800 border-2 border-transparent rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+        >
+          Later
+        </button>
+        <button
+          onClick={handleUpdate}
+          className="px-4 py-1.5 text-xs font-extrabold text-black bg-[#4ade80] hover:bg-[#22c55e] border-2 border-black rounded-lg shadow-card-sm transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+        >
+          Update Now
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -47,22 +47,24 @@ const GOOGLE_CLIENT_ID =
   import.meta.env.VITE_GOOGLE_CLIENT_ID ||
   "27042928964-pbolsldqvdv2hfipblmrcf332evg83v8.apps.googleusercontent.com";
 
-// Register Service Worker
+import { registerSW } from "virtual:pwa-register";
+
+// Register Service Worker with prompt-based update flow
 if (typeof window !== "undefined" && "serviceWorker" in navigator) {
   window.addEventListener("load", () => {
-    navigator.serviceWorker
-      .register(import.meta.env.DEV ? "/dev-sw.js?dev-sw" : "/sw.js", {
-        type: import.meta.env.DEV ? "module" : "classic",
-      })
-      .then((registration) => {
-        console.log(
-          "[ServiceWorker] Registered with scope:",
-          registration.scope,
+    const updateSW = registerSW({
+      onNeedRefresh() {
+        console.log("[ServiceWorker] New update available — prompting user.");
+        window.dispatchEvent(
+          new CustomEvent("pwa-need-refresh", {
+            detail: { updateSW },
+          }),
         );
-      })
-      .catch((error) => {
-        console.error("[ServiceWorker] Registration failed:", error);
-      });
+      },
+      onOfflineReady() {
+        console.log("[ServiceWorker] App ready to work offline.");
+      },
+    });
   });
 }
 

--- a/frontend/src/sw.js
+++ b/frontend/src/sw.js
@@ -58,12 +58,31 @@ const DB_VERSION = 2;
 
 self.addEventListener("install", (event) => {
   console.log("[ServiceWorker] Installed");
-  event.waitUntil(self.skipWaiting());
 });
 
 self.addEventListener("activate", (event) => {
   console.log("[ServiceWorker] Activated");
-  event.waitUntil(self.clients.claim());
+  event.waitUntil(
+    (async () => {
+      const windowClients = await self.clients.matchAll({ type: "window" });
+      const hasActiveSession = windowClients.some((client) => {
+        return (
+          client.url.includes("/sandbox") ||
+          client.url.includes("/lessons") ||
+          client.url.includes("/challenges") ||
+          client.url.includes("/chat")
+        );
+      });
+
+      if (hasActiveSession) {
+        console.log(
+          "[ServiceWorker] Active session detected, delaying client claim...",
+        );
+        await new Promise((resolve) => setTimeout(resolve, 60000));
+      }
+      await self.clients.claim();
+    })(),
+  );
 });
 
 self.addEventListener("sync", (event) => {
@@ -75,7 +94,9 @@ self.addEventListener("sync", (event) => {
 
 self.addEventListener("message", (event) => {
   console.log("[ServiceWorker] Message received:", event.data);
-  if (event.data && event.data.type === "TRIGGER_SYNC") {
+  if (event.data && event.data.type === "SKIP_WAITING") {
+    self.skipWaiting();
+  } else if (event.data && event.data.type === "TRIGGER_SYNC") {
     event.waitUntil(syncProgressQueue());
   }
 });

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="vite/client" />
+/// <reference types="vite-plugin-pwa/client" />

--- a/frontend/tests/e2e/pwa-update.spec.ts
+++ b/frontend/tests/e2e/pwa-update.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Service Worker Prompt-Based Update Flow", () => {
+  test("displays UpdateAvailableBanner on update detection and does not auto-reload", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    // Dispatch custom PWA update event simulating update detection
+    await page.evaluate(() => {
+      window.dispatchEvent(
+        new CustomEvent("pwa-need-refresh", {
+          detail: {
+            updateSW: (reload?: boolean) => {
+              (window as any).__pwaUpdateTriggered = reload;
+            },
+          },
+        }),
+      );
+    });
+
+    // Verify banner appears
+    const banner = page.locator('[data-testid="pwa-update-banner"]');
+    await expect(banner).toBeVisible();
+    await expect(banner).toContainText("New Version Available");
+
+    // Verify page did not reload automatically without user interaction
+    const isReloaded = await page.evaluate(
+      () => (window as any).__pwaUpdateTriggered,
+    );
+    expect(isReloaded).toBeUndefined();
+
+    // Click "Update Now"
+    await banner.getByRole("button", { name: /Update Now/i }).click();
+
+    // Verify update handler was triggered
+    const wasUpdated = await page.evaluate(
+      () => (window as any).__pwaUpdateTriggered,
+    );
+    expect(wasUpdated).toBe(true);
+  });
+
+  test("dismisses banner when Later is clicked", async ({ page }) => {
+    await page.goto("/");
+
+    await page.evaluate(() => {
+      window.dispatchEvent(
+        new CustomEvent("pwa-need-refresh", {
+          detail: { updateSW: () => {} },
+        }),
+      );
+    });
+
+    const banner = page.locator('[data-testid="pwa-update-banner"]');
+    await expect(banner).toBeVisible();
+
+    await banner.getByRole("button", { name: /Later/i }).click();
+    await expect(banner).not.toBeVisible();
+  });
+});

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -40,7 +40,7 @@ export default defineConfig({
       strategies: "injectManifest",
       srcDir: "src",
       filename: "sw.js",
-      registerType: "autoUpdate",
+      registerType: "prompt",
       injectManifest: {
         globPatterns: ["**/*.{js,css,html,ico,png,svg,json,md}"],
         maximumFileSizeToCacheInBytes: 7 * 1024 * 1024,


### PR DESCRIPTION
Summary of Work Completed
Vite PWA Prompt Configuration

Changed registerType: "autoUpdate" to registerType: "prompt" in frontend/vite.config.ts.
Added vite-plugin-pwa/client type reference in frontend/src/vite-env.d.ts.
Active Session Protection in Service Worker

Removed auto skipWaiting() from install listener in frontend/src/sw.js
.
Added active session route inspection (/sandbox, /lessons, /challenges, /chat) with 60-second delayed client claiming in activate listener.
Handled SKIP_WAITING message from client.
Update Available Banner UI Component

Created src/components/ui/UpdateAvailableBanner.tsx with "Update Now" and "Later" buttons (data-testid="pwa-update-banner").
Wired registerSW onNeedRefresh callback in frontend/src/main.tsx and rendered banner in frontend/src/app/App.tsx
.
Playwright E2E Tests

Created E2E test in frontend/e2e/pwa-update.spec.ts verifying prompt banner rendering, non-automatic page reload, update triggering, and dismissal.


closes #2067