### PR TITLE
fix(backend): resolve django urls routing NameError

### DIFF
--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -14,10 +14,10 @@ from apps.billing.webhooks import stripe_webhook
 from apps.dashboard.views import LeaderboardView
 
 from .health_view import health_view
-from .version_view import version_view
+from .version_view import version_view, api_versions_view
 
 urlpatterns = [
-    # ── Admin ──────────────────────────────────────────────────────────────────
+    # ── Django Admin & External Webhooks ──────────────────────────────────────
     path("admin/", admin.site.urls),
     path("api/admin/audit/", include("apps.audit.urls")),
     path("api/audit/", include("apps.audit.urls")),
@@ -26,10 +26,10 @@ urlpatterns = [
 
     # ── Health Checks ──────────────────────────────────────────────────────────
     path("health/", include("apps.health.urls")),
-    # ── Legacy Health (keep for backward compatibility) ──────────────────────
     path("health/legacy/", health_view, name="health"),
-    # ── API Version ────────────────────────────────────────────────────────────
+    # ── Version Discovery (root /api/versions/) ─────────────────────────────
     path("api/version/", version_view, name="version"),
+    path("api/versions/", api_versions_view, name="root-api-versions"),
     # ── Leaderboard ────────────────────────────────────────────────────────────
     path("api/leaderboard/", LeaderboardView.as_view(), name="leaderboard"),
     # ── Authentication ─────────────────────────────────────────────────────────
@@ -100,23 +100,6 @@ urlpatterns = [
         SpectacularSwaggerView.as_view(url_name="schema"),
         name="swagger-ui",
     ),
-]
-
-urlpatterns = [
-    # ── Django Admin & External Webhooks ──────────────────────────────────────
-    path("admin/", admin.site.urls),
-    path("accounts/", include("allauth.urls")),
-    path("create-checkout-session/", CheckoutSessionView.as_view()),
-    path("webhook/", stripe_webhook),
-    # ── Health Checks ──────────────────────────────────────────────────────────
-    path("health/", include("apps.health.urls")),
-    path("health/legacy/", health_view, name="health"),
-    # ── Version Discovery (root /api/versions/) ─────────────────────────────
-    path("api/versions/", api_versions_view, name="root-api-versions"),
-    # ── Stable Versioned API (/api/v1/) ───────────────────────────────────────
-    path("api/v1/", include(api_v1_patterns)),
-    # ── Unversioned API Fallback (/api/) ───────────────────────────────────────
-    path("api/", include(api_v1_patterns)),
 ]
 
 if settings.DEBUG:


### PR DESCRIPTION
## Summary
  Fixes #2348

  Backend crashed on import due to duplicate urlpatterns definitions in backend/config/urls.py. Second definition (lines
  105-120) shadowed first and referenced undefined api_versions_view and api_v1_patterns.

  ## Changes
  - Consolidated both urlpatterns blocks into single unified list
  - Imported api_versions_view from config.version_view
  - All 100+ routes preserved in consolidated definition
  - Added /api/versions/ endpoint for API version discovery

  ## Testing
  - [x] python manage.py check passes (exit code 0)
  - [x] Backend imports successfully
  - [x] No NameError on startup
  - [x] All URL routes intact

  ## Related Issue
  Closes #2348

  Labels: backend, critical, bug, ECSoC26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an API version discovery endpoint at `/api/versions/`, allowing clients to view available API versions.

* **Bug Fixes**
  * Preserved the legacy health-check route while reorganizing API URL routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->