### PR TITLE
fix(scripts): support .as_view() imports in dead code view detection

### DIFF
--- a/scripts/dead_code_detector.py
+++ b/scripts/dead_code_detector.py
@@ -60,8 +60,11 @@ class DeadCodeDetector:
             with open(url_file, 'r') as f:
                 content = f.read()
                 # Find view references in URLs
-                pattern = r"views\.(\w+)"
-                for match in re.finditer(pattern, content):
+                pattern1 = r"views\.(\w+)"
+                pattern2 = r"(\w+)\.as_view\("
+                for match in re.finditer(pattern1, content):
+                    urls.append(match.group(1))
+                for match in re.finditer(pattern2, content):
                     urls.append(match.group(1))
 
         # Find unused views


### PR DESCRIPTION
## Description

Fixes a bug in `scripts/dead_code_detector.py` where directly imported class-based views (used via `.as_view()`) were improperly flagged as dead code. The script's regex parsing of `urls.py` was enhanced to support `path(..., SomeView.as_view())` rather than just `views.SomeView`.

Fixes #2340

## 🏆 Program Participation
- [ ] **Social Summer of Code (SSoC 2026)**
- [ ] **Elite Coder Summer of Code (ECSoC 2026)**

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
### Manual Verification
Ran the `dead_code_detector.py` script and verified that class-based views imported into `urls.py` directly are no longer incorrectly flagged as dead code.
