### PR TITLE
fix(uploads): scan full file content for dangerous script markers, not just the 8192-byte magic-byte header

### DIFF
--- a/backend/apps/uploads/validators.py
+++ b/backend/apps/uploads/validators.py
@@ -47,6 +47,7 @@ SVG_DANGEROUS_TAGS = {"script", "foreignObject"}
 SVG_URL_ATTRIBUTES = {"href", "{http://www.w3.org/1999/xlink}href"}
 DANGEROUS_URL_RE = re.compile(r"^\s*(?:javascript|data\s*:\s*text/html)", re.I)
 
+_SCAN_CHUNK_SIZE = 65536  # 64KB chunks, bounded memory regardless of file size
 
 def max_size_for(upload_type: str) -> int:
     limits = getattr(
@@ -88,6 +89,34 @@ def _looks_like_svg(header: bytes) -> bool:
     )
 
 
+def _contains_dangerous_marker(stream: BinaryIO) -> bool:
+    """
+    Scan the FULL stream (not just the magic-byte header) for dangerous
+    script markers, in bounded chunks so large text files don't get
+    loaded entirely into memory. Handles markers that could straddle a
+    chunk boundary by overlapping a small tail from the previous chunk.
+    """
+    position = stream.tell()
+    try:
+        stream.seek(0)
+        max_marker_len = max(len(m) for m in DANGEROUS_TEXT_MARKERS)
+        tail = b""
+        while True:
+            chunk = stream.read(_SCAN_CHUNK_SIZE)
+            if not chunk:
+                break
+            window = tail + chunk
+            lowered = window.lower()
+            if any(marker in lowered for marker in DANGEROUS_TEXT_MARKERS):
+                return True
+            # Keep a small tail so a marker split across the chunk
+            # boundary is still caught on the next iteration.
+            tail = window[-(max_marker_len - 1):] if max_marker_len > 1 else b""
+        return False
+    finally:
+        stream.seek(position)
+
+
 def detect_file_type(stream: BinaryIO) -> str:
     position = stream.tell()
     try:
@@ -113,8 +142,9 @@ def detect_file_type(stream: BinaryIO) -> str:
     if _looks_like_svg(header):
         return "svg"
     if _looks_like_text(header):
-        lowered = header.lower()
-        if any(marker in lowered for marker in DANGEROUS_TEXT_MARKERS):
+        # Scan the FULL file, not just the header, for dangerous markers —
+        # a marker placed past byte 8192 was previously invisible to this check.
+        if _contains_dangerous_marker(stream):
             raise ValidationError(
                 "Executable or server-side script content is not allowed."
             )


### PR DESCRIPTION
## Description

`detect_file_type()`'s dangerous-script-content check only scanned the
first 8192 bytes (shared with magic-byte detection), letting a marker
placed later in a text file bypass detection entirely. Now scans the
full file content in bounded 64KB chunks (with boundary-overlap handling)
for text-like files, while magic-byte detection is unchanged.

Fixes #2232 

## 🏆 Program Participation
- [ ] **Social Summer of Code (SSoC 2026)**
- [x] **Elite Coder Summer of Code (ECSoC 2026)**

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update (no code changes)
- [ ] ⚙️ CI/CD or build pipeline change
- [ ] ⚡ Performance optimization
- [ ] 🛠️ Refactoring (no functional changes)

## How Has This Been Tested?

### Automated Tests
- [x] Backend tests pass: `cd backend && pytest`
- [ ] Frontend tests pass: `cd frontend && npm run test`
- [ ] Frontend builds successfully: `cd frontend && npm run build`

### Manual Verification
Reproduced the original bypass with a marker past byte 8192, confirmed
it's now caught; confirmed chunk-boundary-split markers are also caught;
confirmed binary-type detection and large clean-file handling are
unaffected — see linked issue testing checklist.

## Pre-Push Checklist

> [!IMPORTANT]
> **All items below must be checked before requesting a review.** Our CI bot and CodeRabbit AI will automatically run build/test checks and review your PR. If CI fails, you will receive a comment explaining what went wrong.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or console errors
- [ ] I have run `npm run build` in `frontend/` and it completes with **0 errors**
- [x] I have run `pytest` in `backend/` and all tests pass
- [x] I have run `git diff` locally and verified my changes

## Deployment Notes

> [!NOTE]
> This project is deployed on **Vercel** (Frontend) and **Hugging Face** (Backend). The CI workflow simulates both deployment environments. If your PR passes CI, it is safe to merge.

<!-- Add any notes about deployment considerations, environment variables, or migration steps needed -->
