### PR TITLE
fix(ui): deduplicate toast notifications in ToastContext

### DIFF
--- a/frontend/src/features/ui/ToastContext.test.tsx
+++ b/frontend/src/features/ui/ToastContext.test.tsx
@@ -202,4 +202,32 @@ describe("ToastContext Edge Cases", () => {
     expect(screen.queryByText("Toast 2")).not.toBeInTheDocument();
     expect(screen.getByText("Toast 3")).toBeInTheDocument();
   });
+
+  it("deduplicates duplicate toasts with identical message and type", async () => {
+    const DuplicateToastComponent = () => {
+      const { addToast } = useToast();
+      return (
+        <button
+          onClick={() => {
+            addToast("Correct!", "success", 5000);
+            addToast("Correct!", "success", 5000);
+            addToast("Correct!", "success", 5000);
+          }}
+        >
+          Trigger Duplicates
+        </button>
+      );
+    };
+
+    render(
+      <ToastProvider>
+        <DuplicateToastComponent />
+      </ToastProvider>,
+    );
+
+    fireEvent.click(screen.getByText("Trigger Duplicates"));
+
+    const elements = screen.getAllByText("Correct!");
+    expect(elements).toHaveLength(1);
+  });
 });

--- a/frontend/src/features/ui/ToastContext.tsx
+++ b/frontend/src/features/ui/ToastContext.tsx
@@ -36,7 +36,10 @@ export const ToastProvider: React.FC<{ children: ReactNode }> = ({
   const addToast = useCallback(
     (message: string, type: ToastType, duration: number = 5000) => {
       const id = Math.random().toString(36).substring(2, 9);
-      setToasts((prev) => [...prev, { id, message, type, duration }]);
+      setToasts((prev) => [
+        ...prev.filter((t) => !(t.message === message && t.type === type)),
+        { id, message, type, duration },
+      ]);
 
       if (duration > 0) {
         setTimeout(() => {


### PR DESCRIPTION
### Summary
Fixes an issue where rapid user interactions (such as quickly completing multiple quiz questions using keyboard shortcuts) caused toast notifications to stack duplicate messages (e.g. 6 "Correct!" toasts rendered simultaneously).

### Changes Made
- Updated `addToast` in [ToastContext.tsx](file:///c:/Users/babin/Desktop/ECSoC_2026/Open-Source-Contribution-Atelier/frontend/src/features/ui/ToastContext.tsx) to filter out existing active toasts with matching `message` and `type` before appending new ones.
- Retained support for distinct toast messages stacking as expected.
- Added comprehensive unit tests in [ToastContext.test.tsx](file:///c:/Users/babin/Desktop/ECSoC_2026/Open-Source-Contribution-Atelier/frontend/src/features/ui/ToastContext.test.tsx) verifying rapid duplicate toast triggers yield at most 1 visible toast.

### Scope & Checklist
- [x] Frontend UI changes (`Frontend only`)
- [x] ECSoC 2026
- [x] Tested locally with unit tests (`vitest`)

Closes #2279


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate toast notifications from appearing when the same message and type are triggered repeatedly.
  * Existing matching notifications are replaced instead of accumulating multiple identical toasts.

* **Tests**
  * Added coverage to verify toast deduplication behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->