### PR TITLE
refactor: remove unreachable return in LessonBookmarkView.delete

### DIFF
--- a/backend/apps/progress/views.py
+++ b/backend/apps/progress/views.py
@@ -1157,8 +1157,6 @@ class LessonBookmarkView(APIView):
 
         return Response(status=status.HTTP_204_NO_CONTENT)
 
-        return Response(status=status.HTTP_204_NO_CONTENT)
-
 
 class ReadingProgressView(APIView):
     permission_classes = [permissions.IsAuthenticated]


### PR DESCRIPTION
## Summary

Removes an unreachable duplicate `return Response(status=status.HTTP_204_NO_CONTENT)` statement from `LessonBookmarkView.delete`.

## Changes

- Removed the duplicate unreachable return statement.
- Preserved the existing behaviour of the endpoint.

## Why

The second `return Response(status=status.HTTP_204_NO_CONTENT)` could never be executed because the method already returns immediately after the first one. Removing it improves code readability and maintainability without changing functionality.

## Testing

- Verified that only the unreachable duplicate return statement was removed.
- No functional changes were introduced.

closes #2130