### PR TITLE
feat: display last updated date on lesson pages

### DIFF
--- a/frontend/src/lib/lessons.ts
+++ b/frontend/src/lib/lessons.ts
@@ -70,6 +70,7 @@ export interface Lesson {
   jsExercise?: JSExercise;
   debugExercise?: DebugExercise;
   category?: string;
+  updatedAt?: string;
 }
 
 // Small built-in fallback lessons (used if API unreachable)
@@ -135,6 +136,11 @@ function mapApiLessons(data: unknown[]): Lesson[] {
       order: Number(les.order ?? index),
       category: String(les.category ?? "general"),
       filePath: les.filePath ? String(les.filePath) : undefined,
+      updatedAt: les.updatedAt
+        ? String(les.updatedAt)
+        : les.updated_at
+          ? String(les.updated_at)
+          : undefined,
     } satisfies Lesson;
   });
 }

--- a/frontend/src/pages/LessonPage.tsx
+++ b/frontend/src/pages/LessonPage.tsx
@@ -948,6 +948,12 @@ export function LessonPage() {
                       }
                     >
                       <MarkdownRenderer content={markdownContent} />
+                      {lesson?.updatedAt && (
+                        <div className="mt-8 border-t pt-4 text-sm text-muted-foreground">
+                          <strong>Last updated:</strong>{" "}
+                          {new Date(lesson.updatedAt).toLocaleDateString()}
+                       </div>
+                      )}
                     </React.Suspense>
                   </article>
                 </>


### PR DESCRIPTION
## Summary

Adds support for displaying the last updated date on lesson pages when the information is available from the API.

## Changes Made

- Added an optional `updatedAt` field to the `Lesson` interface.
- Mapped both `updatedAt` and `updated_at` from the lesson API response.
- Displayed the "Last updated" date below the lesson content when a valid timestamp is available.
- Preserved existing behaviour when no update date is provided by the API.

## Testing

- ✅ `npm run lint` completed successfully (0 errors, existing repository warnings only).
- ⚠️ `npm run dev` could not be fully verified due to an existing repository dependency issue (`codemirror-spell-checker`) unrelated to this change.

Closes #2254

