### PR TITLE
fix(content): parse code spans first to allow pipe characters in markdown tables

### DIFF
--- a/frontend/src/components/ui/MarkdownRenderer.test.tsx
+++ b/frontend/src/components/ui/MarkdownRenderer.test.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MarkdownRenderer } from "./MarkdownRenderer";
+
+describe("MarkdownRenderer Table Parsing", () => {
+  it("renders markdown table with pipes inside code spans correctly", () => {
+    const markdown = `
+| Command | Description |
+|---|---|
+| \`git Log --oneline | grep feat\` | Filter logs by feat |
+`;
+
+    render(
+      <MarkdownRenderer
+        content={markdown}
+        loadGlossaryFn={async () => []}
+      />,
+    );
+
+    expect(screen.getByText("Command")).toBeInTheDocument();
+    expect(screen.getByText("Description")).toBeInTheDocument();
+    expect(screen.getByText("git Log --oneline | grep feat")).toBeInTheDocument();
+    expect(screen.getByText("Filter logs by feat")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/ui/MarkdownRenderer.tsx
+++ b/frontend/src/components/ui/MarkdownRenderer.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import CopyButton from "./CopyButton";
 import { pluginRegistry } from "../../lib/markdownPlugins";
 import { GlossaryTerm } from "./GlossaryTerm";
@@ -16,7 +16,17 @@ interface MarkdownRendererProps {
   loadGlossaryFn?: () => Promise<GlossaryEntry[]>;
 }
 
-// Helper to parse markdown table rows, ignoring pipes inside backticks or escaped pipes.
+// Helper to parse markdown table rows, parsing code spans first to treat pipes inside backticks as literal characters.
+function maskCodeSpanPipes(text: string): string {
+  return text.replace(/(`+)([\s\S]*?)\1/g, (match, p1, p2) => {
+    return p1 + p2.replace(/\|/g, "__ESCAPED_PIPE__") + p1;
+  });
+}
+
+function unmaskCodeSpanPipes(text: string): string {
+  return text.replace(/__ESCAPED_PIPE__/g, "|");
+}
+
 function splitTableRow(row: string): string[] {
   let trimmed = row.trim();
   if (trimmed.startsWith("|")) {
@@ -26,25 +36,24 @@ function splitTableRow(row: string): string[] {
     trimmed = trimmed.substring(0, trimmed.length - 1);
   }
 
+  // Parse code spans first to mask pipes inside backticks as literal characters
+  const maskedRow = maskCodeSpanPipes(trimmed);
+
   const cells: string[] = [];
   let currentCell = "";
-  let inCode = false;
 
-  for (let i = 0; i < trimmed.length; i++) {
-    const char = trimmed[i];
-    const prevChar = i > 0 ? trimmed[i - 1] : "";
+  for (let i = 0; i < maskedRow.length; i++) {
+    const char = maskedRow[i];
+    const prevChar = i > 0 ? maskedRow[i - 1] : "";
 
-    if (char === "`" && prevChar !== "\\") {
-      inCode = !inCode;
-      currentCell += char;
-    } else if (char === "|" && !inCode && prevChar !== "\\") {
-      cells.push(currentCell.trim());
+    if (char === "|" && prevChar !== "\\") {
+      cells.push(unmaskCodeSpanPipes(currentCell.trim()));
       currentCell = "";
     } else {
       currentCell += char;
     }
   }
-  cells.push(currentCell.trim());
+  cells.push(unmaskCodeSpanPipes(currentCell.trim()));
   return cells;
 }
 


### PR DESCRIPTION
### Summary
Resolves table layout breakdown in lesson markdown content when table cells contain code snippets with pipe (`|`) characters (e.g. `git log | grep feat`).

### Changes Made
- Refactored `splitTableRow` in [MarkdownRenderer.tsx](file:///c:/Users/babin/Desktop/ECSoC_2026/Open-Source-Contribution-Atelier/frontend/src/components/ui/MarkdownRenderer.tsx) to parse code spans (single, double, or multi-backtick blocks) first and temporarily mask pipe characters within backticks before splitting rows by table column delimiters (`|`).
- Restored literal pipe characters inside cell tokens before rendering inline formatting.
- Added unit test suite in [MarkdownRenderer.test.tsx](file:///c:/Users/babin/Desktop/ECSoC_2026/Open-Source-Contribution-Atelier/frontend/src/components/ui/MarkdownRenderer.test.tsx) verifying complex tables containing piped command code spans parse into correct table columns.

### Scope & Checklist
- [x] Frontend markdown parser fix (`Frontend only`)
- [x] ECSoC 2026
- [x] Unit test coverage added

Closes #2280
