### PR TITLE
fix: Implement PKCE and state validation for GitHub OAuth (#2053)

### DIFF
--- a/backend/apps/accounts/tests/test_oauth.py
+++ b/backend/apps/accounts/tests/test_oauth.py
@@ -1,0 +1,101 @@
+import time
+from unittest.mock import patch
+
+from django.test import Client, TestCase
+from django.urls import reverse
+
+
+class OAuthSecurityTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.callback_url = reverse("github-callback")
+
+    def test_missing_state_returns_401(self):
+        response = self.client.get(self.callback_url, {"code": "some-code"})
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.json()["detail"], "Missing state parameter.")
+
+    def test_invalid_session_state_returns_401(self):
+        # State parameter is present, but no session state exists
+        response = self.client.get(
+            self.callback_url, {"code": "some-code", "state": "some-state"}
+        )
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.json()["detail"], "OAuth session expired or invalid.")
+
+    def test_mismatched_state_returns_401(self):
+        session = self.client.session
+        session["github_oauth_state"] = {
+            "value": "valid-state",
+            "created_at": time.time(),
+        }
+        session["github_oauth_verifier"] = "valid-verifier"
+        session.save()
+
+        response = self.client.get(
+            self.callback_url, {"code": "some-code", "state": "attacker-state"}
+        )
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.json()["detail"], "Invalid OAuth state.")
+
+    def test_expired_state_returns_401(self):
+        session = self.client.session
+        # Set state created_at to 11 minutes ago (expired)
+        session["github_oauth_state"] = {
+            "value": "valid-state",
+            "created_at": time.time() - 660,
+        }
+        session["github_oauth_verifier"] = "valid-verifier"
+        session.save()
+
+        response = self.client.get(
+            self.callback_url, {"code": "some-code", "state": "valid-state"}
+        )
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.json()["detail"], "OAuth state expired.")
+
+    def test_replay_attack_fails(self):
+        session = self.client.session
+        session["github_oauth_state"] = {
+            "value": "valid-state",
+            "created_at": time.time(),
+        }
+        session["github_oauth_verifier"] = "valid-verifier"
+        session.save()
+
+        # Mock requests so it doesn't try to hit GitHub
+        with patch("apps.accounts.views.http_requests.post") as mock_post:
+            with patch("apps.accounts.views.http_requests.get") as mock_get:
+                mock_post.return_value.ok = True
+                mock_post.return_value.json.return_value = {"access_token": "token"}
+
+                mock_get.return_value.ok = True
+                mock_get.return_value.json.return_value = {"email": "test@example.com"}
+
+                # First request should succeed and pop the session state
+                response = self.client.get(
+                    self.callback_url, {"code": "some-code", "state": "valid-state"}
+                )
+                self.assertEqual(response.status_code, 302)
+
+        # Second request with the same state should fail because state was popped
+        response = self.client.get(
+            self.callback_url, {"code": "some-code", "state": "valid-state"}
+        )
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.json()["detail"], "OAuth session expired or invalid.")
+
+    def test_missing_pkce_verifier_returns_401(self):
+        session = self.client.session
+        session["github_oauth_state"] = {
+            "value": "valid-state",
+            "created_at": time.time(),
+        }
+        # Intentionally missing github_oauth_verifier
+        session.save()
+
+        response = self.client.get(
+            self.callback_url, {"code": "some-code", "state": "valid-state"}
+        )
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.json()["detail"], "OAuth session expired or invalid.")

--- a/backend/apps/accounts/throttles.py
+++ b/backend/apps/accounts/throttles.py
@@ -100,6 +100,7 @@ class RedisLuaRateLimiter:
 
         return allowed, current_count, ttl_remaining
 
+
 from apps.core.throttling import SlidingWindowAnonThrottle
 
 
@@ -119,19 +120,18 @@ def _get_real_ip(request) -> str:
     return request.META.get("REMOTE_ADDR", "")
 
 
-
 class BaseDistributedThrottle(SimpleRateThrottle):
     """
     Base throttle that uses Redis Lua scripting when settings.RATE_LIMIT_BACKEND == "redis".
     Falls back to local cache implementation if "local" or when Redis is down.
     """
 
-class _ProxyAwareThrottle(SlidingWindowAnonThrottle): # type: ignore
+
+class _ProxyAwareThrottle(SlidingWindowAnonThrottle):  # type: ignore
     """Base class that uses the proxy-aware IP resolver for cache keys."""
 
-
-    num_requests: int # type: ignore
-    duration: int # type: ignore
+    num_requests: int  # type: ignore
+    duration: int  # type: ignore
 
     def allow_request(self, request, view):
         if self.rate is None:
@@ -286,3 +286,7 @@ class MagicLinkVerifyThrottle(_ProxyAwareThrottle):
 
 class OAuthThrottle(_ProxyAwareThrottle):
     scope = "auth_oauth"
+
+
+class GitHubOAuthCallbackThrottle(_ProxyAwareThrottle):
+    scope = "auth_github_callback"

--- a/backend/apps/accounts/views.py
+++ b/backend/apps/accounts/views.py
@@ -1,8 +1,11 @@
 import logging
 
 logger = logging.getLogger(__name__)
+import base64
+import hashlib
 import os
 import secrets
+import time
 from pathlib import Path
 from typing import Optional
 from urllib.parse import urlencode
@@ -69,6 +72,7 @@ from .tasks import (
     send_password_reset_email_task,
 )
 from .throttles import (
+    GitHubOAuthCallbackThrottle,
     LoginThrottle,
     MagicLinkRequestThrottle,
     MagicLinkVerifyThrottle,
@@ -336,12 +340,31 @@ class GitHubOAuthStartView(APIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
+        state = secrets.token_urlsafe(32)
+        code_verifier = secrets.token_urlsafe(64)
+        code_challenge = (
+            base64.urlsafe_b64encode(
+                hashlib.sha256(code_verifier.encode("ascii")).digest()
+            )
+            .decode("ascii")
+            .rstrip("=")
+        )
+
+        request.session["github_oauth_state"] = {
+            "value": state,
+            "created_at": time.time(),
+        }
+        request.session["github_oauth_verifier"] = code_verifier
+
         callback_url = request.build_absolute_uri("/api/auth/github/callback/")
         params = urlencode(
             {
                 "client_id": client_id,
                 "redirect_uri": callback_url,
                 "scope": "read:user user:email",
+                "state": state,
+                "code_challenge": code_challenge,
+                "code_challenge_method": "S256",
             }
         )
         return redirect(f"https://github.com/login/oauth/authorize?{params}")
@@ -349,10 +372,12 @@ class GitHubOAuthStartView(APIView):
 
 class GitHubOAuthCallbackView(APIView):
     permission_classes = [permissions.AllowAny]
-    throttle_classes = [OAuthThrottle]
+    throttle_classes = [GitHubOAuthCallbackThrottle]
 
     def get(self, request):
         code = request.query_params.get("code")
+        state = request.query_params.get("state")
+
         if not code:
             return redirect(
                 frontend_url("/", {"auth_error": "GitHub authorization was cancelled."})
@@ -363,6 +388,31 @@ class GitHubOAuthCallbackView(APIView):
         if not client_id or not client_secret:
             return redirect(
                 frontend_url("/", {"auth_error": "GitHub OAuth is not configured."})
+            )
+
+        if not state:
+            return Response(
+                {"detail": "Missing state parameter."},
+                status=status.HTTP_401_UNAUTHORIZED,
+            )
+
+        session_state = request.session.pop("github_oauth_state", None)
+        code_verifier = request.session.pop("github_oauth_verifier", None)
+
+        if not session_state or not code_verifier:
+            return Response(
+                {"detail": "OAuth session expired or invalid."},
+                status=status.HTTP_401_UNAUTHORIZED,
+            )
+
+        if state != session_state.get("value"):
+            return Response(
+                {"detail": "Invalid OAuth state."}, status=status.HTTP_401_UNAUTHORIZED
+            )
+
+        if time.time() - session_state.get("created_at", 0) > 600:
+            return Response(
+                {"detail": "OAuth state expired."}, status=status.HTTP_401_UNAUTHORIZED
             )
 
         callback_url = request.build_absolute_uri("/api/auth/github/callback/")
@@ -380,6 +430,7 @@ class GitHubOAuthCallbackView(APIView):
                         "client_secret": client_secret,
                         "code": code,
                         "redirect_uri": callback_url,
+                        "code_verifier": code_verifier,
                     },
                     timeout=5,
                 )

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -27,9 +27,11 @@ STRIPE_WEBHOOK_SECRET = os.getenv("STRIPE_WEBHOOK_SECRET")
 
 stripe.api_key = STRIPE_SECRET_KEY
 
+
 def load_dotenv(dotenv_path: Path) -> None:
     if not dotenv_path.exists():
         return
+
 
 from dotenv import load_dotenv
 
@@ -483,6 +485,7 @@ REST_FRAMEWORK = {
         "auth_otp_verify": os.getenv("RATE_AUTH_OTP_VERIFY", "5/minute"),
         "auth_password_reset": os.getenv("RATE_AUTH_PASSWORD_RESET", "3/hour"),
         "auth_oauth": os.getenv("RATE_AUTH_OAUTH", "20/minute"),
+        "auth_github_callback": "5/minute",
         "auth_magic_link_request": os.getenv(
             "RATE_AUTH_MAGIC_LINK_REQUEST", "3/minute"
         ),
@@ -868,4 +871,3 @@ TESTING = ("test" in sys.argv) or any("pytest" in arg for arg in sys.argv)
 if TESTING:
     CELERY_TASK_ALWAYS_EAGER = True
     CELERY_TASK_EAGER_PROPAGATES = True
-


### PR DESCRIPTION
## Description

Fixes #2053

This PR addresses the CSRF and account takeover vulnerabilities in the GitHub OAuth flow by enforcing strict state tracking and PKCE validation.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🔒 Security fix

## How Has This Been Tested?
### Automated Tests
- [x] Backend tests pass: `cd backend && pytest apps/accounts/tests/test_oauth.py`
  - Validated missing `state` parameter returns 401
  - Validated mismatched/missing session state returns 401
  - Validated state expiry (>10 minutes) returns 401
  - Validated replay attack fails due to session pop returning 401

## Pre-Push Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have run `pytest` in `backend/` and all tests pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Strengthened GitHub OAuth sign-in with state validation and PKCE protection.
  * Added safeguards against expired, invalid, missing, and replayed OAuth callbacks.
  * Added dedicated rate limiting for GitHub OAuth callbacks.

* **Bug Fixes**
  * Improved handling of incomplete OAuth sessions with clear unauthorized responses.

* **Tests**
  * Added coverage for OAuth callback security scenarios, including state and PKCE validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->