### PR TITLE
fix: use shared QueryClient in QueryProvider

### DIFF
--- a/frontend/src/QueryProvider.tsx
+++ b/frontend/src/QueryProvider.tsx
@@ -1,9 +1,15 @@
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode } from "react";
+import { queryClient } from "./lib/queryClient";
 
-const queryClient = new QueryClient();
+interface QueryProviderProps {
+  children: ReactNode;
+}
 
-export function QueryProvider({ children }) {
+export function QueryProvider({ children }: QueryProviderProps) {
   return (
-    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    <QueryClientProvider client={queryClient}>
+      {children}
+    </QueryClientProvider>
   );
 }


### PR DESCRIPTION
## Summary

This PR fixes #2004 by updating `QueryProvider` to use the shared `queryClient` instance from `frontend/src/lib/queryClient` instead of creating a new `QueryClient`.

### Changes
- Removed the locally instantiated `QueryClient`.
- Imported and used the shared `queryClient`.
- Ensures global React Query configurations (such as `staleTime`, `gcTime`, retry policy, `networkMode`, and event listeners) are consistently applied across the application.

### Testing
- Verified the application runs successfully with `npm run dev`.

Closes #2004

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the app’s shared data-query configuration for more consistent behavior.
  * Added stronger type safety around content rendered through the query provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->