### PR TITLE
fix(admin): resolve crashing dashboard due to missing imports

### DIFF
--- a/backend/apps/admin/services.py
+++ b/backend/apps/admin/services.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 
 from django.contrib.auth import get_user_model
-from django.db.models import Avg, Count, Q
+from django.db.models import Avg, Count, Q, F
 from django.utils import timezone
 
 from apps.dashboard.models import PullRequest
@@ -28,10 +28,10 @@ class ProductivityService:
             issues_closed = issues.filter(closed_at__isnull=False)
 
             # Average review time
-            avg_review_time = prs_closed.aggregate(avg=Avg("closed_at" - "created_at"))[
-                "avg"
-            ]
-
+            avg_review_time = prs_closed.aggregate(
+                avg=Avg(F('closed_at') - F('created_at'))
+            )['avg']
+            
             # Stalled PRs
             stalled = prs.filter(updated_at__lte=timezone.now() - timedelta(days=7))
 

--- a/backend/apps/admin/views.py
+++ b/backend/apps/admin/views.py
@@ -1,14 +1,20 @@
 import csv
+from datetime import timedelta
+import csv
 
+from django.contrib.auth import get_user_model
+from django.db.models import Q
 from django.http import HttpResponse
+from django.utils import timezone
 from rest_framework.permissions import IsAdminUser
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from apps.dashboard.models import PullRequest
 from .serializers import ProductivitySerializer
 from .services import ProductivityService
 
-
+User = get_user_model()
 class ProductivityDashboardView(APIView):
     permission_classes = [IsAdminUser]
 


### PR DESCRIPTION
## Description
Closes #2187

This PR resolves the critical dashboard crashes in the `admin` app caused by missing module imports and incorrect `Avg` aggregation syntax.

## Key Changes
- **Fixed Imports:** Added missing imports (`timezone`, `timedelta`, `Q`, `User`, `PullRequest`, `csv`, `HttpResponse`) to `backend/apps/admin/views.py`.
- **Fixed Query Aggregation:** Corrected the string subtraction `Avg('closed_at' - 'created_at')` in `backend/apps/admin/services.py` by utilizing Django's `F` expression (`Avg(F('closed_at') - F('created_at'))`).

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the accuracy of average review-time metrics in administrative reporting.
  - Improved administrative activity and contributor metrics by applying more reliable user and time-based filtering.
  - Preserved existing administrative interfaces and workflows while correcting metric calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->