### PR TITLE
fix(scripts): exclude definition file in dead code serializer detection

### DIFF
--- a/scripts/dead_code_detector.py
+++ b/scripts/dead_code_detector.py
@@ -92,7 +92,10 @@ class DeadCodeDetector:
         for py_file in self.project_root.glob('backend/**/*.py'):
             with open(py_file, 'r') as f:
                 content = f.read()
-                for serializer_name in serializers.keys():
+                for serializer_name, definition_file in serializers.items():
+                    # Do not count occurrences in the file where it is defined
+                    if str(py_file) == definition_file:
+                        continue
                     if serializer_name in content:
                         references.append(serializer_name)
 


### PR DESCRIPTION
## Description

Fixes a bug in `scripts/dead_code_detector.py` where serializers were never correctly flagged as dead code. The script previously included matches found inside the `serializers.py` file itself, guaranteeing that the reference count was never zero. This PR adds logic to exclude the serializer definition file from reference counting.

Fixes #2339 

## 🏆 Program Participation
- [ ] **Social Summer of Code (SSoC 2026)**
- [ ] **Elite Coder Summer of Code (ECSoC 2026)**

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
### Manual Verification
Ran the `dead_code_detector.py` script and verified that unused serializers are now properly flagged instead of yielding a false negative.
