### PR TITLE
fix(security): Prevent wildcard ALLOWED_HOSTS in production (#1735)

### DIFF
--- a/backend/apps/core/tests/test_security.py
+++ b/backend/apps/core/tests/test_security.py
@@ -1,0 +1,15 @@
+import pytest
+from django.test import Client
+
+@pytest.mark.django_db
+def test_host_header_validation_rejects_unallowed_hosts():
+    """
+    Ensures that Host header validation is active and rejects unknown hosts.
+    This prevents Host header injection vulnerabilities.
+    """
+    client = Client()
+    
+    # An arbitrary unknown host should be rejected with a 400 Bad Request
+    response = client.get("/health/", HTTP_HOST="malicious-attacker.com")
+    
+    assert response.status_code == 400

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -3,8 +3,9 @@ import os
 import sys
 from datetime import timedelta
 from pathlib import Path
-import stripe
+
 import dj_database_url
+import stripe
 
 # pyrefly: ignore [missing-import]
 from django.core.exceptions import ImproperlyConfigured
@@ -93,11 +94,15 @@ CONTENT_SECURITY_POLICY = (
 
 TESTING = "test" in sys.argv or "pytest" in sys.modules
 
-ALLOWED_HOSTS = [
-    host.strip()
-    for host in os.getenv("ALLOWED_HOSTS", "localhost,127.0.0.1").split(",")
-    if host.strip()
-]
+_raw_hosts = os.getenv("ALLOWED_HOSTS", "localhost,127.0.0.1").split(",")
+ALLOWED_HOSTS = [host.strip() for host in _raw_hosts if host.strip()]
+
+if not DEBUG and "*" in ALLOWED_HOSTS:
+    ALLOWED_HOSTS.remove("*")
+
+_render_host = os.getenv("RENDER_EXTERNAL_HOSTNAME")
+if _render_host and _render_host not in ALLOWED_HOSTS:
+    ALLOWED_HOSTS.append(_render_host)
 
 if not DEBUG and not TESTING and not ALLOWED_HOSTS:
     from django.core.exceptions import ImproperlyConfigured


### PR DESCRIPTION
## Description

Removes the wildcard `*` fallback for `ALLOWED_HOSTS` in production to prevent Host header injection vulnerabilities. Automatically injects `RENDER_EXTERNAL_HOSTNAME` to seamlessly support dynamic Render environments and PR previews.

Fixes #1735

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🔒 Security fix

## How Has This Been Tested?

### Automated Tests
- [x] Backend tests pass: `cd backend && pytest` *(Note: added explicit `test_security.py` to assert rejection of malicious Host headers)*

## Pre-Push Checklist

> [!IMPORTANT]
> **All items below must be checked before requesting a review.**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or console errors
- [x] I have run `pytest` in `backend/` and all tests pass
- [x] I have run `git diff` locally and verified my changes
