### PR TITLE
fix(seo): update social share preview Open Graph meta tags to valid image URL

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,6 +7,23 @@
       content="width=device-width, initial-scale=1.0, viewport-fit=cover"
     />
     <meta name="google-adsense-account" content="ca-pub-6128720993372931" />
+    <!-- Open Graph / Social Share Meta Tags -->
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="Open Source Contribution Atelier" />
+    <meta
+      property="og:description"
+      content="Master git workflows, open source contributions, and interactive playground sandbox challenges."
+    />
+    <meta property="og:image" content="/icons/icon-512x512.png" />
+
+    <!-- Twitter Meta Tags -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Open Source Contribution Atelier" />
+    <meta
+      name="twitter:description"
+      content="Master git workflows, open source contributions, and interactive playground sandbox challenges."
+    />
+    <meta name="twitter:image" content="/icons/icon-512x512.png" />
     <script>
       try {
         var t = localStorage.getItem("theme");

--- a/frontend/prerender.js
+++ b/frontend/prerender.js
@@ -58,8 +58,16 @@ async function prerender() {
       );
 
       // Inject description meta tag
-      const metaDescription = `<meta name="description" content="${route.description}" />`;
-      html = html.replace("</head>", `  ${metaDescription}\n</head>`);
+      const metaTags = `
+  <meta name="description" content="${route.description}" />
+  <meta property="og:title" content="${route.title}" />
+  <meta property="og:description" content="${route.description}" />
+  <meta property="og:image" content="/icons/icon-512x512.png" />
+  <meta name="twitter:title" content="${route.title}" />
+  <meta name="twitter:description" content="${route.description}" />
+  <meta name="twitter:image" content="/icons/icon-512x512.png" />
+`;
+      html = html.replace("</head>", `${metaTags}\n</head>`);
 
       // Ensure parent directory exists
       const outPath = toAbsolute(route.output);


### PR DESCRIPTION
### Summary
Fixes broken preview card images when sharing lesson links on Twitter/X, Slack, and Discord by ensuring Open Graph (`og:image`) and Twitter (`twitter:image`) meta tags reference valid image resources.

### Changes Made
- Configured default social preview meta tags in [index.html](file:///c:/Users/babin/Desktop/ECSoC_2026/Open-Source-Contribution-Atelier/frontend/index.html) pointing to valid platform asset `/icons/icon-512x512.png`.
- Updated static SSR pre-renderer in [prerender.js](file:///c:/Users/babin/Desktop/ECSoC_2026/Open-Source-Contribution-Atelier/frontend/prerender.js) to inject valid `og:title`, `og:description`, `og:image`, `twitter:title`, `twitter:description`, and `twitter:image` tags.

### Scope & Checklist
- [x] Frontend metadata fix (`Frontend only`)
- [x] ECSoC 2026
- [x] Checked pre-rendered output

Closes #2282
