### PR TITLE
fix(store): disable app state reset on location change to prevent store wipe

### DIFF
--- a/frontend/src/store/middleware/cleanupMiddleware.ts
+++ b/frontend/src/store/middleware/cleanupMiddleware.ts
@@ -2,8 +2,8 @@ import { Middleware } from "@reduxjs/toolkit";
 
 export const cleanupMiddleware: Middleware = (store) => (next) => (action: any) => {
   if (action && action.type === "LOCATION_CHANGE") {
-    // Dispatch RESET_APP_STATE when location changes to trigger page-level slice cleanup
-    store.dispatch({ type: "RESET_APP_STATE", payload: action.payload });
+    // Disabled RESET_APP_STATE as it was wiping the entire Redux store on navigation.
+    // store.dispatch({ type: "RESET_APP_STATE", payload: action.payload });
   }
   return next(action);
 };


### PR DESCRIPTION
## Description
Closes #2188

This PR prevents the Redux store from being completely wiped whenever the user navigates between pages on the frontend.

## Key Changes
- **Disabled Global Reset:** Modified `frontend/src/store/middleware/cleanupMiddleware.ts` to disable the overly-aggressive `RESET_APP_STATE` dispatch on every `LOCATION_CHANGE` action.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)