### PR TITLE
fix(progress): Resolve NameError in ExportNotesView JSON export

### DIFF
--- a/backend/apps/progress/tests/test_notes_export.py
+++ b/backend/apps/progress/tests/test_notes_export.py
@@ -1,0 +1,69 @@
+import json
+
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient, APITestCase
+
+from apps.content.models import Lesson
+from apps.progress.models import UserNote
+
+User = get_user_model()
+
+
+class TestExportNotesView(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="testuser", password="password", email="test@example.com"
+        )
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+
+        self.lesson = Lesson.objects.create(
+            title="Test Lesson",
+            slug="test-lesson",
+            order=1,
+            difficulty="beginner",
+            summary="test",
+            content="test",
+        )
+
+    def test_export_no_notes_404(self):
+        url = reverse("notes-export")
+        response = self.client.get(url, {"format": "json"})
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_export_json_success(self):
+        UserNote.objects.create(
+            user=self.user,
+            lesson=self.lesson,
+            content="This is a test note",
+            tags=["test"],
+        )
+
+        url = reverse("notes-export")
+        response = self.client.get(url, {"format": "json"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response["Content-Type"], "application/json; charset=utf-8")
+
+        data = response.json()
+        self.assertEqual(data["total_notes"], 1)
+        self.assertEqual(data["username"], self.user.username)
+        self.assertEqual(len(data["notes"]), 1)
+        self.assertEqual(data["notes"][0]["content"], "This is a test note")
+
+    def test_export_markdown_success(self):
+        UserNote.objects.create(
+            user=self.user,
+            lesson=self.lesson,
+            content="This is a test note",
+            tags=["test"],
+        )
+
+        url = reverse("notes-export")
+        response = self.client.get(url, {"format": "md"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response["Content-Type"], "text/markdown; charset=utf-8")
+        self.assertIn(b"This is a test note", response.content)

--- a/backend/apps/progress/views.py
+++ b/backend/apps/progress/views.py
@@ -1,28 +1,32 @@
+import json
 import uuid  # NEW: Added for cryptographic nonce generation
-from datetime import datetime, timezone as dt_timezone
+from datetime import datetime
+from datetime import timezone as dt_timezone
 
 from django.contrib.auth import get_user_model
 
 User = get_user_model()
+from django.core.cache import cache
 from django.db import transaction
-from django.utils import timezone
 from django.db.models import Count, Min, Sum
-from apps.progress.constants import XP_PER_LEVEL
-from apps.progress.models import XPEvent
+from django.http import HttpResponse
 from django.shortcuts import get_object_or_404
+from django.utils import timezone
 from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_view
 from rest_framework import permissions, status
 from rest_framework.generics import ListAPIView
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import BasePermission
 from rest_framework.response import Response
-from apps.core.throttling import SlidingWindowAnonThrottle, SlidingWindowScopedThrottle
 from rest_framework.views import APIView
-from django.http import HttpResponse
-from django.core.cache import cache
-from apps.content.serializers import LessonSerializer
-from apps.content.models import Lesson
 
+from apps.content.models import Lesson
+from apps.content.serializers import LessonSerializer
+from apps.core.throttling import SlidingWindowAnonThrottle, SlidingWindowScopedThrottle
+from apps.progress.constants import XP_PER_LEVEL
+from apps.progress.models import XPEvent
+
+from .models import UserNote  # ✅ ADD: UserNote model
 from .models import (
     Badge,
     Certificate,
@@ -33,17 +37,16 @@ from .models import (
     LessonProgress,
     QuizAttempt,
     UserBadge,
-    UserNote,  # ✅ ADD: UserNote model
 )
 from .serializers import (
     BadgeSerializer,
     BulkSyncSerializer,
     CertificateVerificationSerializer,
+    DailyProgressSerializer,
     HelpRequestSerializer,
     LessonProgressCreateSerializer,
     LessonProgressSerializer,
     QuizAttemptSerializer,
-    DailyProgressSerializer,
 )
 from .throttles import HelpRequestRateThrottle
 
@@ -253,11 +256,11 @@ class MyProgressView(APIView):
         return Response(serializer.data)
 
     def post(self, request):
+        from apps.content.models import Lesson
+        from apps.progress.services.progress_buffer import ProgressBufferService
         from apps.progress.services.progress_tracking_service import (
             ProgressTrackingService,
         )
-        from apps.progress.services.progress_buffer import ProgressBufferService
-        from apps.content.models import Lesson
 
         lesson_slug = request.data.get("lesson_slug")
         idempotency_key = request.data.get("idempotency_key")
@@ -376,9 +379,9 @@ class BulkProgressUpdateView(APIView):
         validated_data = serializer.validated_data["lessons"]
 
         from apps.progress.services.progress_batch_service import (
-            process_bulk_progress_updates,
             DuplicateEntryException,
             InvalidLessonException,
+            process_bulk_progress_updates,
         )
 
         try:
@@ -1296,15 +1299,17 @@ class HeatmapView(APIView):
         from django.contrib.auth import get_user_model
 
         User = get_user_model()
-        from django.shortcuts import get_object_or_404
-        from apps.progress.models import (
-            DailyActivity,
-            LessonProgress,
-            QuizAttempt,
-            ExerciseAttempt,
-        )
         import datetime
         from collections import defaultdict
+
+        from django.shortcuts import get_object_or_404
+
+        from apps.progress.models import (
+            DailyActivity,
+            ExerciseAttempt,
+            LessonProgress,
+            QuizAttempt,
+        )
 
         username = request.query_params.get("username")
         if username:
@@ -1468,16 +1473,18 @@ class HeatmapCSVExportView(APIView):
     permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request):
-        from apps.progress.models import (
-            DailyActivity,
-            LessonProgress,
-            QuizAttempt,
-            ExerciseAttempt,
-        )
+        import csv
         import datetime
         from collections import defaultdict
-        import csv
+
         from django.http import HttpResponse
+
+        from apps.progress.models import (
+            DailyActivity,
+            ExerciseAttempt,
+            LessonProgress,
+            QuizAttempt,
+        )
 
         user = request.user
 


### PR DESCRIPTION
## Description

Resolves a `NameError` crash occurring on the `GET /api/progress/notes/export/?format=json` endpoint because the `json` module wasn't imported. Also adds dedicated test coverage for the `ExportNotesView` to prevent regressions on both the JSON and Markdown export paths.

Fixes #2005

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update (no code changes)
- [ ] ⚙️ CI/CD or build pipeline change
- [ ] ⚡ Performance optimization
- [ ] 🛠️ Refactoring (no functional changes)

## How Has This Been Tested?

Added robust unit tests in `test_notes_export.py` covering:
- Valid `?format=json` request handling (properly parsing JSON output).
- Valid `?format=md` default handling.
- `404 Not Found` response when the user attempts to export zero notes.

### Automated Tests
- [x] Backend tests pass: `cd backend && pytest`
- [ ] Frontend tests pass: `cd frontend && npm run test`
- [ ] Frontend builds successfully: `cd frontend && npm run build`

### Manual Verification
- Verified the code locally utilizing pytest on `test_notes_export.py`.

## Pre-Push Checklist

> [!IMPORTANT]
> **All items below must be checked before requesting a review.** Our CI bot will automatically run the frontend build and backend tests on your PR. If CI fails, you will receive a comment explaining what went wrong.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or console errors
- [ ] I have run `npm run build` in `frontend/` and it completes with **0 errors**
- [x] I have run `pytest` in `backend/` and all tests pass
- [x] I have run `git diff` locally and verified my changes

## Deployment Notes

> [!NOTE]
> This project is deployed on **Vercel** (Frontend) and **Hugging Face** (Backend). The CI workflow simulates both deployment environments. If your PR passes CI, it is safe to merge.

No special migration or deployment steps required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authenticated note exports in JSON and Markdown formats.
  * Added one-time quiz submission protection using short-lived validation tokens.
* **Bug Fixes**
  * Prevented duplicate or replayed quiz submissions by rejecting missing, invalid, or expired tokens.
  * Note exports now clearly handle accounts with no notes.
* **Tests**
  * Added coverage for successful JSON and Markdown exports, empty-note responses, and quiz submission validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->