### PR TITLE
feat(predictions): time-scope delay alert deduplication to 48 hours

### DIFF
--- a/backend/apps/predictions/tasks.py
+++ b/backend/apps/predictions/tasks.py
@@ -1,6 +1,8 @@
 import logging
 
 import numpy as np
+from datetime import timedelta
+from django.utils import timezone
 from celery import shared_task
 
 from .ml_engine import predictor
@@ -50,9 +52,11 @@ def monitor_pr_review_delays():
 
         # Trigger automated delay alert for HIGH or CRITICAL risk (with deduplication)
         if res["risk_level"] in ["HIGH", "CRITICAL"]:
+            time_threshold = timezone.now() - timedelta(hours=48)
             existing_alert = DelayAlert.objects.filter(
                 prediction__pr=pr,
                 prediction__risk_level__in=["HIGH", "CRITICAL"],
+                created_at__gte=time_threshold
             ).exists()
 
             if not existing_alert:


### PR DESCRIPTION
## Description
This PR addresses an edge case where predicting a HIGH/CRITICAL PR stagnation risk would permanently silence all future alerts for that PR, even if the PR recovers and stagnates again weeks later.
Closes #2190 
## Key Changes
- **Time-Scoped Deduplication:** Updated `monitor_pr_review_delays` in `backend/apps/predictions/tasks.py` to scope alert deduplication by time. Delay alerts are now only suppressed if a similar alert was generated for that PR within the last **48 hours**.

## Type of Change
- [x] Enhancement (non-breaking change which improves functionality)