### PR TITLE
feat(sandbox): create unified SandboxExecutor service and refactor pl…

### DIFF
--- a/backend/apps/content/unit_test_challenge_plugin.py
+++ b/backend/apps/content/unit_test_challenge_plugin.py
@@ -27,6 +27,8 @@ from typing import Any, Dict, List
 from .plugins import LessonPlugin, registry
 
 
+from apps.sandbox.services.sandbox_executor import SandboxExecutor
+
 def _run_in_sandbox(
     test_code: str, implementation_code: str, function_name: str
 ) -> Dict[str, Any]:
@@ -38,44 +40,7 @@ def _run_in_sandbox(
     """
     # Combine implementation and test code
     full_code = f"{implementation_code}\n\n{test_code}\n\n{function_name}()"
-
-    # Restricted globals for basic safety in the simulated sandbox
-    safe_globals = {
-        "__builtins__": {
-            "abs": abs,
-            "all": all,
-            "any": any,
-            "bool": bool,
-            "dict": dict,
-            "enumerate": enumerate,
-            "filter": filter,
-            "float": float,
-            "int": int,
-            "len": len,
-            "list": list,
-            "map": map,
-            "max": max,
-            "min": min,
-            "pow": pow,
-            "range": range,
-            "round": round,
-            "set": set,
-            "str": str,
-            "sum": sum,
-            "tuple": tuple,
-            "zip": zip,
-            "AssertionError": AssertionError,
-            "Exception": Exception,
-            "ValueError": ValueError,
-            "TypeError": TypeError,
-        }
-    }
-
-    try:
-        exec(full_code, safe_globals)
-        return {"passed": True, "error": None}
-    except Exception as e:
-        return {"passed": False, "error": str(e)}
+    return SandboxExecutor.execute(full_code)
 
 
 class UnitTestChallengePlugin(LessonPlugin):

--- a/backend/apps/sandbox/services/sandbox_executor.py
+++ b/backend/apps/sandbox/services/sandbox_executor.py
@@ -1,0 +1,47 @@
+import time
+from typing import Any, Dict, Tuple
+
+class SandboxExecutor:
+    """
+    Unified sandboxing service to provide a restricted execution environment
+    for backend validation of untrusted Python code.
+    """
+
+    @staticmethod
+    def _get_safe_globals() -> Dict[str, Any]:
+        return {
+            "__builtins__": {
+                "abs": abs, "all": all, "any": any, "bool": bool, "dict": dict,
+                "enumerate": enumerate, "filter": filter, "float": float, "int": int,
+                "len": len, "list": list, "map": map, "max": max, "min": min,
+                "pow": pow, "range": range, "round": round, "set": set, "str": str,
+                "sum": sum, "tuple": tuple, "zip": zip,
+                "AssertionError": AssertionError, "Exception": Exception,
+                "ValueError": ValueError, "TypeError": TypeError,
+            }
+        }
+
+    @classmethod
+    def execute(cls, code: str, safe_globals: Dict[str, Any] = None) -> Dict[str, Any]:
+        """
+        Executes untrusted code in a restricted globals environment.
+        Returns a dict with 'passed' boolean and 'error' string (if any).
+        """
+        env = safe_globals if safe_globals is not None else cls._get_safe_globals()
+        try:
+            exec(code, env)
+            return {"passed": True, "error": None}
+        except Exception as e:
+            return {"passed": False, "error": str(e)}
+
+    @classmethod
+    def execute_timed(cls, code: str, safe_globals: Dict[str, Any] = None) -> Tuple[float, Dict[str, Any]]:
+        """
+        Executes untrusted code and returns the wall-clock time in seconds,
+        along with the regular execution result.
+        """
+        env = safe_globals if safe_globals is not None else cls._get_safe_globals()
+        start = time.time()
+        result = cls.execute(code, env)
+        end = time.time()
+        return (end - start), result


### PR DESCRIPTION
## Description

Extracts sandbox execution logic into a dedicated, unified `SandboxExecutor` service located at `backend/apps/sandbox/services/sandbox_executor.py`. This provides a centralized and safe environment for backend plugins to execute untrusted code without relying on duplicate `exec` implementations. It also refactors the `unit_test_challenge_plugin.py` to use this new public API.

Fixes #2338 

## 🏆 Program Participation
- [x] **Social Summer of Code (SSoC 2026)**
- [ ] **Elite Coder Summer of Code (ECSoC 2026)**

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Refactoring (no functional changes)

## How Has This Been Tested?
### Automated Tests
- [x] Backend tests pass: `cd backend && pytest`
- [ ] Frontend tests pass: `cd frontend && npm run test`
- [ ] Frontend builds successfully: `cd frontend && npm run build`
