### PR TITLE
fix: resolve RuntimeWarning during backend app initialization (#2160)

### DIFF
--- a/backend/apps/accounts/apps.py
+++ b/backend/apps/accounts/apps.py
@@ -9,9 +9,14 @@ class AccountsConfig(AppConfig):
     name = "apps.accounts"
 
     def ready(self):
+        from django.db.models.signals import post_migrate
+
         import apps.accounts.receivers  # noqa: F401
         import apps.accounts.signals  # noqa: F401
 
+        post_migrate.connect(self.setup_initial_data, sender=self)
+
+    def setup_initial_data(self, sender, **kwargs):
         try:
             from django_q.models import Schedule
 

--- a/backend/apps/core/apps.py
+++ b/backend/apps/core/apps.py
@@ -30,6 +30,11 @@ class CoreConfig(AppConfig):
         except ImportError:
             pass
 
+        from django.db.models.signals import post_migrate
+
+        post_migrate.connect(self.setup_initial_data, sender=self)
+
+    def setup_initial_data(self, sender, **kwargs):
         try:
             from django_q.models import Schedule
 

--- a/backend/apps/gamification/apps.py
+++ b/backend/apps/gamification/apps.py
@@ -9,8 +9,13 @@ class GamificationConfig(AppConfig):
     name = "apps.gamification"
 
     def ready(self):
+        from django.db.models.signals import post_migrate
+
         import apps.gamification.signals  # noqa: F401
 
+        post_migrate.connect(self.setup_initial_data, sender=self)
+
+    def setup_initial_data(self, sender, **kwargs):
         try:
             from django_q.models import Schedule
 

--- a/backend/apps/progress/apps.py
+++ b/backend/apps/progress/apps.py
@@ -9,8 +9,13 @@ class ProgressConfig(AppConfig):
     name = "apps.progress"
 
     def ready(self):
+        from django.db.models.signals import post_migrate
+
         import apps.progress.signals  # noqa: F401
 
+        post_migrate.connect(self.setup_initial_data, sender=self)
+
+    def setup_initial_data(self, sender, **kwargs):
         # Register Django-Q schedule for weekly progress summary
         try:
             from django_q.models import Schedule

--- a/backend/apps/sandbox/apps.py
+++ b/backend/apps/sandbox/apps.py
@@ -10,6 +10,15 @@ class SandboxConfig(AppConfig):
 
         logger = logging.getLogger(__name__)
 
+        from django.db.models.signals import post_migrate
+
+        post_migrate.connect(self.setup_initial_data, sender=self)
+
+    def setup_initial_data(self, sender, **kwargs):
+        import logging
+
+        logger = logging.getLogger(__name__)
+
         try:
             from django_q.models import Schedule
 


### PR DESCRIPTION
## Description

Resolves the `RuntimeWarning: Accessing the database during app initialization is discouraged` warning on backend startup. This PR refactors the database queries (like `Schedule.objects.get_or_create`) out of the `ready()` methods across several apps (`accounts`, `core`, `gamification`, `progress`, `sandbox`). The seeding logic has been moved to a `post_migrate` signal handler to ensure it only executes after the apps are loaded and tables are fully created, adhering to Django best practices.

Fixes #2160

## 🏆 Program Participation
- [x] **Social Summer of Code (SSoC 2026)**
- [ ] **Elite Coder Summer of Code (ECSoC 2026)**

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update (no code changes)
- [ ] ⚙️ CI/CD or build pipeline change
- [ ] ⚡ Performance optimization
- [ ] 🛠️ Refactoring (no functional changes)

## Screenshots / Recordings

<!-- For UI changes, paste before/after screenshots or screen recordings here. Delete this section if not applicable. -->

## How Has This Been Tested?

The backend successfully starts without throwing the `RuntimeWarning` caused by database queries during app initialization. The default scheduled tasks and items are still seeded correctly upon running `python manage.py migrate`.

### Automated Tests
- [x] Backend tests pass: `cd backend && pytest`
- [x] Frontend tests pass: `cd frontend && npm run test`
- [x] Frontend builds successfully: `cd frontend && npm run build`

### Manual Verification
Manually verified `runserver` startup logs and verified that the `post_migrate` signal runs the seeding code when the `migrate` command is issued.

## Pre-Push Checklist

> [!IMPORTANT]
> **All items below must be checked before requesting a review.** Our CI bot and CodeRabbit AI will automatically run build/test checks and review your PR. If CI fails, you will receive a comment explaining what went wrong.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or console errors
- [x] I have run `npm run build` in `frontend/` and it completes with **0 errors**
- [x] I have run `pytest` in `backend/` and all tests pass
- [x] I have run `git diff` locally and verified my changes

## Deployment Notes

> [!NOTE]
> This project is deployed on **Vercel** (Frontend) and **Hugging Face** (Backend). The CI workflow simulates both deployment environments. If your PR passes CI, it is safe to merge.

Since these queries were previously evaluated on every server start and they now only evaluate upon migration, Hugging Face deployment initialization logs will be cleaner and boot slightly faster.
